### PR TITLE
[Scheduling] Find & Book / View times over a date range

### DIFF
--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.module.css
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.module.css
@@ -11,16 +11,33 @@
   flex-wrap: wrap;
   gap: var(--mantine-spacing-lg);
   align-items: flex-start;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
+/* Each column scrolls on its own, so a wide stretch of days does not carry the form
+   off the top of the screen. Resolves to no bound at all where the layout has no
+   height to speak of, which is what leaves an unbounded host scrolling as one. */
 .form {
   flex: 1 1 300px;
   min-width: 0;
   max-width: 420px;
+  max-height: 100%;
+  overflow-y: auto;
 }
 
 /* Only present while the time search is open, which is what widens the panel. */
 .results {
   flex: 1 1 380px;
   min-width: 0;
+  max-height: 100%;
+  overflow-y: auto;
+}
+
+/* Both columns are stacks, so everything in them is a flex item, and a clamped column
+   squeezes its items to fit before it agrees to scroll — enough to press a button flat.
+   They keep their own heights and the column scrolls instead. */
+.form > *,
+.results > * {
+  flex-shrink: 0;
 }

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.test.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.test.ts
@@ -7,6 +7,7 @@ import {
   enumerateDateRange,
   filterByTimeOfDay,
   formatDateRange,
+  formatDayLabel,
   formatZonedTime,
   getActorGroupKey,
   getAppointmentKey,
@@ -244,6 +245,21 @@ describe('formatDateRange', () => {
 
   test('Says nothing when neither end was asked for', () => {
     expect(formatDateRange({})).toBeUndefined();
+  });
+
+  test('Names the days however the caller asks them to be named', () => {
+    // Beside headings that already carry the weekday, saying it again says the same
+    // thing twice.
+    expect(formatDateRange({ start: new Date(2026, 6, 27), end: new Date(2026, 6, 30) }, formatDayLabel)).toBe(
+      'July 27 – July 30'
+    );
+    expect(formatDateRange({ start: new Date(2026, 6, 27) }, formatDayLabel)).toBe('From July 27');
+  });
+});
+
+describe('formatDayLabel', () => {
+  test('Names a day without its weekday', () => {
+    expect(formatDayLabel(new Date(2026, 6, 27))).toBe('July 27');
   });
 });
 

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.test.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.test.ts
@@ -91,6 +91,29 @@ describe('groupAppointmentsByDay', () => {
     expect(day.date.getMonth()).toBe(6);
     expect(day.date.getDate()).toBe(27);
   });
+
+  test('Lists every day searched, including the ones offering nothing', () => {
+    const days = groupAppointmentsByDay([buildProposedAppointment({ start: '2026-07-27T13:00:00.000Z' })], EASTERN, {
+      start: new Date(2026, 6, 27),
+      end: new Date(2026, 6, 29, 23, 59, 59, 999),
+    });
+
+    expect(days.map((day) => day.key)).toStrictEqual(['2026-07-27', '2026-07-28', '2026-07-29']);
+    expect(days[0].groups).toHaveLength(1);
+    expect(days[1].groups).toStrictEqual([]);
+    expect(days[2].groups).toStrictEqual([]);
+  });
+
+  test('Keeps a day that offered times outside the days searched', () => {
+    // The window is asked for in whole local days and the times are read at the site,
+    // so a search can be answered with a day at either edge of the one asked about.
+    const days = groupAppointmentsByDay([buildProposedAppointment({ start: '2026-07-26T13:00:00.000Z' })], EASTERN, {
+      start: new Date(2026, 6, 27),
+      end: new Date(2026, 6, 27, 23, 59, 59, 999),
+    });
+
+    expect(days.map((day) => day.key)).toStrictEqual(['2026-07-26', '2026-07-27']);
+  });
 });
 
 describe('keys and durations', () => {

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.test.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.test.ts
@@ -106,8 +106,8 @@ describe('groupAppointmentsByDay', () => {
   });
 
   test('Keeps a day that offered times outside the days searched', () => {
-    // The window is asked for in whole local days and the times are read at the site,
-    // so a search can be answered with a day at either edge of the one asked about.
+    // The search window is local days, but times are read in the site's own timezone,
+    // so a result can land a day off the searched edge.
     const days = groupAppointmentsByDay([buildProposedAppointment({ start: '2026-07-26T13:00:00.000Z' })], EASTERN, {
       start: new Date(2026, 6, 27),
       end: new Date(2026, 6, 27, 23, 59, 59, 999),
@@ -248,8 +248,6 @@ describe('formatDateRange', () => {
   });
 
   test('Names the days however the caller asks them to be named', () => {
-    // Beside headings that already carry the weekday, saying it again says the same
-    // thing twice.
     expect(formatDateRange({ start: new Date(2026, 6, 27), end: new Date(2026, 6, 30) }, formatDayLabel)).toBe(
       'July 27 – July 30'
     );

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.ts
@@ -12,6 +12,13 @@ export const MAX_FIND_WINDOW_DAYS = 31;
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
+/**
+ * The most days one listing will name, however many were searched. A search that
+ * grows a couple of days at a time can outrun a single `$find` window, so the bound
+ * is a year rather than that operation's own.
+ */
+const MAX_LISTED_DAYS = 366;
+
 export type TimeOfDay = 'any' | 'morning' | 'afternoon';
 
 /** A calendar day's worth of available times, split by the actors offering them. */
@@ -165,17 +172,23 @@ export function filterByTimeOfDay(
  *
  * @param appointments - Proposed appointments from `$find`.
  * @param timezone - IANA timezone identifier. Defaults to the browser's.
+ * @param searched - Days to list whether or not they offer anything, so a day that was
+ *   asked about and came back empty says so rather than going missing. Read as calendar
+ *   days on the reader's own clock, which is the calendar a day is picked from.
  * @returns Days in ascending order, each holding its groups.
  */
-export function groupAppointmentsByDay(appointments: readonly Appointment[], timezone?: string): AppointmentDay[] {
+export function groupAppointmentsByDay(
+  appointments: readonly Appointment[],
+  timezone?: string,
+  searched?: DateRange
+): AppointmentDay[] {
   const days = new Map<string, Map<string, Appointment[]>>();
 
   for (const appointment of appointments) {
     if (!appointment.start) {
       continue;
     }
-    const { year, month, day } = getZonedParts(new Date(appointment.start), timezone);
-    const dayKey = `${year}-${pad(month)}-${pad(day)}`;
+    const dayKey = getZonedDayKey(new Date(appointment.start), timezone);
 
     let groups = days.get(dayKey);
     if (!groups) {
@@ -189,6 +202,13 @@ export function groupAppointmentsByDay(appointments: readonly Appointment[], tim
       group.push(appointment);
     } else {
       groups.set(groupKey, [appointment]);
+    }
+  }
+
+  for (const day of enumerateDateRange(searched ?? {}, MAX_LISTED_DAYS)) {
+    const key = getDayKey(day.getFullYear(), day.getMonth() + 1, day.getDate());
+    if (!days.has(key)) {
+      days.set(key, new Map());
     }
   }
 
@@ -260,6 +280,28 @@ export function getDurationMinutes(appointment: Appointment | undefined): number
  */
 export function getAppointmentKey(appointment: Appointment): string {
   return `${appointment.start}/${appointment.end}/${getActorGroupKey(appointment)}`;
+}
+
+/**
+ * Keys the calendar day an instant falls on in a timezone.
+ * @param date - The instant to read.
+ * @param timezone - IANA timezone identifier. Defaults to the browser's.
+ * @returns The day as `YYYY-MM-DD`.
+ */
+function getZonedDayKey(date: Date, timezone: string | undefined): string {
+  const { year, month, day } = getZonedParts(date, timezone);
+  return getDayKey(year, month, day);
+}
+
+/**
+ * Writes a calendar date as the key days are held under.
+ * @param year - The full year.
+ * @param month - The month, from 1.
+ * @param day - The day of the month.
+ * @returns The day as `YYYY-MM-DD`.
+ */
+function getDayKey(year: number, month: number, day: number): string {
+  return `${year}-${pad(month)}-${pad(day)}`;
 }
 
 /**

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.ts
@@ -100,6 +100,15 @@ export function formatDayHeading(date: Date): string {
 }
 
 /**
+ * Names a calendar day without its weekday (e.g. "July 27").
+ * @param date - Local midnight of the day.
+ * @returns The formatted day.
+ */
+export function formatDayLabel(date: Date): string {
+  return new Intl.DateTimeFormat(undefined, { month: 'long', day: 'numeric' }).format(date);
+}
+
+/**
  * Returns how far a timezone is from UTC at a given instant.
  * @param instant - The instant to read the offset at.
  * @param timezone - IANA timezone identifier.
@@ -414,18 +423,22 @@ export function getFindWindowError(range: DateRange): string | undefined {
 /**
  * Says in words which days a search covers.
  * @param range - The days asked for.
+ * @param formatDay - How to name one day. Defaults to naming it with its weekday.
  * @returns The range as a phrase, or undefined when both ends are open.
  */
-export function formatDateRange(range: DateRange): string | undefined {
+export function formatDateRange(
+  range: DateRange,
+  formatDay: (date: Date) => string = formatDayHeading
+): string | undefined {
   const { start, end } = range;
   if (start && end) {
-    return isSameDay(start, end) ? formatDayHeading(start) : `${formatDayHeading(start)} – ${formatDayHeading(end)}`;
+    return isSameDay(start, end) ? formatDay(start) : `${formatDay(start)} – ${formatDay(end)}`;
   }
   if (start) {
-    return `From ${formatDayHeading(start)}`;
+    return `From ${formatDay(start)}`;
   }
   if (end) {
-    return `Through ${formatDayHeading(end)}`;
+    return `Through ${formatDay(end)}`;
   }
   return undefined;
 }

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.ts
@@ -38,6 +38,26 @@ export interface AppointmentDay {
   readonly groups: readonly AppointmentSlotGroup[];
 }
 
+// Building an `Intl.DateTimeFormat` costs far more than formatting with one, and a
+// stretch of days formats a time for every appointment on it, on every render.
+const formatters = new Map<string, Intl.DateTimeFormat>();
+
+/**
+ * Returns a formatter for a set of options, building it the first time it is asked for.
+ * @param key - What tells one formatter apart from another.
+ * @param options - How to format, read only when the formatter is built.
+ * @param locale - The locale to build it in. Defaults to the browser's.
+ * @returns The cached formatter.
+ */
+function getFormatter(key: string, options: Intl.DateTimeFormatOptions, locale?: string): Intl.DateTimeFormat {
+  let formatter = formatters.get(key);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat(locale, options);
+    formatters.set(key, formatter);
+  }
+  return formatter;
+}
+
 interface ZonedParts {
   readonly year: number;
   readonly month: number;
@@ -54,15 +74,19 @@ interface ZonedParts {
  * @returns The year, month, day, and hour in that timezone.
  */
 function getZonedParts(date: Date, timezone: string | undefined): ZonedParts {
-  const parts = new Intl.DateTimeFormat('en-US', {
-    timeZone: timezone,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    hourCycle: 'h23',
-  }).formatToParts(date);
+  const parts = getFormatter(
+    `parts:${timezone ?? ''}`,
+    {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hourCycle: 'h23',
+    },
+    'en-US'
+  ).formatToParts(date);
 
   const read = (type: Intl.DateTimeFormatPartTypes): number => Number(parts.find((p) => p.type === type)?.value);
 
@@ -82,7 +106,7 @@ function getZonedParts(date: Date, timezone: string | undefined): ZonedParts {
  * @returns The formatted time.
  */
 export function formatZonedTime(date: Date, timezone?: string): string {
-  return new Intl.DateTimeFormat(undefined, {
+  return getFormatter(`time:${timezone ?? ''}`, {
     timeZone: timezone,
     hour: 'numeric',
     minute: '2-digit',
@@ -341,6 +365,15 @@ export function getNativeInputType(type: 'date' | 'time'): string {
 }
 
 /**
+ * Returns the first instant of a day, so that a range opens at the top of it.
+ * @param date - Any instant during the day.
+ * @returns Local midnight at the start of that day.
+ */
+export function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+/**
  * Returns the last instant of a day, so that a range covers the whole of it.
  * @param date - Any instant during the day.
  * @returns Local midnight less a millisecond, at the end of that day.
@@ -415,8 +448,19 @@ export function getFindWindowError(range: DateRange): string | undefined {
   if (!start || !end) {
     return undefined;
   }
-  const days = Math.ceil((end.getTime() - start.getTime()) / MS_PER_DAY);
-  return days > MAX_FIND_WINDOW_DAYS ? `Choose at most ${MAX_FIND_WINDOW_DAYS} days at a time.` : undefined;
+  return getDayCount(start, end) > MAX_FIND_WINDOW_DAYS
+    ? `Choose at most ${MAX_FIND_WINDOW_DAYS} days at a time.`
+    : undefined;
+}
+
+/**
+ * Counts the days a window covers, a part of a day counting as a whole one.
+ * @param start - The first instant of the window.
+ * @param end - Its last instant.
+ * @returns The number of days the window reaches over.
+ */
+export function getDayCount(start: Date, end: Date): number {
+  return Math.ceil((end.getTime() - start.getTime()) / MS_PER_DAY);
 }
 
 /**

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.ts
@@ -13,9 +13,8 @@ export const MAX_FIND_WINDOW_DAYS = 31;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 /**
- * The most days one listing will name, however many were searched. A search that
- * grows a couple of days at a time can outrun a single `$find` window, so the bound
- * is a year rather than that operation's own.
+ * The most days one listing will name. A search that grows a few days at a time can
+ * outrun a single `$find` window, so this is bounded independently, at roughly a year.
  */
 const MAX_LISTED_DAYS = 366;
 
@@ -181,9 +180,9 @@ export function filterByTimeOfDay(
  *
  * @param appointments - Proposed appointments from `$find`.
  * @param timezone - IANA timezone identifier. Defaults to the browser's.
- * @param searched - Days to list whether or not they offer anything, so a day that was
- *   asked about and came back empty says so rather than going missing. Read as calendar
- *   days on the reader's own clock, which is the calendar a day is picked from.
+ * @param searched - Days to list whether or not they offer anything, so a searched day
+ *   that came back empty still shows up rather than going missing. Read on the local
+ *   calendar, matching how a day is picked.
  * @returns Days in ascending order, each holding its groups.
  */
 export function groupAppointmentsByDay(

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.test.tsx
@@ -492,7 +492,7 @@ describe('AppointmentProposalForm', () => {
       setup(medplum);
       await openFinderOnThreeDays();
 
-      await dragDays('17', '18', '19', '20', '21');
+      await dragDays('17', '21');
 
       // Reaching a week's worth of times otherwise costs a click for every two days
       // beyond the first three.
@@ -509,7 +509,7 @@ describe('AppointmentProposalForm', () => {
       await openFinderOnThreeDays();
       get.mockClear();
 
-      await dragDays('17', '18', '19', '20', '21');
+      await dragDays('17', '21');
 
       // `$find` pages a window at once, so the five days are one request asked for a
       // page wide enough to hold all of them.
@@ -523,7 +523,7 @@ describe('AppointmentProposalForm', () => {
       setup(medplum);
       await openFinderOnThreeDays();
 
-      await dragDays('17', '18', '19', '20', '21');
+      await dragDays('17', '21');
 
       // Unlike the days that merely come with a picked day, where only the day picked
       // is marked: here every day of the stretch was asked for.
@@ -583,7 +583,7 @@ describe('AppointmentProposalForm', () => {
     test('Adds days under a stretch that was picked', async () => {
       setup(medplum);
       await openFinderOnThreeDays();
-      await dragDays('17', '18', '19', '20', '21');
+      await dragDays('17', '21');
       await screen.findByText(/Friday, August 21/);
 
       await showMoreDays();
@@ -596,7 +596,7 @@ describe('AppointmentProposalForm', () => {
     test('Puts the added days away back to the stretch that was picked, not to three days', async () => {
       setup(medplum);
       await openFinderOnThreeDays();
-      await dragDays('17', '18', '19', '20', '21');
+      await dragDays('17', '21');
       await screen.findByText(/Friday, August 21/);
       await showMoreDays();
       expect(await screen.findByText(/Sunday, August 23/)).toBeInTheDocument();
@@ -616,7 +616,7 @@ describe('AppointmentProposalForm', () => {
       await chooseFirstOfferedTime();
       expect(chosenTimeField()).not.toBeNull();
 
-      await dragDays('17', '18', '19', '20', '21');
+      await dragDays('17', '21');
 
       // The times on offer have changed, and a proposal carries the Slots it was
       // found for.
@@ -630,7 +630,7 @@ describe('AppointmentProposalForm', () => {
       // The gesture leaves no mark on the calendar to find it by.
       expect(screen.getByText(/August 17 – August 19 · drag or shift-click/)).toBeInTheDocument();
 
-      await dragDays('17', '18', '19', '20', '21');
+      await dragDays('17', '21');
 
       expect(await screen.findByText(/August 17 – August 21 · drag or shift-click/)).toBeInTheDocument();
     });

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.test.tsx
@@ -166,8 +166,8 @@ describe('AppointmentProposalForm', () => {
       await chooseActor(/provider/i, 'oka', 'Dr. Tunde Okafor');
       await openTimeFinder();
 
-      // One set of actors, not two: `$find` intersects the schedules it is given. A
-      // card per day carries that same set, so the days are what there is more than one of.
+      // One set of actors, not two: `$find` intersects the schedules it is given. Now
+      // that each day gets its own card, distinct groups are counted by testid, not length.
       const groups = await screen.findAllByTestId(/^slot-group-/);
       expect(new Set(groups.map((group) => group.dataset.testid)).size).toBe(1);
       expect(within(groups[0]).getByText('Dr. Maya Rivera')).toBeInTheDocument();
@@ -373,8 +373,6 @@ describe('AppointmentProposalForm', () => {
       await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
       await openTimeFinder();
 
-      // One day's times are often too few to choose between, and the two days after it
-      // are then a look away rather than a click away.
       expect(await screen.findByText(/Monday, August 17/)).toBeInTheDocument();
       expect(screen.getByText(/Tuesday, August 18/)).toBeInTheDocument();
       expect(screen.getByText(/Wednesday, August 19/)).toBeInTheDocument();
@@ -389,8 +387,8 @@ describe('AppointmentProposalForm', () => {
 
       const params = lastFindParams(get) as URLSearchParams;
       expect(new Date(params.get('end') as string).getDate()).toBe(19);
-      // `$find` pages a whole window at once, so twenty times would be spent inside the
-      // first day and the two after it would come back empty.
+      // More than one day's worth: `$find` pages a whole window at once, so twenty
+      // times (one day's worth) would leave the two days after it empty.
       expect(Number(params.get('_count'))).toBeGreaterThan(20);
     });
 
@@ -405,8 +403,7 @@ describe('AppointmentProposalForm', () => {
 
       expect(await screen.findByText(/Thursday, August 20/)).toBeInTheDocument();
       expect(screen.getByText(/Friday, August 21/)).toBeInTheDocument();
-      // Appended rather than replaced: the days already answered stay where they were,
-      // and a time picked from one of them stays picked.
+      // Appended, not replaced: the days already answered stay on screen.
       expect(screen.getByText(/Monday, August 17/)).toBeInTheDocument();
     });
 
@@ -420,8 +417,7 @@ describe('AppointmentProposalForm', () => {
 
       await showMoreDays();
 
-      // Asking again for the days already answered would cost a request per click to be
-      // told what is already on screen.
+      // Not the days already answered: re-asking would waste a request per click.
       const start = new Date(lastFindStart(get) as string);
       expect(start.getDate()).toBe(20);
       expect(start.getHours()).toBe(0);
@@ -433,8 +429,7 @@ describe('AppointmentProposalForm', () => {
       await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
       await openTimeFinder();
 
-      // A Friday, and after it a weekend the clinic keeps no hours on. Dropping those
-      // two would make asking for them look like it did nothing at all.
+      // 21st is a Friday; the clinic keeps no hours on the weekend after it.
       await chooseDay('21');
 
       expect(await screen.findByText(/Saturday, August 22/)).toBeInTheDocument();
@@ -472,8 +467,7 @@ describe('AppointmentProposalForm', () => {
 
       await chooseActor(/provider/i, 'oka', 'Dr. Tunde Okafor');
 
-      // The times on screen are what one provider offered, not times the pair of them
-      // share, so the days go back to the first three and are searched again.
+      // The times on screen were one provider's alone, not times the pair share.
       await waitFor(() => expect(screen.queryByText(/Friday, August 21/)).not.toBeInTheDocument());
       expect(await screen.findByText(/Monday, August 17/)).toBeInTheDocument();
     });
@@ -494,12 +488,10 @@ describe('AppointmentProposalForm', () => {
 
       await dragDays('17', '21');
 
-      // Reaching a week's worth of times otherwise costs a click for every two days
-      // beyond the first three.
       expect(await screen.findByText(/Friday, August 21/)).toBeInTheDocument();
       expect(screen.getByText(/Monday, August 17/)).toBeInTheDocument();
       expect(screen.getByText(/Thursday, August 20/)).toBeInTheDocument();
-      // The drag stopped on the Friday, so the weekend was never asked about.
+      // Stopped at the Friday, so the weekend after it was never asked about.
       expect(screen.queryByText(/Saturday, August 22/)).not.toBeInTheDocument();
     });
 
@@ -511,8 +503,7 @@ describe('AppointmentProposalForm', () => {
 
       await dragDays('17', '21');
 
-      // `$find` pages a window at once, so the five days are one request asked for a
-      // page wide enough to hold all of them.
+      // `$find` pages a window at once: one request for all five days, wide enough to hold them.
       expect(findRequests(get)).toHaveLength(1);
       const params = lastFindParams(get) as URLSearchParams;
       expect(new Date(params.get('end') as string).getDate()).toBe(21);
@@ -525,8 +516,8 @@ describe('AppointmentProposalForm', () => {
 
       await dragDays('17', '21');
 
-      // Unlike the days that merely come with a picked day, where only the day picked
-      // is marked: here every day of the stretch was asked for.
+      // Unlike a picked day, where only that day is marked: every day of a picked
+      // stretch was asked for, so every day is marked.
       await waitFor(() => expect(dayCell('21').className).toContain('selected'));
       expect(dayCell('17').className).toContain('selected');
       expect(dayCell('19').closest('td')?.className).toContain('inRange');
@@ -543,8 +534,7 @@ describe('AppointmentProposalForm', () => {
       await shiftChooseDay('21');
 
       expect(await screen.findByText(/Friday, August 21/)).toBeInTheDocument();
-      // The stretch grew from the day picked rather than starting over at the day
-      // shift-clicked.
+      // Grew from the day picked, rather than starting over at the day shift-clicked.
       expect(screen.getByText(/Tuesday, August 18/)).toBeInTheDocument();
       expect(new Date(lastFindParams(get)?.get('end') as string).getDate()).toBe(21);
     });
@@ -556,8 +546,7 @@ describe('AppointmentProposalForm', () => {
       await chooseDay('20');
       await screen.findByText(/Thursday, August 20/);
 
-      // The 20th is further from the 17th than the 22nd is, so the far end is held and
-      // the stretch runs back over a day that is already under way.
+      // 17th is today: the stretch now reaches back over a day already under way.
       await shiftChooseDay('17');
 
       expect(await screen.findByText(/Monday, August 17/)).toBeInTheDocument();
@@ -574,8 +563,7 @@ describe('AppointmentProposalForm', () => {
       await showNextMonth();
       await shiftChooseDay('20');
 
-      // Said before the request rather than after it comes back refused, and nothing
-      // is asked for in the meantime.
+      // Caught before the request, not by a refusal coming back.
       expect(await screen.findByText('Choose at most 31 days at a time.')).toBeInTheDocument();
       expect(findRequests(get)).toHaveLength(0);
     });
@@ -603,8 +591,7 @@ describe('AppointmentProposalForm', () => {
 
       await chooseActor(/provider/i, 'oka', 'Dr. Tunde Okafor');
 
-      // Only what "Show more days" added goes away: the days that were asked for are
-      // still what is being searched, now for the pair of them.
+      // Only what "Show more days" added goes away; the picked stretch stays as the search.
       await waitFor(() => expect(screen.queryByText(/Sunday, August 23/)).not.toBeInTheDocument());
       expect(screen.getByText(/Friday, August 21/)).toBeInTheDocument();
       expect(screen.getByText(/Monday, August 17/)).toBeInTheDocument();
@@ -618,8 +605,7 @@ describe('AppointmentProposalForm', () => {
 
       await dragDays('17', '21');
 
-      // The times on offer have changed, and a proposal carries the Slots it was
-      // found for.
+      // A proposal carries the Slots it was found for, and the search has moved on.
       expect(chosenTimeField()).toBeNull();
     });
 
@@ -627,7 +613,6 @@ describe('AppointmentProposalForm', () => {
       setup(medplum);
       await openFinderOnThreeDays();
 
-      // The gesture leaves no mark on the calendar to find it by.
       expect(screen.getByText(/August 17 – August 19 · drag or shift-click/)).toBeInTheDocument();
 
       await dragDays('17', '21');
@@ -1005,8 +990,7 @@ describe('AppointmentProposalForm', () => {
       await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
       await openTimeFinder();
 
-      // The days are counted off the floor rather than off the day named, so a stale
-      // day offers as much to choose between as any other.
+      // Counted off the floored start, not the stale day named, so all three days show.
       expect(await screen.findByText(/Monday, August 17/)).toBeInTheDocument();
       expect(screen.getByText(/Wednesday, August 19/)).toBeInTheDocument();
     });

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.test.tsx
@@ -367,18 +367,19 @@ describe('AppointmentProposalForm', () => {
   });
 
   describe('Showing several days at a time', () => {
-    test('Offers the picked day and the two days after it', async () => {
+    test('Offers the day picked, and none of the days around it', async () => {
       setup(medplum);
       await chooseImagingService();
       await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
       await openTimeFinder();
 
       expect(await screen.findByText(/Monday, August 17/)).toBeInTheDocument();
-      expect(screen.getByText(/Tuesday, August 18/)).toBeInTheDocument();
-      expect(screen.getByText(/Wednesday, August 19/)).toBeInTheDocument();
+      // "Show more days" is what asks for the days after; a click asks only for its own.
+      expect(screen.queryByText(/Tuesday, August 18/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Wednesday, August 19/)).not.toBeInTheDocument();
     });
 
-    test('Asks about the three days at once, with a page wide enough for all of them', async () => {
+    test('Asks about the one day picked, with a page wide enough for it', async () => {
       const get = vi.spyOn(medplum, 'get');
       setup(medplum);
       await chooseImagingService();
@@ -386,10 +387,23 @@ describe('AppointmentProposalForm', () => {
       await openTimeFinder();
 
       const params = lastFindParams(get) as URLSearchParams;
-      expect(new Date(params.get('end') as string).getDate()).toBe(19);
-      // More than one day's worth: `$find` pages a whole window at once, so fifty
-      // times (one day's worth) would leave the two days after it empty.
-      expect(Number(params.get('_count'))).toBeGreaterThan(50);
+      expect(new Date(params.get('end') as string).getDate()).toBe(17);
+      expect(Number(params.get('_count'))).toBe(50);
+    });
+
+    test('Asks about only the day clicked, not the days after it', async () => {
+      const get = vi.spyOn(medplum, 'get');
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+
+      // Not just the day the form opens on: clicking a later day narrows the same way.
+      await chooseDay('20');
+
+      expect(await screen.findByText(/Thursday, August 20/)).toBeInTheDocument();
+      expect(screen.queryByText(/Friday, August 21/)).not.toBeInTheDocument();
+      expect(new Date(lastFindParams(get)?.get('end') as string).getDate()).toBe(20);
     });
 
     test('Adds the next two days under the ones already on screen', async () => {
@@ -401,8 +415,8 @@ describe('AppointmentProposalForm', () => {
 
       await showMoreDays();
 
-      expect(await screen.findByText(/Thursday, August 20/)).toBeInTheDocument();
-      expect(screen.getByText(/Friday, August 21/)).toBeInTheDocument();
+      expect(await screen.findByText(/Tuesday, August 18/)).toBeInTheDocument();
+      expect(screen.getByText(/Wednesday, August 19/)).toBeInTheDocument();
       // Appended, not replaced: the days already answered stay on screen.
       expect(screen.getByText(/Monday, August 17/)).toBeInTheDocument();
     });
@@ -419,8 +433,9 @@ describe('AppointmentProposalForm', () => {
 
       // Not the days already answered: re-asking would waste a request per click.
       const start = new Date(lastFindStart(get) as string);
-      expect(start.getDate()).toBe(20);
+      expect(start.getDate()).toBe(18);
       expect(start.getHours()).toBe(0);
+      expect(Number(lastFindParams(get)?.get('_count'))).toBe(100);
     });
 
     test('Names a day that offers nothing, so nothing is missing but the days nobody asked about', async () => {
@@ -429,8 +444,11 @@ describe('AppointmentProposalForm', () => {
       await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
       await openTimeFinder();
 
-      // 21st is a Friday; the clinic keeps no hours on the weekend after it.
+      // 21st is a Friday; the clinic keeps no hours on the weekend "Show more days" reaches into.
       await chooseDay('21');
+      await screen.findByText(/Friday, August 21/);
+
+      await showMoreDays();
 
       expect(await screen.findByText(/Saturday, August 22/)).toBeInTheDocument();
       expect(screen.getByText(/Sunday, August 23/)).toBeInTheDocument();
@@ -446,14 +464,16 @@ describe('AppointmentProposalForm', () => {
 
       // Which days the times below belong to is otherwise only in their headings.
       expect(dayCell('17').className).toContain('selected');
-      expect(dayCell('18').className).not.toContain('selected');
-      expect(dayCell('18').closest('td')?.className).toContain('inRange');
-      expect(dayCell('20').closest('td')?.className).not.toContain('inRange');
+      expect(dayCell('18').closest('td')?.className).not.toContain('inRange');
 
       await showMoreDays();
 
-      await waitFor(() => expect(dayCell('20').closest('td')?.className).toContain('inRange'));
+      await waitFor(() => expect(dayCell('18').closest('td')?.className).toContain('inRange'));
+      expect(dayCell('19').closest('td')?.className).toContain('inRange');
+      expect(dayCell('20').closest('td')?.className).not.toContain('inRange');
+      // The day picked keeps its own mark, rather than the widened window taking it over.
       expect(dayCell('17').className).toContain('selected');
+      expect(dayCell('19').className).not.toContain('selected');
     });
 
     test('Puts the added days away when the named resources change', async () => {
@@ -463,19 +483,19 @@ describe('AppointmentProposalForm', () => {
       await openTimeFinder();
       await screen.findByText(/Monday, August 17/);
       await showMoreDays();
-      expect(await screen.findByText(/Friday, August 21/)).toBeInTheDocument();
+      expect(await screen.findByText(/Wednesday, August 19/)).toBeInTheDocument();
 
       await chooseActor(/provider/i, 'oka', 'Dr. Tunde Okafor');
 
       // The times on screen were one provider's alone, not times the pair share.
-      await waitFor(() => expect(screen.queryByText(/Friday, August 21/)).not.toBeInTheDocument());
+      await waitFor(() => expect(screen.queryByText(/Wednesday, August 19/)).not.toBeInTheDocument());
       expect(await screen.findByText(/Monday, August 17/)).toBeInTheDocument();
     });
   });
 
   describe('Choosing several days at once', () => {
-    /** Gets as far as a time search open on the default three days. */
-    async function openFinderOnThreeDays(): Promise<void> {
+    /** Gets as far as a time search open on the day the form starts on. */
+    async function openFinder(): Promise<void> {
       await chooseImagingService();
       await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
       await openTimeFinder();
@@ -484,7 +504,7 @@ describe('AppointmentProposalForm', () => {
 
     test('Searches every day a drag covered', async () => {
       setup(medplum);
-      await openFinderOnThreeDays();
+      await openFinder();
 
       await dragDays('17', '21');
 
@@ -498,7 +518,7 @@ describe('AppointmentProposalForm', () => {
     test('Asks about the whole stretch in one window, not one request per day', async () => {
       const get = vi.spyOn(medplum, 'get');
       setup(medplum);
-      await openFinderOnThreeDays();
+      await openFinder();
       get.mockClear();
 
       await dragDays('17', '21');
@@ -512,7 +532,7 @@ describe('AppointmentProposalForm', () => {
 
     test('Marks both ends of a stretch that was picked on purpose', async () => {
       setup(medplum);
-      await openFinderOnThreeDays();
+      await openFinder();
 
       await dragDays('17', '21');
 
@@ -527,7 +547,7 @@ describe('AppointmentProposalForm', () => {
     test('Shift-clicking widens the days searched, holding the end it is not moving', async () => {
       const get = vi.spyOn(medplum, 'get');
       setup(medplum);
-      await openFinderOnThreeDays();
+      await openFinder();
       await chooseDay('18');
       await screen.findByText(/Tuesday, August 18/);
 
@@ -542,7 +562,7 @@ describe('AppointmentProposalForm', () => {
     test('Searches a stretch reaching back over today from now rather than from midnight', async () => {
       const get = vi.spyOn(medplum, 'get');
       setup(medplum);
-      await openFinderOnThreeDays();
+      await openFinder();
       await chooseDay('20');
       await screen.findByText(/Thursday, August 20/);
 
@@ -557,7 +577,7 @@ describe('AppointmentProposalForm', () => {
     test('Refuses a stretch longer than one `$find` window', async () => {
       const get = vi.spyOn(medplum, 'get');
       setup(medplum);
-      await openFinderOnThreeDays();
+      await openFinder();
       get.mockClear();
 
       await showNextMonth();
@@ -570,7 +590,7 @@ describe('AppointmentProposalForm', () => {
 
     test('Adds days under a stretch that was picked', async () => {
       setup(medplum);
-      await openFinderOnThreeDays();
+      await openFinder();
       await dragDays('17', '21');
       await screen.findByText(/Friday, August 21/);
 
@@ -581,9 +601,9 @@ describe('AppointmentProposalForm', () => {
       expect(screen.getByText(/Monday, August 17/)).toBeInTheDocument();
     });
 
-    test('Puts the added days away back to the stretch that was picked, not to three days', async () => {
+    test('Puts the added days away back to the stretch that was picked', async () => {
       setup(medplum);
-      await openFinderOnThreeDays();
+      await openFinder();
       await dragDays('17', '21');
       await screen.findByText(/Friday, August 21/);
       await showMoreDays();
@@ -599,7 +619,7 @@ describe('AppointmentProposalForm', () => {
 
     test('Clears the chosen time when a stretch is picked', async () => {
       setup(medplum);
-      await openFinderOnThreeDays();
+      await openFinder();
       await chooseFirstOfferedTime();
       expect(chosenTimeField()).not.toBeNull();
 
@@ -611,9 +631,9 @@ describe('AppointmentProposalForm', () => {
 
     test('Names the days being searched, without the weekdays their headings carry', async () => {
       setup(medplum);
-      await openFinderOnThreeDays();
+      await openFinder();
 
-      expect(screen.getByText(/August 17 – August 19 · drag or shift-click/)).toBeInTheDocument();
+      expect(screen.getByText(/^August 17 · drag or shift-click/)).toBeInTheDocument();
 
       await dragDays('17', '21');
 
@@ -984,15 +1004,15 @@ describe('AppointmentProposalForm', () => {
       expect(await screen.findByText(/Wednesday, September 2/)).toBeInTheDocument();
     });
 
-    test('Opens on three days from now when the day the host named has gone', async () => {
+    test('Opens on today when the day the host named has gone', async () => {
       setup(medplum, { defaultService: UltrasoundImagingService, defaultStart: new Date(2026, 7, 10, 0, 0, 0) });
       await settleAutocomplete();
       await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
       await openTimeFinder();
 
-      // Counted off the floored start, not the stale day named, so all three days show.
+      // Floored to now rather than searching from the stale day named.
       expect(await screen.findByText(/Monday, August 17/)).toBeInTheDocument();
-      expect(screen.getByText(/Wednesday, August 19/)).toBeInTheDocument();
+      expect(screen.queryByText(/August 10/)).not.toBeInTheDocument();
     });
   });
 

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.test.tsx
@@ -455,7 +455,7 @@ describe('AppointmentProposalForm', () => {
       expect(screen.getAllByText('No times are offered on this day.')).toHaveLength(2);
     });
 
-    test('Marks the days on show against the calendar, the picked day apart', async () => {
+    test('Marks the days on show against the calendar, widening the range as it grows', async () => {
       setup(medplum);
       await chooseImagingService();
       await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
@@ -471,9 +471,10 @@ describe('AppointmentProposalForm', () => {
       await waitFor(() => expect(dayCell('18').closest('td')?.className).toContain('inRange'));
       expect(dayCell('19').closest('td')?.className).toContain('inRange');
       expect(dayCell('20').closest('td')?.className).not.toContain('inRange');
-      // The day picked keeps its own mark, rather than the widened window taking it over.
+      // "Show more days" widens the range on show, so its new far end is marked
+      // too, the same as the day first picked.
       expect(dayCell('17').className).toContain('selected');
-      expect(dayCell('19').className).not.toContain('selected');
+      expect(dayCell('19').className).toContain('selected');
     });
 
     test('Puts the added days away when the named resources change', async () => {

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.test.tsx
@@ -387,9 +387,9 @@ describe('AppointmentProposalForm', () => {
 
       const params = lastFindParams(get) as URLSearchParams;
       expect(new Date(params.get('end') as string).getDate()).toBe(19);
-      // More than one day's worth: `$find` pages a whole window at once, so twenty
+      // More than one day's worth: `$find` pages a whole window at once, so fifty
       // times (one day's worth) would leave the two days after it empty.
-      expect(Number(params.get('_count'))).toBeGreaterThan(20);
+      expect(Number(params.get('_count'))).toBeGreaterThan(50);
     });
 
     test('Adds the next two days under the ones already on screen', async () => {
@@ -507,7 +507,7 @@ describe('AppointmentProposalForm', () => {
       expect(findRequests(get)).toHaveLength(1);
       const params = lastFindParams(get) as URLSearchParams;
       expect(new Date(params.get('end') as string).getDate()).toBe(21);
-      expect(Number(params.get('_count'))).toBe(100);
+      expect(Number(params.get('_count'))).toBe(250);
     });
 
     test('Marks both ends of a stretch that was picked on purpose', async () => {

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.test.tsx
@@ -33,11 +33,13 @@ import {
   chooseSite,
   chosenTimeField,
   clickBook,
+  dayCell,
   field,
   fillBooking,
   finderButton,
   hasPill,
   isBefore,
+  lastFindParams,
   lastFindStart,
   MONDAY_MORNING,
   openRoleField,
@@ -46,6 +48,7 @@ import {
   removePill,
   searchField,
   setupBookingClient,
+  showMoreDays,
 } from '../test-utils/bookingForm';
 import { act, fireEvent, renderWithMedplum, screen, waitFor, within } from '../test-utils/render';
 import type { AppointmentProposalFormProps } from './AppointmentProposalForm';
@@ -159,9 +162,10 @@ describe('AppointmentProposalForm', () => {
       await chooseActor(/provider/i, 'oka', 'Dr. Tunde Okafor');
       await openTimeFinder();
 
-      // One group, not two: `$find` intersects the schedules it is given.
+      // One set of actors, not two: `$find` intersects the schedules it is given. A
+      // card per day carries that same set, so the days are what there is more than one of.
       const groups = await screen.findAllByTestId(/^slot-group-/);
-      expect(groups).toHaveLength(1);
+      expect(new Set(groups.map((group) => group.dataset.testid)).size).toBe(1);
       expect(within(groups[0]).getByText('Dr. Maya Rivera')).toBeInTheDocument();
       expect(within(groups[0]).getByText('Dr. Tunde Okafor')).toBeInTheDocument();
     });
@@ -296,7 +300,7 @@ describe('AppointmentProposalForm', () => {
       await openTimeFinder();
 
       const groups = await screen.findAllByTestId(/^slot-group-/);
-      expect(groups).toHaveLength(1);
+      expect(new Set(groups.map((group) => group.dataset.testid)).size).toBe(1);
       expect(within(groups[0]).getByText('Dr. Maya Rivera')).toBeInTheDocument();
       expect(within(groups[0]).getByText('Exam Room A')).toBeInTheDocument();
     });
@@ -355,6 +359,119 @@ describe('AppointmentProposalForm', () => {
       expect(start).toBeDefined();
       // Local midnight would be 07:00Z on this clock; the floor must not go back there.
       expect(new Date(start as string).getTime()).toBeGreaterThanOrEqual(MONDAY_MORNING.getTime());
+    });
+  });
+
+  describe('Showing several days at a time', () => {
+    test('Offers the picked day and the two days after it', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+
+      // One day's times are often too few to choose between, and the two days after it
+      // are then a look away rather than a click away.
+      expect(await screen.findByText(/Monday, August 17/)).toBeInTheDocument();
+      expect(screen.getByText(/Tuesday, August 18/)).toBeInTheDocument();
+      expect(screen.getByText(/Wednesday, August 19/)).toBeInTheDocument();
+    });
+
+    test('Asks about the three days at once, with a page wide enough for all of them', async () => {
+      const get = vi.spyOn(medplum, 'get');
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+
+      const params = lastFindParams(get) as URLSearchParams;
+      expect(new Date(params.get('end') as string).getDate()).toBe(19);
+      // `$find` pages a whole window at once, so twenty times would be spent inside the
+      // first day and the two after it would come back empty.
+      expect(Number(params.get('_count'))).toBeGreaterThan(20);
+    });
+
+    test('Adds the next two days under the ones already on screen', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      await screen.findByText(/Monday, August 17/);
+
+      await showMoreDays();
+
+      expect(await screen.findByText(/Thursday, August 20/)).toBeInTheDocument();
+      expect(screen.getByText(/Friday, August 21/)).toBeInTheDocument();
+      // Appended rather than replaced: the days already answered stay where they were,
+      // and a time picked from one of them stays picked.
+      expect(screen.getByText(/Monday, August 17/)).toBeInTheDocument();
+    });
+
+    test('Asks only about the days it is adding', async () => {
+      const get = vi.spyOn(medplum, 'get');
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      await screen.findByText(/Monday, August 17/);
+
+      await showMoreDays();
+
+      // Asking again for the days already answered would cost a request per click to be
+      // told what is already on screen.
+      const start = new Date(lastFindStart(get) as string);
+      expect(start.getDate()).toBe(20);
+      expect(start.getHours()).toBe(0);
+    });
+
+    test('Names a day that offers nothing, so nothing is missing but the days nobody asked about', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+
+      // A Friday, and after it a weekend the clinic keeps no hours on. Dropping those
+      // two would make asking for them look like it did nothing at all.
+      await chooseDay('21');
+
+      expect(await screen.findByText(/Saturday, August 22/)).toBeInTheDocument();
+      expect(screen.getByText(/Sunday, August 23/)).toBeInTheDocument();
+      expect(screen.getAllByText('No times are offered on this day.')).toHaveLength(2);
+    });
+
+    test('Marks the days on show against the calendar, the picked day apart', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      await screen.findByText(/Monday, August 17/);
+
+      // Which days the times below belong to is otherwise only in their headings.
+      expect(dayCell('17').className).toContain('selected');
+      expect(dayCell('18').className).not.toContain('selected');
+      expect(dayCell('18').closest('td')?.className).toContain('inRange');
+      expect(dayCell('20').closest('td')?.className).not.toContain('inRange');
+
+      await showMoreDays();
+
+      await waitFor(() => expect(dayCell('20').closest('td')?.className).toContain('inRange'));
+      expect(dayCell('17').className).toContain('selected');
+    });
+
+    test('Puts the added days away when the named resources change', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      await screen.findByText(/Monday, August 17/);
+      await showMoreDays();
+      expect(await screen.findByText(/Friday, August 21/)).toBeInTheDocument();
+
+      await chooseActor(/provider/i, 'oka', 'Dr. Tunde Okafor');
+
+      // The times on screen are what one provider offered, not times the pair of them
+      // share, so the days go back to the first three and are searched again.
+      await waitFor(() => expect(screen.queryByText(/Friday, August 21/)).not.toBeInTheDocument());
+      expect(await screen.findByText(/Monday, August 17/)).toBeInTheDocument();
     });
   });
 

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.test.tsx
@@ -34,9 +34,11 @@ import {
   chosenTimeField,
   clickBook,
   dayCell,
+  dragDays,
   field,
   fillBooking,
   finderButton,
+  findRequests,
   hasPill,
   isBefore,
   lastFindParams,
@@ -48,7 +50,9 @@ import {
   removePill,
   searchField,
   setupBookingClient,
+  shiftChooseDay,
   showMoreDays,
+  showNextMonth,
 } from '../test-utils/bookingForm';
 import { act, fireEvent, renderWithMedplum, screen, waitFor, within } from '../test-utils/render';
 import type { AppointmentProposalFormProps } from './AppointmentProposalForm';
@@ -475,6 +479,163 @@ describe('AppointmentProposalForm', () => {
     });
   });
 
+  describe('Choosing several days at once', () => {
+    /** Gets as far as a time search open on the default three days. */
+    async function openFinderOnThreeDays(): Promise<void> {
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      await screen.findByText(/Monday, August 17/);
+    }
+
+    test('Searches every day a drag covered', async () => {
+      setup(medplum);
+      await openFinderOnThreeDays();
+
+      await dragDays('17', '18', '19', '20', '21');
+
+      // Reaching a week's worth of times otherwise costs a click for every two days
+      // beyond the first three.
+      expect(await screen.findByText(/Friday, August 21/)).toBeInTheDocument();
+      expect(screen.getByText(/Monday, August 17/)).toBeInTheDocument();
+      expect(screen.getByText(/Thursday, August 20/)).toBeInTheDocument();
+      // The drag stopped on the Friday, so the weekend was never asked about.
+      expect(screen.queryByText(/Saturday, August 22/)).not.toBeInTheDocument();
+    });
+
+    test('Asks about the whole stretch in one window, not one request per day', async () => {
+      const get = vi.spyOn(medplum, 'get');
+      setup(medplum);
+      await openFinderOnThreeDays();
+      get.mockClear();
+
+      await dragDays('17', '18', '19', '20', '21');
+
+      // `$find` pages a window at once, so the five days are one request asked for a
+      // page wide enough to hold all of them.
+      expect(findRequests(get)).toHaveLength(1);
+      const params = lastFindParams(get) as URLSearchParams;
+      expect(new Date(params.get('end') as string).getDate()).toBe(21);
+      expect(Number(params.get('_count'))).toBe(100);
+    });
+
+    test('Marks both ends of a stretch that was picked on purpose', async () => {
+      setup(medplum);
+      await openFinderOnThreeDays();
+
+      await dragDays('17', '18', '19', '20', '21');
+
+      // Unlike the days that merely come with a picked day, where only the day picked
+      // is marked: here every day of the stretch was asked for.
+      await waitFor(() => expect(dayCell('21').className).toContain('selected'));
+      expect(dayCell('17').className).toContain('selected');
+      expect(dayCell('19').closest('td')?.className).toContain('inRange');
+      expect(dayCell('22').closest('td')?.className).not.toContain('inRange');
+    });
+
+    test('Shift-clicking widens the days searched, holding the end it is not moving', async () => {
+      const get = vi.spyOn(medplum, 'get');
+      setup(medplum);
+      await openFinderOnThreeDays();
+      await chooseDay('18');
+      await screen.findByText(/Tuesday, August 18/);
+
+      await shiftChooseDay('21');
+
+      expect(await screen.findByText(/Friday, August 21/)).toBeInTheDocument();
+      // The stretch grew from the day picked rather than starting over at the day
+      // shift-clicked.
+      expect(screen.getByText(/Tuesday, August 18/)).toBeInTheDocument();
+      expect(new Date(lastFindParams(get)?.get('end') as string).getDate()).toBe(21);
+    });
+
+    test('Searches a stretch reaching back over today from now rather than from midnight', async () => {
+      const get = vi.spyOn(medplum, 'get');
+      setup(medplum);
+      await openFinderOnThreeDays();
+      await chooseDay('20');
+      await screen.findByText(/Thursday, August 20/);
+
+      // The 20th is further from the 17th than the 22nd is, so the far end is held and
+      // the stretch runs back over a day that is already under way.
+      await shiftChooseDay('17');
+
+      expect(await screen.findByText(/Monday, August 17/)).toBeInTheDocument();
+      const start = new Date(lastFindStart(get) as string);
+      expect(start.getTime()).toBeGreaterThanOrEqual(MONDAY_MORNING.getTime());
+    });
+
+    test('Refuses a stretch longer than one `$find` window', async () => {
+      const get = vi.spyOn(medplum, 'get');
+      setup(medplum);
+      await openFinderOnThreeDays();
+      get.mockClear();
+
+      await showNextMonth();
+      await shiftChooseDay('20');
+
+      // Said before the request rather than after it comes back refused, and nothing
+      // is asked for in the meantime.
+      expect(await screen.findByText('Choose at most 31 days at a time.')).toBeInTheDocument();
+      expect(findRequests(get)).toHaveLength(0);
+    });
+
+    test('Adds days under a stretch that was picked', async () => {
+      setup(medplum);
+      await openFinderOnThreeDays();
+      await dragDays('17', '18', '19', '20', '21');
+      await screen.findByText(/Friday, August 21/);
+
+      await showMoreDays();
+
+      expect(await screen.findByText(/Saturday, August 22/)).toBeInTheDocument();
+      expect(screen.getByText(/Sunday, August 23/)).toBeInTheDocument();
+      expect(screen.getByText(/Monday, August 17/)).toBeInTheDocument();
+    });
+
+    test('Puts the added days away back to the stretch that was picked, not to three days', async () => {
+      setup(medplum);
+      await openFinderOnThreeDays();
+      await dragDays('17', '18', '19', '20', '21');
+      await screen.findByText(/Friday, August 21/);
+      await showMoreDays();
+      expect(await screen.findByText(/Sunday, August 23/)).toBeInTheDocument();
+
+      await chooseActor(/provider/i, 'oka', 'Dr. Tunde Okafor');
+
+      // Only what "Show more days" added goes away: the days that were asked for are
+      // still what is being searched, now for the pair of them.
+      await waitFor(() => expect(screen.queryByText(/Sunday, August 23/)).not.toBeInTheDocument());
+      expect(screen.getByText(/Friday, August 21/)).toBeInTheDocument();
+      expect(screen.getByText(/Monday, August 17/)).toBeInTheDocument();
+    });
+
+    test('Clears the chosen time when a stretch is picked', async () => {
+      setup(medplum);
+      await openFinderOnThreeDays();
+      await chooseFirstOfferedTime();
+      expect(chosenTimeField()).not.toBeNull();
+
+      await dragDays('17', '18', '19', '20', '21');
+
+      // The times on offer have changed, and a proposal carries the Slots it was
+      // found for.
+      expect(chosenTimeField()).toBeNull();
+    });
+
+    test('Names the days being searched, without the weekdays their headings carry', async () => {
+      setup(medplum);
+      await openFinderOnThreeDays();
+
+      // The gesture leaves no mark on the calendar to find it by.
+      expect(screen.getByText(/August 17 – August 19 · drag or shift-click/)).toBeInTheDocument();
+
+      await dragDays('17', '18', '19', '20', '21');
+
+      expect(await screen.findByText(/August 17 – August 21 · drag or shift-click/)).toBeInTheDocument();
+    });
+  });
+
   describe('Reading times in the site’s timezone', () => {
     test('Shows an offered time as the time at the site', async () => {
       setup(medplum);
@@ -836,6 +997,18 @@ describe('AppointmentProposalForm', () => {
       await openTimeFinder();
 
       expect(await screen.findByText(/Wednesday, September 2/)).toBeInTheDocument();
+    });
+
+    test('Opens on three days from now when the day the host named has gone', async () => {
+      setup(medplum, { defaultService: UltrasoundImagingService, defaultStart: new Date(2026, 7, 10, 0, 0, 0) });
+      await settleAutocomplete();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+
+      // The days are counted off the floor rather than off the day named, so a stale
+      // day offers as much to choose between as any other.
+      expect(await screen.findByText(/Monday, August 17/)).toBeInTheDocument();
+      expect(screen.getByText(/Wednesday, August 19/)).toBeInTheDocument();
     });
   });
 

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.test.tsx
@@ -368,6 +368,7 @@ describe('AppointmentProposalForm', () => {
 
   describe('Showing several days at a time', () => {
     test('Offers the day picked, and none of the days around it', async () => {
+      const get = vi.spyOn(medplum, 'get');
       setup(medplum);
       await chooseImagingService();
       await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
@@ -377,6 +378,12 @@ describe('AppointmentProposalForm', () => {
       // "Show more days" is what asks for the days after; a click asks only for its own.
       expect(screen.queryByText(/Tuesday, August 18/)).not.toBeInTheDocument();
       expect(screen.queryByText(/Wednesday, August 19/)).not.toBeInTheDocument();
+
+      await chooseDay('20');
+
+      expect(await screen.findByText(/Thursday, August 20/)).toBeInTheDocument();
+      expect(screen.queryByText(/Friday, August 21/)).not.toBeInTheDocument();
+      expect(new Date(lastFindParams(get)?.get('end') as string).getDate()).toBe(20);
     });
 
     test('Asks about the one day picked, with a page wide enough for it', async () => {
@@ -389,21 +396,6 @@ describe('AppointmentProposalForm', () => {
       const params = lastFindParams(get) as URLSearchParams;
       expect(new Date(params.get('end') as string).getDate()).toBe(17);
       expect(Number(params.get('_count'))).toBe(50);
-    });
-
-    test('Asks about only the day clicked, not the days after it', async () => {
-      const get = vi.spyOn(medplum, 'get');
-      setup(medplum);
-      await chooseImagingService();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      await openTimeFinder();
-
-      // Not just the day the form opens on: clicking a later day narrows the same way.
-      await chooseDay('20');
-
-      expect(await screen.findByText(/Thursday, August 20/)).toBeInTheDocument();
-      expect(screen.queryByText(/Friday, August 21/)).not.toBeInTheDocument();
-      expect(new Date(lastFindParams(get)?.get('end') as string).getDate()).toBe(20);
     });
 
     test('Adds the next two days under the ones already on screen', async () => {

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
@@ -41,6 +41,7 @@ import { AppointmentOptionRow } from './AppointmentOptionRow';
 import { AppointmentServiceSelect } from './AppointmentServiceSelect';
 import { isServiceKeptAtLocation } from './AppointmentServiceSelect.utils';
 import { useProposedAppointments } from './useProposedAppointments';
+import type { DateTimeRange } from '../types';
 
 // Excludes what a room is rather than admitting what a site is: `physicalType` is
 // optional, so `physical-type=si,bu` would hide a Location that never declared one.
@@ -646,20 +647,14 @@ function getMedicalRecordNumber(patient: WithId<Patient>, mrnSystem: string | un
   );
 }
 
-/** Days a search covers, both ends closed, as `$find` requires. */
-interface SearchWindow {
-  readonly start: Date;
-  readonly end: Date;
-}
-
 /** The days on offer, and the times the ones already answered came back with. */
 interface DaySearch {
   /** The one day that was picked, or undefined when a stretch of days was picked instead. */
   readonly picked: Date | undefined;
   /** The window the search opened on, which is what putting the added days away goes back to. */
-  readonly first: SearchWindow;
-  /** The days being asked about now, which is the newest window alone. */
-  readonly range: SearchWindow;
+  readonly first: DateTimeRange;
+  /** The days being asked about now, which is the newest window alone. Both ends closed, as `$find` requires. */
+  readonly range: DateTimeRange;
   /** Times the earlier windows offered, kept on screen while a further one is out. */
   readonly found: readonly Appointment[];
   /** Whether days beyond the first window have been asked for. */
@@ -713,7 +708,7 @@ function openDaySearch(date: Date): DaySearch {
  * @param range - The window last asked about.
  * @returns The window following it, opening at midnight of the next day.
  */
-function nextWindow(range: SearchWindow): SearchWindow {
+function nextWindow(range: DateTimeRange): DateTimeRange {
   const next = addDays(range.end, 1);
   const start = new Date(next.getFullYear(), next.getMonth(), next.getDate());
   return { start, end: endOfDay(addDays(start, MORE_DAYS - 1)) };
@@ -733,7 +728,7 @@ function resetDaySearch(previous: DaySearch): DaySearch {
  * @param range - The days being searched.
  * @returns The line to show beneath the calendar.
  */
-function getSearchedDaysHint(range: SearchWindow): string {
+function getSearchedDaysHint(range: DateTimeRange): string {
   return [formatDateRange(range, formatDayLabel), DAY_GESTURE_HINT].filter(isDefined).join(HINT_SEPARATOR);
 }
 

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
@@ -54,23 +54,17 @@ const PATIENT_SEARCH_CRITERIA = { _count: '25', _sort: 'name,birthdate' };
 // No month-wide scan exists, so every day is offered and the search answers.
 const NO_MARKED_DATES: Date[] = [];
 
-// Picking a day asks about the two after it as well: one day's times are often too
-// few to choose between, and the days after it are then a look away, not a click away.
+// Also searches the two days after the one picked: one day's times are often too
+// few to choose between.
 const DAYS_SHOWN = 3;
 
-/** Days each "Show more" adds under the ones already on screen. */
 const MORE_DAYS = 2;
 
-/** Times to ask for per day searched. */
 const TIMES_PER_DAY = 20;
 
-/**
- * What the calendar's gestures do, said beneath it because neither leaves a mark on it
- * to be found by.
- */
+// Shown beneath the calendar, since dragging or shift-clicking leaves no visible mark.
 const DAY_GESTURE_HINT = 'drag or shift-click to search more days';
 
-/** Joins phrases sharing a line. Presentational: neither phrase it separates carries it. */
 const HINT_SEPARATOR = ' · ';
 
 export interface AppointmentProposalFormProps {
@@ -196,29 +190,25 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
     return service ? getSchedulingTimezone(service, first?.schedule, first?.actorResource) : undefined;
   }, [service, selections]);
 
-  // What the windows already answered offered, plus the one being answered now.
-  // While a further window is out the hook still holds the last one's times, which
-  // `found` is already carrying.
+  // While a further window is loading, `search.appointments` is that window's
+  // in-flight result, not yet part of `found`.
   const times = useMemo(
     () => (search.loading ? daySearch.found : [...daySearch.found, ...search.appointments]),
     [search.loading, search.appointments, daySearch.found]
   );
 
-  // Every day asked about, the calendar and the times reading off the same stretch.
   const shownDays = useMemo(
     () => ({ start: daySearch.first.start, end: daySearch.range.end }),
     [daySearch.first.start, daySearch.range.end]
   );
 
-  // Including the days offering nothing: a day that goes missing is indistinguishable
-  // from a day nobody looked at, which would make "Show more" look like it did nothing
-  // at all.
+  // Passing shownDays lists empty days too, so a day that came back with nothing still
+  // shows up rather than looking like nobody asked about it.
   const days = useMemo(() => groupAppointmentsByDay(times, timezone, shownDays), [times, timezone, shownDays]);
 
   const anyTimes = days.some((day) => day.groups.length > 0);
 
-  // Nothing to show yet rather than something to add to: the first window for these
-  // answers is still out, so the panel holds a spinner instead of days.
+  // A spinner rather than empty days: only while the first window is still out.
   const pending = search.loading && !daySearch.extended;
 
   // The ref holds what the host was last told, so mounting reports nothing and a
@@ -295,20 +285,13 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
     setChosen(undefined);
   }
 
-  /**
-   * Searches the stretch of days a drag or a shift-click asked for, all at once.
-   *
-   * Held stable, unlike {@link chooseDay}: the calendar listens for the end of a drag
-   * on the window while one is under way, and re-subscribes whenever this changes.
-   */
+  // Held stable, unlike `chooseDay`: the calendar listens for a drag's end on the
+  // window for as long as it's under way, and re-subscribes whenever this changes.
   const chooseRange = useCallback((start: Date, end: Date): void => {
     setDaySearch(openRangeSearch(start, end));
     setChosen(undefined);
   }, []);
 
-  /**
-   * Puts the days after the ones on screen up for searching too.
-   */
   function showMoreDays(): void {
     setDaySearch((previous) => ({
       ...previous,
@@ -460,8 +443,7 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
             </Text>
           )}
           {!pending && !search.error && !windowError && (
-            // Nothing says how far ahead there is anything to find, so the days keep
-            // going as long as they are asked for.
+            // No signal for how far ahead there's anything to find, so this has no end state.
             <Button variant="subtle" loading={search.loading} onClick={showMoreDays}>
               Show more days
             </Button>

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
@@ -61,7 +61,8 @@ const DAYS_SHOWN = 3;
 
 const MORE_DAYS = 2;
 
-const TIMES_PER_DAY = 20;
+// Generous heuristic for how many time results might be returned for a given day.
+const TIMES_PER_DAY = 50;
 
 // Shown beneath the calendar, since dragging or shift-clicking leaves no visible mark.
 const DAY_GESTURE_HINT = 'drag or shift-click to search more days';

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
@@ -27,8 +27,14 @@ import type { SchedulingRole } from './AppointmentFinder.roles';
 import { getActorRoleLabel, SCHEDULING_ROLES } from './AppointmentFinder.roles';
 import type { ActorSelections, ScheduleCandidate } from './AppointmentFinder.schedules';
 import { getActorCombinations, getSelectedCandidates, getSelectionError } from './AppointmentFinder.schedules';
-import type { DateRange } from './AppointmentFinder.times';
-import { endOfDay, getDurationMinutes, getFindWindowError, groupAppointmentsByDay } from './AppointmentFinder.times';
+import {
+  addDays,
+  endOfDay,
+  enumerateDateRange,
+  getDurationMinutes,
+  getFindWindowError,
+  groupAppointmentsByDay,
+} from './AppointmentFinder.times';
 import { AppointmentOptionRow } from './AppointmentOptionRow';
 import { AppointmentServiceSelect } from './AppointmentServiceSelect';
 import { isServiceKeptAtLocation } from './AppointmentServiceSelect.utils';
@@ -45,6 +51,16 @@ const PATIENT_SEARCH_CRITERIA = { _count: '25', _sort: 'name,birthdate' };
 
 // No month-wide scan exists, so every day is offered and the search answers.
 const NO_MARKED_DATES: Date[] = [];
+
+// Picking a day asks about the two after it as well: one day's times are often too
+// few to choose between, and the days after it are then a look away, not a click away.
+const DAYS_SHOWN = 3;
+
+/** Days each "Show more" adds under the ones already on screen. */
+const MORE_DAYS = 2;
+
+/** Times to ask for per day searched. */
+const TIMES_PER_DAY = 20;
 
 export interface AppointmentProposalFormProps {
   /** Pre-fills where the visit is, for a host that already knows. */
@@ -128,7 +144,7 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
   const [location, setLocation] = useState<WithId<Location> | undefined>(defaultLocation);
   const [service, setService] = useState<WithId<HealthcareService> | undefined>(defaultService);
   const [selections, setSelections] = useState<ActorSelections>({});
-  const [range, setRange] = useState<DateRange>(() => oneDay(defaultStart ?? new Date()));
+  const [daySearch, setDaySearch] = useState<DaySearch>(() => openDaySearch(defaultStart ?? new Date()));
   const [month, setMonth] = useState<Date | undefined>(defaultStart);
   const [finding, setFinding] = useState(false);
   const [chosen, setChosen] = useState<Appointment | undefined>(undefined);
@@ -142,7 +158,7 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
   const [bookError, setBookError] = useState<unknown>(undefined);
 
   const selectionError = getSelectionError(selections);
-  const windowError = getFindWindowError(range);
+  const windowError = getFindWindowError(daySearch.range);
 
   // Derived, not a flag: closing is never its own rule, so losing the last provider
   // closes the search however it was lost.
@@ -155,7 +171,12 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
     [searching, windowError, selections]
   );
 
-  const search = useProposedAppointments({ service, combinations, range });
+  const search = useProposedAppointments({
+    service,
+    combinations,
+    range: daySearch.range,
+    count: TIMES_PER_DAY * enumerateDateRange(daySearch.range).length,
+  });
 
   // The first actor's schedule answers for all of them: every actor in one search
   // shares the scheduling parameters, or `$find` rejects the request.
@@ -164,7 +185,30 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
     return service ? getSchedulingTimezone(service, first?.schedule, first?.actorResource) : undefined;
   }, [service, selections]);
 
-  const days = useMemo(() => groupAppointmentsByDay(search.appointments, timezone), [search.appointments, timezone]);
+  // What the windows already answered offered, plus the one being answered now.
+  // While a further window is out the hook still holds the last one's times, which
+  // `found` is already carrying.
+  const times = useMemo(
+    () => (search.loading ? daySearch.found : [...daySearch.found, ...search.appointments]),
+    [search.loading, search.appointments, daySearch.found]
+  );
+
+  // Every day asked about, the calendar and the times reading off the same stretch.
+  const shownDays = useMemo(
+    () => ({ start: daySearch.from, end: daySearch.range.end }),
+    [daySearch.from, daySearch.range.end]
+  );
+
+  // Including the days offering nothing: a day that goes missing is indistinguishable
+  // from a day nobody looked at, which would make "Show more" look like it did nothing
+  // at all.
+  const days = useMemo(() => groupAppointmentsByDay(times, timezone, shownDays), [times, timezone, shownDays]);
+
+  const anyTimes = days.some((day) => day.groups.length > 0);
+
+  // Nothing to show yet rather than something to add to: the first window for these
+  // answers is still out, so the panel holds a spinner instead of days.
+  const pending = search.loading && !daySearch.extended;
 
   // The ref holds what the host was last told, so mounting reports nothing and a
   // search that closed on its own is reported like one closed by hand.
@@ -203,6 +247,7 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
     // a resource changes it would hold whoever is named inside the proposal, and
     // `$book` cannot catch that: the proposal is internally consistent.
     setChosen(undefined);
+    setDaySearch(collapseDays);
   }, []);
 
   function chooseService(next: WithId<HealthcareService> | undefined): void {
@@ -231,11 +276,24 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
     setSelections({});
     setChosen(undefined);
     setRoleFieldsKey((key) => key + 1);
+    setDaySearch(collapseDays);
   }
 
   function chooseDay(date: Date): void {
-    setRange(oneDay(date));
+    setDaySearch(openDaySearch(date));
     setChosen(undefined);
+  }
+
+  /**
+   * Puts the days after the ones on screen up for searching too.
+   */
+  function showMoreDays(): void {
+    setDaySearch((previous) => ({
+      ...previous,
+      range: nextWindow(previous.range),
+      found: [...previous.found, ...search.appointments],
+      extended: true,
+    }));
   }
 
   // The two answers a written booking can still be changed by. Everything else
@@ -319,7 +377,8 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
               allowUnavailableDates
               earliestDate={new Date()}
               month={month}
-              selected={range.start}
+              selected={daySearch.from}
+              range={shownDays}
               onChangeMonth={setMonth}
               onClick={chooseDay}
             />
@@ -355,10 +414,10 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
 
       {searching && (
         <Stack className={classes.results} gap="lg">
-          {search.loading && <Loader size="sm" />}
+          {pending && <Loader size="sm" />}
           {search.error && <Alert color="red">{normalizeErrorString(search.error)}</Alert>}
-          {!search.loading &&
-            !search.error &&
+          {!pending &&
+            anyTimes &&
             days.map((day) => (
               <AppointmentDayTimes
                 key={day.key}
@@ -369,10 +428,17 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
                 onSelectAppointment={chooseTime}
               />
             ))}
-          {!search.loading && !search.error && !windowError && days.length === 0 && (
+          {!pending && !anyTimes && !search.error && !windowError && (
             <Text c="dimmed" ta="center">
               No times are available for this selection.
             </Text>
+          )}
+          {!pending && !search.error && !windowError && (
+            // Nothing says how far ahead there is anything to find, so the days keep
+            // going as long as they are asked for.
+            <Button variant="subtle" loading={search.loading} onClick={showMoreDays}>
+              Show more days
+            </Button>
           )}
         </Stack>
       )}
@@ -569,6 +635,24 @@ function getMedicalRecordNumber(patient: WithId<Patient>, mrnSystem: string | un
   );
 }
 
+/** Days a search covers, both ends closed, as `$find` requires. */
+interface SearchWindow {
+  readonly start: Date;
+  readonly end: Date;
+}
+
+/** The days on offer, and the times the ones already answered came back with. */
+interface DaySearch {
+  /** Where the search opened: the day that was picked, or now if that day is under way. */
+  readonly from: Date;
+  /** The days being asked about now, which is the newest window alone. */
+  readonly range: SearchWindow;
+  /** Times the earlier windows offered, kept on screen while a further one is out. */
+  readonly found: readonly Appointment[];
+  /** Whether days beyond the first window have been asked for. */
+  readonly extended: boolean;
+}
+
 /**
  * Reads the interval a proposal runs over.
  *
@@ -583,19 +667,48 @@ function toRange(appointment: Appointment | undefined): DateTimeRange | undefine
 }
 
 /**
- * Returns the range covering the bookable part of one day.
+ * Opens the search on a day, asking about it and the two days after it.
  *
  * `$find` treats `start` as a hard floor, so a day already under way starts from now
  * rather than midnight: the calendar hands back local midnight, and asking from there
  * would offer times that have already passed.
  *
- * @param date - Any instant during the day.
- * @returns The day from now at the earliest, both ends closed, as `$find` requires.
+ * @param date - Any instant during the day to open on.
+ * @returns The first window, with nothing found yet.
  */
-function oneDay(date: Date): DateRange {
+function openDaySearch(date: Date): DaySearch {
   const now = new Date();
-  const start = date > now ? date : now;
-  return { start, end: endOfDay(start) };
+  const from = date > now ? date : now;
+  return {
+    from,
+    range: { start: from, end: endOfDay(addDays(from, DAYS_SHOWN - 1)) },
+    found: [],
+    extended: false,
+  };
+}
+
+/**
+ * Moves the search on to the days after the ones already asked about.
+ * @param range - The window last asked about.
+ * @returns The window following it, opening at midnight of the next day.
+ */
+function nextWindow(range: SearchWindow): SearchWindow {
+  const next = addDays(range.end, 1);
+  const start = new Date(next.getFullYear(), next.getMonth(), next.getDate());
+  return { start, end: endOfDay(addDays(start, MORE_DAYS - 1)) };
+}
+
+/**
+ * Puts the added days away, for an answer that changes what every day offers.
+ *
+ * Only when days were added: rebuilding the first window moves its floor to now,
+ * which is a different search and so another request for the same days.
+ *
+ * @param previous - The day search as it stands.
+ * @returns The day search, back to its first window.
+ */
+function collapseDays(previous: DaySearch): DaySearch {
+  return previous.extended ? openDaySearch(previous.from) : previous;
 }
 
 /**

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
@@ -27,22 +27,11 @@ import type { SchedulingRole } from './AppointmentFinder.roles';
 import { getActorRoleLabel, SCHEDULING_ROLES } from './AppointmentFinder.roles';
 import type { ActorSelections, ScheduleCandidate } from './AppointmentFinder.schedules';
 import { getActorCombinations, getSelectedCandidates, getSelectionError } from './AppointmentFinder.schedules';
-import {
-  addDays,
-  endOfDay,
-  enumerateDateRange,
-  formatDateRange,
-  formatDayLabel,
-  getDurationMinutes,
-  getFindWindowError,
-  groupAppointmentsByDay,
-  isSameDay,
-} from './AppointmentFinder.times';
+import { formatDateRange, formatDayLabel, getDurationMinutes } from './AppointmentFinder.times';
 import { AppointmentOptionRow } from './AppointmentOptionRow';
 import { AppointmentServiceSelect } from './AppointmentServiceSelect';
 import { isServiceKeptAtLocation } from './AppointmentServiceSelect.utils';
-import { useProposedAppointments } from './useProposedAppointments';
-import type { DateTimeRange } from '../types';
+import { useDaySearch } from './useDaySearch';
 
 // Excludes what a room is rather than admitting what a site is: `physicalType` is
 // optional, so `physical-type=si,bu` would hide a Location that never declared one.
@@ -55,11 +44,6 @@ const PATIENT_SEARCH_CRITERIA = { _count: '25', _sort: 'name,birthdate' };
 
 // No month-wide scan exists, so every day is offered and the search answers.
 const NO_MARKED_DATES: Date[] = [];
-
-const MORE_DAYS = 2;
-
-// Generous heuristic for how many time results might be returned for a given day.
-const TIMES_PER_DAY = 50;
 
 // Shown beneath the calendar, since dragging or shift-clicking leaves no visible mark.
 const DAY_GESTURE_HINT = 'drag or shift-click to search more days';
@@ -148,7 +132,6 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
   const [location, setLocation] = useState<WithId<Location> | undefined>(defaultLocation);
   const [service, setService] = useState<WithId<HealthcareService> | undefined>(defaultService);
   const [selections, setSelections] = useState<ActorSelections>({});
-  const [daySearch, setDaySearch] = useState<DaySearch>(() => openDaySearch(defaultStart ?? new Date()));
   const [month, setMonth] = useState<Date | undefined>(defaultStart);
   const [finding, setFinding] = useState(false);
   const [chosen, setChosen] = useState<Appointment | undefined>(undefined);
@@ -162,7 +145,6 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
   const [bookError, setBookError] = useState<unknown>(undefined);
 
   const selectionError = getSelectionError(selections);
-  const windowError = getFindWindowError(daySearch.range);
 
   // Derived, not a flag: closing is never its own rule, so losing the last provider
   // closes the search however it was lost.
@@ -170,17 +152,7 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
 
   // Nothing is searched until the time search is open, so the answers above cost no
   // request per keystroke.
-  const combinations = useMemo(
-    () => (searching && !windowError ? getActorCombinations(selections) : []),
-    [searching, windowError, selections]
-  );
-
-  const search = useProposedAppointments({
-    service,
-    combinations,
-    range: daySearch.range,
-    count: TIMES_PER_DAY * enumerateDateRange(daySearch.range).length,
-  });
+  const combinations = useMemo(() => (searching ? getActorCombinations(selections) : []), [searching, selections]);
 
   // The first actor's schedule answers for all of them: every actor in one search
   // shares the scheduling parameters, or `$find` rejects the request.
@@ -189,30 +161,12 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
     return service ? getSchedulingTimezone(service, first?.schedule, first?.actorResource) : undefined;
   }, [service, selections]);
 
-  // While a further window is loading, `search.appointments` is that window's
-  // in-flight result, not yet part of `found`.
-  const times = useMemo(
-    () => (search.loading ? daySearch.found : [...daySearch.found, ...search.appointments]),
-    [search.loading, search.appointments, daySearch.found]
-  );
+  // A proposal carries the Slots it was found for, so it cannot outlive the days it
+  // was offered from.
+  const clearChosen = useCallback((): void => setChosen(undefined), []);
 
-  const shownDays = useMemo(
-    () => ({ start: daySearch.first.start, end: daySearch.range.end }),
-    [daySearch.first.start, daySearch.range.end]
-  );
-
-  // Read off the first window rather than the days on show, so a day picked stays marked
-  // as the one picked once "Show more days" has widened what is on show around it.
-  const picked = getPickedDay(daySearch);
-
-  // Passing shownDays lists empty days too, so a day that came back with nothing still
-  // shows up rather than looking like nobody asked about it.
-  const days = useMemo(() => groupAppointmentsByDay(times, timezone, shownDays), [times, timezone, shownDays]);
-
-  const anyTimes = days.some((day) => day.groups.length > 0);
-
-  // A spinner rather than empty days: only while the first window is still out.
-  const pending = search.loading && !daySearch.extended;
+  const daySearch = useDaySearch({ service, combinations, timezone, defaultStart, onDaysChanged: clearChosen });
+  const { reset: resetDaySearch } = daySearch;
 
   // The ref holds what the host was last told, so mounting reports nothing and a
   // search that closed on its own is reported like one closed by hand.
@@ -245,14 +199,17 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
     setFinding(!finding);
   }
 
-  const chooseResources = useCallback((update: (selections: ActorSelections) => ActorSelections): void => {
-    setSelections(update);
-    // A chosen time is a proposal carrying the Slots it was found for. Booked after
-    // a resource changes it would hold whoever is named inside the proposal, and
-    // `$book` cannot catch that: the proposal is internally consistent.
-    setChosen(undefined);
-    setDaySearch(resetDaySearch);
-  }, []);
+  const chooseResources = useCallback(
+    (update: (selections: ActorSelections) => ActorSelections): void => {
+      setSelections(update);
+      // A chosen time is a proposal carrying the Slots it was found for. Booked after
+      // a resource changes it would hold whoever is named inside the proposal, and
+      // `$book` cannot catch that: the proposal is internally consistent.
+      setChosen(undefined);
+      resetDaySearch();
+    },
+    [resetDaySearch]
+  );
 
   function chooseService(next: WithId<HealthcareService> | undefined): void {
     setService(next);
@@ -280,31 +237,7 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
     setSelections({});
     setChosen(undefined);
     setRoleFieldsKey((key) => key + 1);
-    setDaySearch(resetDaySearch);
-  }
-
-  function chooseDay(date: Date): void {
-    setDaySearch(openDaySearch(date));
-    setChosen(undefined);
-  }
-
-  // Held stable, unlike `chooseDay`: the calendar listens for a drag's end on the
-  // window for as long as it's under way, and re-subscribes whenever this changes.
-  const chooseRange = useCallback((start: Date, end: Date): void => {
-    setDaySearch(openDaySearch(start, end));
-    setChosen(undefined);
-  }, []);
-
-  // The button that calls this is `loading={search.loading}` and Mantine-disabled
-  // while loading, so `search.appointments` here is always the settled result of
-  // the current window, never an in-flight or stale one.
-  function showMoreDays(): void {
-    setDaySearch((previous) => ({
-      ...previous,
-      range: nextWindow(previous.range),
-      found: [...previous.found, ...search.appointments],
-      extended: true,
-    }));
+    resetDaySearch();
   }
 
   // The two answers a written booking can still be changed by. Everything else
@@ -388,16 +321,16 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
               allowUnavailableDates
               earliestDate={new Date()}
               month={month}
-              selected={picked}
-              range={shownDays}
+              selected={daySearch.picked}
+              range={daySearch.shown}
               onChangeMonth={setMonth}
-              onClick={chooseDay}
-              onSelectRange={chooseRange}
+              onClick={daySearch.chooseDay}
+              onSelectRange={daySearch.chooseRange}
             />
             <Text size="xs" c="dimmed">
-              {getSearchedDaysHint(shownDays)}
+              {getSearchedDaysHint(daySearch.shown)}
             </Text>
-            {windowError && <Alert color="yellow">{windowError}</Alert>}
+            {daySearch.windowError && <Alert color="yellow">{daySearch.windowError}</Alert>}
           </Stack>
         )}
 
@@ -429,11 +362,11 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
 
       {searching && (
         <Stack className={classes.results} gap="lg">
-          {pending && <Loader size="sm" />}
-          {search.error && <Alert color="red">{normalizeErrorString(search.error)}</Alert>}
-          {!pending &&
-            anyTimes &&
-            days.map((day) => (
+          {daySearch.pending && <Loader size="sm" />}
+          {daySearch.error && <Alert color="red">{normalizeErrorString(daySearch.error)}</Alert>}
+          {!daySearch.pending &&
+            daySearch.anyTimes &&
+            daySearch.days.map((day) => (
               <AppointmentDayTimes
                 key={day.key}
                 date={day.date}
@@ -443,14 +376,14 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
                 onSelectAppointment={chooseTime}
               />
             ))}
-          {!pending && !anyTimes && !search.error && !windowError && (
+          {!daySearch.pending && !daySearch.anyTimes && !daySearch.error && !daySearch.windowError && (
             <Text c="dimmed" ta="center">
               No times are available for this selection.
             </Text>
           )}
-          {!pending && !search.error && !windowError && (
+          {!daySearch.pending && !daySearch.error && !daySearch.windowError && (
             // No signal for how far ahead there's anything to find, so this has no end state.
-            <Button variant="subtle" loading={search.loading} onClick={showMoreDays}>
+            <Button variant="subtle" loading={daySearch.loading} onClick={daySearch.showMoreDays}>
               Show more days
             </Button>
           )}
@@ -649,38 +582,6 @@ function getMedicalRecordNumber(patient: WithId<Patient>, mrnSystem: string | un
   );
 }
 
-/** The days on offer, and the times the ones already answered came back with. */
-interface DaySearch {
-  /** The window the search opened on, which is what putting the added days away goes back to. */
-  readonly first: DateTimeRange;
-  /** The days being asked about now, which is the newest window alone. Both ends closed, as `$find` requires. */
-  readonly range: DateTimeRange;
-  /** Times the earlier windows offered, kept on screen while a further one is out. */
-  readonly found: readonly Appointment[];
-  /** Whether days beyond the first window have been asked for. */
-  readonly extended: boolean;
-}
-
-function floorToNow(date: Date): Date {
-  const now = new Date();
-  return date > now ? date : now;
-}
-
-/**
- * Opens the search on a stretch of days, asking about all of them at once.
- *
- * A day picked on its own is a stretch of one, so a click and a drag open the same way.
- *
- * @param start - Any instant during the first day of the stretch.
- * @param end - Any instant during its last day. Defaults to the first day.
- * @returns The first window, with nothing found yet.
- */
-function openDaySearch(start: Date, end: Date = start): DaySearch {
-  const from = floorToNow(start);
-  const window = { start: from, end: endOfDay(end > from ? end : from) };
-  return { first: window, range: window, found: [], extended: false };
-}
-
 /**
  * Reads the interval a proposal runs over.
  *
@@ -692,39 +593,6 @@ function toRange(appointment: Appointment | undefined): DateTimeRange | undefine
     return undefined;
   }
   return { start: new Date(appointment.start), end: new Date(appointment.end) };
-}
-
-/**
- * Returns the day picked, when a day was picked rather than a stretch of them.
- *
- * A one-day first window means a click: `CalendarDateInput` only reports a range once a
- * drag has crossed a day, so a drag that stayed put arrives as an ordinary click.
- *
- * @param search - The day search as it stands.
- * @returns The day picked, or undefined when a stretch of days was picked instead.
- */
-function getPickedDay(search: DaySearch): Date | undefined {
-  return isSameDay(search.first.start, search.first.end) ? search.first.start : undefined;
-}
-
-/**
- * Moves the search on to the days after the ones already asked about.
- * @param range - The window last asked about.
- * @returns The window following it, opening at midnight of the next day.
- */
-function nextWindow(range: DateTimeRange): DateTimeRange {
-  const next = addDays(range.end, 1);
-  const start = new Date(next.getFullYear(), next.getMonth(), next.getDate());
-  return { start, end: endOfDay(addDays(start, MORE_DAYS - 1)) };
-}
-
-/**
- * Puts the added days away, for an answer that changes what every day offers.
- * @param previous - The day search as it stands.
- * @returns The day search, back to its first window.
- */
-function resetDaySearch(previous: DaySearch): DaySearch {
-  return { first: previous.first, range: previous.first, found: [], extended: false };
 }
 
 /**

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
@@ -170,7 +170,7 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
 
   // The first window is back and nothing is holding the search up, so what it found —
   // even if that is nothing — is what is on screen.
-  const settled = !daySearch.pending && !daySearch.error && !daySearch.windowError;
+  const settled = !daySearch.loadingFirstDays && !daySearch.findRequestError && !daySearch.windowError;
 
   // The ref holds what the host was last told, so mounting reports nothing and a
   // search that closed on its own is reported like one closed by hand.
@@ -325,13 +325,13 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
               allowUnavailableDates
               earliestDate={new Date()}
               month={month}
-              range={daySearch.shown}
+              range={daySearch.selectedDayRange}
               onChangeMonth={setMonth}
-              onClick={daySearch.chooseDay}
-              onSelectRange={daySearch.chooseRange}
+              onClick={daySearch.chooseDayRange}
+              onSelectRange={daySearch.chooseDayRange}
             />
             <Text size="xs" c="dimmed">
-              {getSearchedDaysHint(daySearch.shown)}
+              {getSearchedDaysHint(daySearch.selectedDayRange)}
             </Text>
             {daySearch.windowError && <Alert color="yellow">{daySearch.windowError}</Alert>}
           </Stack>
@@ -365,11 +365,11 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
 
       {searching && (
         <Stack className={classes.results} gap="lg">
-          {daySearch.pending && <Loader size="sm" />}
-          {daySearch.error && <Alert color="red">{normalizeErrorString(daySearch.error)}</Alert>}
-          {!daySearch.pending &&
-            daySearch.anyTimes &&
-            daySearch.days.map((day) => (
+          {daySearch.loadingFirstDays && <Loader size="sm" />}
+          {daySearch.findRequestError && <Alert color="red">{normalizeErrorString(daySearch.findRequestError)}</Alert>}
+          {!daySearch.loadingFirstDays &&
+            daySearch.hasTimes &&
+            daySearch.timeResultsByDay.map((day) => (
               <AppointmentDayTimes
                 key={day.key}
                 date={day.date}
@@ -381,13 +381,13 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
             ))}
           {settled && (
             <>
-              {!daySearch.anyTimes && (
+              {!daySearch.hasTimes && (
                 <Text c="dimmed" ta="center">
                   No times are available for this selection.
                 </Text>
               )}
               {/* No signal for how far ahead there's anything to find, so this has no end state. */}
-              <Button variant="subtle" loading={daySearch.loading} onClick={daySearch.showMoreDays}>
+              <Button variant="subtle" loading={daySearch.loadingMoreDays} onClick={daySearch.showMoreDays}>
                 Show more days
               </Button>
             </>

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
@@ -36,6 +36,7 @@ import {
   getDurationMinutes,
   getFindWindowError,
   groupAppointmentsByDay,
+  isSameDay,
 } from './AppointmentFinder.times';
 import { AppointmentOptionRow } from './AppointmentOptionRow';
 import { AppointmentServiceSelect } from './AppointmentServiceSelect';
@@ -54,10 +55,6 @@ const PATIENT_SEARCH_CRITERIA = { _count: '25', _sort: 'name,birthdate' };
 
 // No month-wide scan exists, so every day is offered and the search answers.
 const NO_MARKED_DATES: Date[] = [];
-
-// Also searches the two days after the one picked: one day's times are often too
-// few to choose between.
-const DAYS_SHOWN = 3;
 
 const MORE_DAYS = 2;
 
@@ -204,6 +201,10 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
     [daySearch.first.start, daySearch.range.end]
   );
 
+  // Read off the first window rather than the days on show, so a day picked stays marked
+  // as the one picked once "Show more days" has widened what is on show around it.
+  const picked = getPickedDay(daySearch);
+
   // Passing shownDays lists empty days too, so a day that came back with nothing still
   // shows up rather than looking like nobody asked about it.
   const days = useMemo(() => groupAppointmentsByDay(times, timezone, shownDays), [times, timezone, shownDays]);
@@ -290,7 +291,7 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
   // Held stable, unlike `chooseDay`: the calendar listens for a drag's end on the
   // window for as long as it's under way, and re-subscribes whenever this changes.
   const chooseRange = useCallback((start: Date, end: Date): void => {
-    setDaySearch(openRangeSearch(start, end));
+    setDaySearch(openDaySearch(start, end));
     setChosen(undefined);
   }, []);
 
@@ -387,7 +388,7 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
               allowUnavailableDates
               earliestDate={new Date()}
               month={month}
-              selected={daySearch.picked}
+              selected={picked}
               range={shownDays}
               onChangeMonth={setMonth}
               onClick={chooseDay}
@@ -650,8 +651,6 @@ function getMedicalRecordNumber(patient: WithId<Patient>, mrnSystem: string | un
 
 /** The days on offer, and the times the ones already answered came back with. */
 interface DaySearch {
-  /** The one day that was picked, or undefined when a stretch of days was picked instead. */
-  readonly picked: Date | undefined;
   /** The window the search opened on, which is what putting the added days away goes back to. */
   readonly first: DateTimeRange;
   /** The days being asked about now, which is the newest window alone. Both ends closed, as `$find` requires. */
@@ -669,14 +668,17 @@ function floorToNow(date: Date): Date {
 
 /**
  * Opens the search on a stretch of days, asking about all of them at once.
+ *
+ * A day picked on its own is a stretch of one, so a click and a drag open the same way.
+ *
  * @param start - Any instant during the first day of the stretch.
- * @param end - Any instant during its last day.
+ * @param end - Any instant during its last day. Defaults to the first day.
  * @returns The first window, with nothing found yet.
  */
-function openRangeSearch(start: Date, end: Date): DaySearch {
+function openDaySearch(start: Date, end: Date = start): DaySearch {
   const from = floorToNow(start);
   const window = { start: from, end: endOfDay(end > from ? end : from) };
-  return { picked: undefined, first: window, range: window, found: [], extended: false };
+  return { first: window, range: window, found: [], extended: false };
 }
 
 /**
@@ -693,15 +695,16 @@ function toRange(appointment: Appointment | undefined): DateTimeRange | undefine
 }
 
 /**
- * Opens the search on a day, asking about it and the two days after it.
+ * Returns the day picked, when a day was picked rather than a stretch of them.
  *
- * @param date - Any instant during the day to open on.
- * @returns The first window, with nothing found yet.
+ * A one-day first window means a click: `CalendarDateInput` only reports a range once a
+ * drag has crossed a day, so a drag that stayed put arrives as an ordinary click.
+ *
+ * @param search - The day search as it stands.
+ * @returns The day picked, or undefined when a stretch of days was picked instead.
  */
-function openDaySearch(date: Date): DaySearch {
-  const from = floorToNow(date);
-  const window = { start: from, end: endOfDay(addDays(from, DAYS_SHOWN - 1)) };
-  return { picked: from, first: window, range: window, found: [], extended: false };
+function getPickedDay(search: DaySearch): Date | undefined {
+  return isSameDay(search.first.start, search.first.end) ? search.first.start : undefined;
 }
 
 /**
@@ -721,7 +724,7 @@ function nextWindow(range: DateTimeRange): DateTimeRange {
  * @returns The day search, back to its first window.
  */
 function resetDaySearch(previous: DaySearch): DaySearch {
-  return { picked: previous.picked, first: previous.first, range: previous.first, found: [], extended: false };
+  return { first: previous.first, range: previous.first, found: [], extended: false };
 }
 
 /**

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
@@ -31,6 +31,8 @@ import {
   addDays,
   endOfDay,
   enumerateDateRange,
+  formatDateRange,
+  formatDayLabel,
   getDurationMinutes,
   getFindWindowError,
   groupAppointmentsByDay,
@@ -61,6 +63,15 @@ const MORE_DAYS = 2;
 
 /** Times to ask for per day searched. */
 const TIMES_PER_DAY = 20;
+
+/**
+ * What the calendar's gestures do, said beneath it because neither leaves a mark on it
+ * to be found by.
+ */
+const DAY_GESTURE_HINT = 'drag or shift-click to search more days';
+
+/** Joins phrases sharing a line. Presentational: neither phrase it separates carries it. */
+const HINT_SEPARATOR = ' · ';
 
 export interface AppointmentProposalFormProps {
   /** Pre-fills where the visit is, for a host that already knows. */
@@ -195,8 +206,8 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
 
   // Every day asked about, the calendar and the times reading off the same stretch.
   const shownDays = useMemo(
-    () => ({ start: daySearch.from, end: daySearch.range.end }),
-    [daySearch.from, daySearch.range.end]
+    () => ({ start: daySearch.first.start, end: daySearch.range.end }),
+    [daySearch.first.start, daySearch.range.end]
   );
 
   // Including the days offering nothing: a day that goes missing is indistinguishable
@@ -283,6 +294,17 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
     setDaySearch(openDaySearch(date));
     setChosen(undefined);
   }
+
+  /**
+   * Searches the stretch of days a drag or a shift-click asked for, all at once.
+   *
+   * Held stable, unlike {@link chooseDay}: the calendar listens for the end of a drag
+   * on the window while one is under way, and re-subscribes whenever this changes.
+   */
+  const chooseRange = useCallback((start: Date, end: Date): void => {
+    setDaySearch(openRangeSearch(start, end));
+    setChosen(undefined);
+  }, []);
 
   /**
    * Puts the days after the ones on screen up for searching too.
@@ -377,11 +399,15 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
               allowUnavailableDates
               earliestDate={new Date()}
               month={month}
-              selected={daySearch.from}
+              selected={daySearch.picked}
               range={shownDays}
               onChangeMonth={setMonth}
               onClick={chooseDay}
+              onSelectRange={chooseRange}
             />
+            <Text size="xs" c="dimmed">
+              {getSearchedDaysHint(shownDays)}
+            </Text>
             {windowError && <Alert color="yellow">{windowError}</Alert>}
           </Stack>
         )}
@@ -643,14 +669,33 @@ interface SearchWindow {
 
 /** The days on offer, and the times the ones already answered came back with. */
 interface DaySearch {
-  /** Where the search opened: the day that was picked, or now if that day is under way. */
-  readonly from: Date;
+  /** The one day that was picked, or undefined when a stretch of days was picked instead. */
+  readonly picked: Date | undefined;
+  /** The window the search opened on, which is what putting the added days away goes back to. */
+  readonly first: SearchWindow;
   /** The days being asked about now, which is the newest window alone. */
   readonly range: SearchWindow;
   /** Times the earlier windows offered, kept on screen while a further one is out. */
   readonly found: readonly Appointment[];
   /** Whether days beyond the first window have been asked for. */
   readonly extended: boolean;
+}
+
+function floorToNow(date: Date): Date {
+  const now = new Date();
+  return date > now ? date : now;
+}
+
+/**
+ * Opens the search on a stretch of days, asking about all of them at once.
+ * @param start - Any instant during the first day of the stretch.
+ * @param end - Any instant during its last day.
+ * @returns The first window, with nothing found yet.
+ */
+function openRangeSearch(start: Date, end: Date): DaySearch {
+  const from = floorToNow(start);
+  const window = { start: from, end: endOfDay(end > from ? end : from) };
+  return { picked: undefined, first: window, range: window, found: [], extended: false };
 }
 
 /**
@@ -669,22 +714,13 @@ function toRange(appointment: Appointment | undefined): DateTimeRange | undefine
 /**
  * Opens the search on a day, asking about it and the two days after it.
  *
- * `$find` treats `start` as a hard floor, so a day already under way starts from now
- * rather than midnight: the calendar hands back local midnight, and asking from there
- * would offer times that have already passed.
- *
  * @param date - Any instant during the day to open on.
  * @returns The first window, with nothing found yet.
  */
 function openDaySearch(date: Date): DaySearch {
-  const now = new Date();
-  const from = date > now ? date : now;
-  return {
-    from,
-    range: { start: from, end: endOfDay(addDays(from, DAYS_SHOWN - 1)) },
-    found: [],
-    extended: false,
-  };
+  const from = floorToNow(date);
+  const window = { start: from, end: endOfDay(addDays(from, DAYS_SHOWN - 1)) };
+  return { picked: from, first: window, range: window, found: [], extended: false };
 }
 
 /**
@@ -700,15 +736,20 @@ function nextWindow(range: SearchWindow): SearchWindow {
 
 /**
  * Puts the added days away, for an answer that changes what every day offers.
- *
- * Only when days were added: rebuilding the first window moves its floor to now,
- * which is a different search and so another request for the same days.
- *
  * @param previous - The day search as it stands.
  * @returns The day search, back to its first window.
  */
 function collapseDays(previous: DaySearch): DaySearch {
-  return previous.extended ? openDaySearch(previous.from) : previous;
+  return previous.extended ? { ...previous, range: previous.first, found: [], extended: false } : previous;
+}
+
+/**
+ * The line under the calendar: which days are being searched, and how to ask for others.
+ * @param range - The days being searched.
+ * @returns The line to show beneath the calendar.
+ */
+function getSearchedDaysHint(range: SearchWindow): string {
+  return [formatDateRange(range, formatDayLabel), DAY_GESTURE_HINT].filter(isDefined).join(HINT_SEPARATOR);
 }
 
 /**

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
@@ -248,7 +248,7 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
     // a resource changes it would hold whoever is named inside the proposal, and
     // `$book` cannot catch that: the proposal is internally consistent.
     setChosen(undefined);
-    setDaySearch(collapseDays);
+    setDaySearch(resetDaySearch);
   }, []);
 
   function chooseService(next: WithId<HealthcareService> | undefined): void {
@@ -277,7 +277,7 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
     setSelections({});
     setChosen(undefined);
     setRoleFieldsKey((key) => key + 1);
-    setDaySearch(collapseDays);
+    setDaySearch(resetDaySearch);
   }
 
   function chooseDay(date: Date): void {
@@ -292,6 +292,9 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
     setChosen(undefined);
   }, []);
 
+  // The button that calls this is `loading={search.loading}` and Mantine-disabled
+  // while loading, so `search.appointments` here is always the settled result of
+  // the current window, never an in-flight or stale one.
   function showMoreDays(): void {
     setDaySearch((previous) => ({
       ...previous,
@@ -721,8 +724,8 @@ function nextWindow(range: SearchWindow): SearchWindow {
  * @param previous - The day search as it stands.
  * @returns The day search, back to its first window.
  */
-function collapseDays(previous: DaySearch): DaySearch {
-  return previous.extended ? { ...previous, range: previous.first, found: [], extended: false } : previous;
+function resetDaySearch(previous: DaySearch): DaySearch {
+  return { picked: previous.picked, first: previous.first, range: previous.first, found: [], extended: false };
 }
 
 /**

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
@@ -168,6 +168,10 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
   const daySearch = useDaySearch({ service, combinations, timezone, defaultStart, onDaysChanged: clearChosen });
   const { reset: resetDaySearch } = daySearch;
 
+  // The first window is back and nothing is holding the search up, so what it found —
+  // even if that is nothing — is what is on screen.
+  const settled = !daySearch.pending && !daySearch.error && !daySearch.windowError;
+
   // The ref holds what the host was last told, so mounting reports nothing and a
   // search that closed on its own is reported like one closed by hand.
   const reported = useRef(false);
@@ -321,7 +325,6 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
               allowUnavailableDates
               earliestDate={new Date()}
               month={month}
-              selected={daySearch.picked}
               range={daySearch.shown}
               onChangeMonth={setMonth}
               onClick={daySearch.chooseDay}
@@ -376,16 +379,18 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
                 onSelectAppointment={chooseTime}
               />
             ))}
-          {!daySearch.pending && !daySearch.anyTimes && !daySearch.error && !daySearch.windowError && (
-            <Text c="dimmed" ta="center">
-              No times are available for this selection.
-            </Text>
-          )}
-          {!daySearch.pending && !daySearch.error && !daySearch.windowError && (
-            // No signal for how far ahead there's anything to find, so this has no end state.
-            <Button variant="subtle" loading={daySearch.loading} onClick={daySearch.showMoreDays}>
-              Show more days
-            </Button>
+          {settled && (
+            <>
+              {!daySearch.anyTimes && (
+                <Text c="dimmed" ta="center">
+                  No times are available for this selection.
+                </Text>
+              )}
+              {/* No signal for how far ahead there's anything to find, so this has no end state. */}
+              <Button variant="subtle" loading={daySearch.loading} onClick={daySearch.showMoreDays}>
+                Show more days
+              </Button>
+            </>
           )}
         </Stack>
       )}

--- a/packages/react-scheduling/src/AppointmentFinder/useDaySearch.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/useDaySearch.ts
@@ -2,18 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
 import type { Appointment, HealthcareService } from '@medplum/fhirtypes';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { DateTimeRange } from '../types';
 import type { ActorCombination } from './AppointmentFinder.schedules';
 import type { AppointmentDay } from './AppointmentFinder.times';
-import {
-  addDays,
-  endOfDay,
-  enumerateDateRange,
-  getFindWindowError,
-  groupAppointmentsByDay,
-  isSameDay,
-} from './AppointmentFinder.times';
+import { addDays, endOfDay, getDayCount, groupAppointmentsByDay, startOfDay } from './AppointmentFinder.times';
 import { useProposedAppointments } from './useProposedAppointments';
 
 // How many days "Show more days" reaches further each time it is pressed.
@@ -38,8 +31,6 @@ export interface UseDaySearchOptions {
 export interface UseDaySearchResult {
   /** Every day on show, which is what the calendar marks. */
   readonly shown: DateTimeRange;
-  /** The day picked, or undefined when a stretch of days was picked instead. */
-  readonly picked: Date | undefined;
   /** The days on show, grouped by day and actor set, days that offered nothing included. */
   readonly days: readonly AppointmentDay[];
   /** Whether any day on show offered a time at all. */
@@ -82,22 +73,11 @@ export function useDaySearch(options: UseDaySearchOptions): UseDaySearchResult {
 
   const [daySearch, setDaySearch] = useState<DaySearch>(() => openDaySearch(defaultStart ?? new Date()));
 
-  // Held in a ref so every handler below can be stable whatever the caller passes:
-  // `chooseRange` in particular is subscribed to a pointer drag already under way.
-  const onDaysChangedRef = useRef(onDaysChanged);
-  useEffect(() => {
-    onDaysChangedRef.current = onDaysChanged;
-  }, [onDaysChanged]);
-
-  const windowError = getFindWindowError(daySearch.range);
-
-  const dayCount = useMemo(() => enumerateDateRange(daySearch.range).length, [daySearch.range]);
-
   const search = useProposedAppointments({
     service,
     combinations,
     range: daySearch.range,
-    count: TIMES_PER_DAY * dayCount,
+    count: TIMES_PER_DAY * getDayCount(daySearch.range.start, daySearch.range.end),
   });
 
   const shown = useMemo(
@@ -115,10 +95,13 @@ export function useDaySearch(options: UseDaySearchOptions): UseDaySearchResult {
     return { days: grouped, anyTimes: grouped.some((day) => day.groups.length > 0) };
   }, [search.loading, search.appointments, daySearch.found, timezone, shown]);
 
-  const chooseRange = useCallback((start: Date, end: Date): void => {
-    setDaySearch(openDaySearch(start, end));
-    onDaysChangedRef.current?.();
-  }, []);
+  const chooseRange = useCallback(
+    (start: Date, end: Date): void => {
+      setDaySearch(openDaySearch(start, end));
+      onDaysChanged?.();
+    },
+    [onDaysChanged]
+  );
 
   const chooseDay = useCallback((date: Date): void => chooseRange(date, date), [chooseRange]);
 
@@ -144,17 +127,14 @@ export function useDaySearch(options: UseDaySearchOptions): UseDaySearchResult {
 
   return {
     shown,
-    // Read off the first window rather than the days on show, so a day picked stays
-    // marked as the one picked once "Show more days" has widened what is around it.
-    picked: isSameDay(daySearch.first.start, daySearch.first.end) ? daySearch.first.start : undefined,
     days,
     anyTimes,
-    // A spinner rather than empty days: only while the first window is still out, i.e.
-    // `range` hasn't yet been extended past `first`.
-    pending: search.loading && daySearch.range === daySearch.first,
+    // A spinner rather than empty days: only while the first window is still out, before
+    // "Show more days" has moved the search past it.
+    pending: search.loading && daySearch.range.start.getTime() === daySearch.first.start.getTime(),
     loading: search.loading,
     error: search.error,
-    windowError,
+    windowError: search.windowError,
     chooseDay,
     chooseRange,
     showMoreDays,
@@ -205,7 +185,6 @@ function openDaySearch(start: Date, end: Date = start): DaySearch {
  * @returns The window following it, opening at midnight of the next day.
  */
 function nextWindow(range: DateTimeRange): DateTimeRange {
-  const next = addDays(range.end, 1);
-  const start = new Date(next.getFullYear(), next.getMonth(), next.getDate());
+  const start = startOfDay(addDays(range.end, 1));
   return { start, end: endOfDay(addDays(start, MORE_DAYS - 1)) };
 }

--- a/packages/react-scheduling/src/AppointmentFinder/useDaySearch.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/useDaySearch.ts
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import type { Appointment, HealthcareService } from '@medplum/fhirtypes';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { DateTimeRange } from '../types';
+import type { ActorCombination } from './AppointmentFinder.schedules';
+import type { AppointmentDay } from './AppointmentFinder.times';
+import {
+  addDays,
+  endOfDay,
+  enumerateDateRange,
+  getFindWindowError,
+  groupAppointmentsByDay,
+  isSameDay,
+} from './AppointmentFinder.times';
+import { useProposedAppointments } from './useProposedAppointments';
+
+// How many days "Show more days" reaches further each time it is pressed.
+const MORE_DAYS = 2;
+
+// Generous heuristic for how many time results might be returned for a given day.
+const TIMES_PER_DAY = 50;
+
+export interface UseDaySearchOptions {
+  /** The service being booked. No search runs without one. */
+  readonly service: WithId<HealthcareService> | undefined;
+  /** The sets of actors to search for. No search runs while this is empty. */
+  readonly combinations: readonly ActorCombination[];
+  /** The zone a day is read in, so a day breaks where the site says it does. */
+  readonly timezone: string | undefined;
+  /** The day to open on. Defaults to today. */
+  readonly defaultStart?: Date;
+  /** Fired when the days picked change, so the caller can drop what it chose from the old ones. */
+  readonly onDaysChanged?: () => void;
+}
+
+export interface UseDaySearchResult {
+  /** Every day on show, which is what the calendar marks. */
+  readonly shown: DateTimeRange;
+  /** The day picked, or undefined when a stretch of days was picked instead. */
+  readonly picked: Date | undefined;
+  /** The days on show, grouped by day and actor set, days that offered nothing included. */
+  readonly days: readonly AppointmentDay[];
+  /** Whether any day on show offered a time at all. */
+  readonly anyTimes: boolean;
+  /** True while the first window is out, when there is nothing yet to show. */
+  readonly pending: boolean;
+  /** True while any window is out, a further one over days already shown included. */
+  readonly loading: boolean;
+  /** Set only when every combination failed. */
+  readonly error: Error | undefined;
+  /** A window `$find` will not answer, caught before the request is made. */
+  readonly windowError: string | undefined;
+  /** Opens the search on one day. */
+  readonly chooseDay: (date: Date) => void;
+  /** Opens the search on a stretch of days, asking about all of them at once. */
+  readonly chooseRange: (start: Date, end: Date) => void;
+  /** Reaches further than the days already answered, keeping them on screen. */
+  readonly showMoreDays: () => void;
+  /** Puts the added days away, for an answer that changes what every day offers. */
+  readonly reset: () => void;
+}
+
+/**
+ * Holds which days the time search covers, and the times they came back with.
+ *
+ * Owns the whole of that machine: the window being asked about, the windows already
+ * answered, the `$find` request each one costs, and the grouping the caller renders. The
+ * search is driven entirely by the window — advancing it *is* the request — so the state
+ * and the fetch have to sit together to stay honest.
+ *
+ * @param options - The service, actors and zone to search against, and the day to open on.
+ * @returns The days on show with their times, load and error state, and the four ways in.
+ */
+export function useDaySearch(options: UseDaySearchOptions): UseDaySearchResult {
+  const { service, combinations, timezone, defaultStart, onDaysChanged } = options;
+
+  const [daySearch, setDaySearch] = useState<DaySearch>(() => openDaySearch(defaultStart ?? new Date()));
+
+  // Held in a ref so every handler below can be stable whatever the caller passes:
+  // `chooseRange` in particular is subscribed to a pointer drag already under way.
+  const onDaysChangedRef = useRef(onDaysChanged);
+  useEffect(() => {
+    onDaysChangedRef.current = onDaysChanged;
+  }, [onDaysChanged]);
+
+  const windowError = getFindWindowError(daySearch.range);
+
+  // Gated here rather than by the caller, which cannot know the window is unanswerable
+  // until this hook has said so.
+  const search = useProposedAppointments({
+    service,
+    combinations: windowError ? [] : combinations,
+    range: daySearch.range,
+    count: TIMES_PER_DAY * enumerateDateRange(daySearch.range).length,
+  });
+
+  // While a further window is loading, `search.appointments` is that window's
+  // in-flight result, not yet part of `found`.
+  const times = useMemo(
+    () => (search.loading ? daySearch.found : [...daySearch.found, ...search.appointments]),
+    [search.loading, search.appointments, daySearch.found]
+  );
+
+  const shown = useMemo(
+    () => ({ start: daySearch.first.start, end: daySearch.range.end }),
+    [daySearch.first.start, daySearch.range.end]
+  );
+
+  // Passing `shown` lists empty days too, so a day that came back with nothing still
+  // shows up rather than looking like nobody asked about it.
+  const days = useMemo(() => groupAppointmentsByDay(times, timezone, shown), [times, timezone, shown]);
+
+  const chooseDay = useCallback((date: Date): void => {
+    setDaySearch(openDaySearch(date));
+    onDaysChangedRef.current?.();
+  }, []);
+
+  const chooseRange = useCallback((start: Date, end: Date): void => {
+    setDaySearch(openDaySearch(start, end));
+    onDaysChangedRef.current?.();
+  }, []);
+
+  // `search.appointments` is the settled result of the current window rather than an
+  // in-flight one, because the control that calls this is disabled while `loading`.
+  const showMoreDays = useCallback((): void => {
+    setDaySearch((previous) => ({
+      first: previous.first,
+      range: nextWindow(previous.range),
+      found: [...previous.found, ...search.appointments],
+      extended: true,
+    }));
+  }, [search.appointments]);
+
+  // Which days were picked does not change, so nothing chosen from them goes stale.
+  const reset = useCallback((): void => {
+    setDaySearch((previous) => ({
+      first: previous.first,
+      range: previous.first,
+      found: [],
+      extended: false,
+    }));
+  }, []);
+
+  return {
+    shown,
+    // Read off the first window rather than the days on show, so a day picked stays
+    // marked as the one picked once "Show more days" has widened what is around it.
+    picked: isSameDay(daySearch.first.start, daySearch.first.end) ? daySearch.first.start : undefined,
+    days,
+    anyTimes: days.some((day) => day.groups.length > 0),
+    // A spinner rather than empty days: only while the first window is still out.
+    pending: search.loading && !daySearch.extended,
+    loading: search.loading,
+    error: search.error,
+    windowError,
+    chooseDay,
+    chooseRange,
+    showMoreDays,
+    reset,
+  };
+}
+
+/** The days on offer, and the times the ones already answered came back with. */
+interface DaySearch {
+  /** The window the search opened on, which is what putting the added days away goes back to. */
+  readonly first: DateTimeRange;
+  /** The days being asked about now, which is the newest window alone. Both ends closed, as `$find` requires. */
+  readonly range: DateTimeRange;
+  /** Times the earlier windows offered, kept on screen while a further one is out. */
+  readonly found: readonly Appointment[];
+  /** Whether days beyond the first window have been asked for. */
+  readonly extended: boolean;
+}
+
+/**
+ * `$find` treats `start` as a hard floor, so a day already under way starts from now
+ * rather than midnight: the calendar hands back local midnight, and asking from there
+ * would offer times that have already passed.
+ * @param date - Any instant during the day.
+ * @returns The later of that instant and now.
+ */
+function floorToNow(date: Date): Date {
+  const now = new Date();
+  return date > now ? date : now;
+}
+
+/**
+ * Opens the search on a stretch of days, asking about all of them at once.
+ *
+ * A day picked on its own is a stretch of one, so a click and a drag open the same way.
+ *
+ * @param start - Any instant during the first day of the stretch.
+ * @param end - Any instant during its last day. Defaults to the first day.
+ * @returns The first window, with nothing found yet.
+ */
+function openDaySearch(start: Date, end: Date = start): DaySearch {
+  const from = floorToNow(start);
+  const window = { start: from, end: endOfDay(end > from ? end : from) };
+  return { first: window, range: window, found: [], extended: false };
+}
+
+/**
+ * Moves the search on to the days after the ones already asked about.
+ * @param range - The window last asked about.
+ * @returns The window following it, opening at midnight of the next day.
+ */
+function nextWindow(range: DateTimeRange): DateTimeRange {
+  const next = addDays(range.end, 1);
+  const start = new Date(next.getFullYear(), next.getMonth(), next.getDate());
+  return { start, end: endOfDay(addDays(start, MORE_DAYS - 1)) };
+}

--- a/packages/react-scheduling/src/AppointmentFinder/useDaySearch.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/useDaySearch.ts
@@ -30,23 +30,25 @@ export interface UseDaySearchOptions {
 
 export interface UseDaySearchResult {
   /** Every day on show, which is what the calendar marks. */
-  readonly shown: DateTimeRange;
+  readonly selectedDayRange: DateTimeRange;
   /** The days on show, grouped by day and actor set, days that offered nothing included. */
-  readonly days: readonly AppointmentDay[];
+  readonly timeResultsByDay: readonly AppointmentDay[];
   /** Whether any day on show offered a time at all. */
-  readonly anyTimes: boolean;
+  readonly hasTimes: boolean;
   /** True while the first window is out, when there is nothing yet to show. */
-  readonly pending: boolean;
-  /** True while any window is out, a further one over days already shown included. */
-  readonly loading: boolean;
-  /** Set only when every combination failed. */
-  readonly error: Error | undefined;
+  readonly loadingFirstDays: boolean;
+  /** True while a window over days beyond the ones already on show is out. */
+  readonly loadingMoreDays: boolean;
+  /** Set only when every combination's `$find` failed. */
+  readonly findRequestError: Error | undefined;
   /** A window `$find` will not answer, caught before the request is made. */
   readonly windowError: string | undefined;
-  /** Opens the search on one day. */
-  readonly chooseDay: (date: Date) => void;
-  /** Opens the search on a stretch of days, asking about all of them at once. */
-  readonly chooseRange: (start: Date, end: Date) => void;
+  /**
+   * Opens the search on a stretch of days, asking about all of them at once.
+   *
+   * A day picked on its own is a stretch of one, so a click and a drag come in the same way.
+   */
+  readonly chooseDayRange: (start: Date, end?: Date) => void;
   /** Reaches further than the days already answered, keeping them on screen. */
   readonly showMoreDays: () => void;
   /**
@@ -66,7 +68,7 @@ export interface UseDaySearchResult {
  * and the fetch have to sit together to stay honest.
  *
  * @param options - The service, actors and zone to search against, and the day to open on.
- * @returns The days on show with their times, load and error state, and the four ways in.
+ * @returns The days on show with their times, load and error state, and the three ways in.
  */
 export function useDaySearch(options: UseDaySearchOptions): UseDaySearchResult {
   const { service, combinations, timezone, defaultStart, onDaysChanged } = options;
@@ -80,33 +82,27 @@ export function useDaySearch(options: UseDaySearchOptions): UseDaySearchResult {
     count: TIMES_PER_DAY * getDayCount(daySearch.range.start, daySearch.range.end),
   });
 
-  const shown = useMemo(
+  const selectedDayRange = useMemo(
     () => ({ start: daySearch.first.start, end: daySearch.range.end }),
     [daySearch.first.start, daySearch.range.end]
   );
 
-  // Passing `shown` lists empty days too, so a day that came back with nothing still
-  // shows up rather than looking like nobody asked about it. While a further window is
-  // loading, `search.appointments` is that window's in-flight result, not yet part of
-  // `found`.
-  const { days, anyTimes } = useMemo(() => {
+  const { timeResultsByDay, hasTimes } = useMemo(() => {
     const times = search.loading ? daySearch.found : [...daySearch.found, ...search.appointments];
-    const grouped = groupAppointmentsByDay(times, timezone, shown);
-    return { days: grouped, anyTimes: grouped.some((day) => day.groups.length > 0) };
-  }, [search.loading, search.appointments, daySearch.found, timezone, shown]);
+    const grouped = groupAppointmentsByDay(times, timezone, selectedDayRange);
+    return { timeResultsByDay: grouped, hasTimes: grouped.some((day) => day.groups.length > 0) };
+  }, [search.loading, search.appointments, daySearch.found, timezone, selectedDayRange]);
 
-  const chooseRange = useCallback(
-    (start: Date, end: Date): void => {
+  const chooseDayRange = useCallback(
+    (start: Date, end?: Date): void => {
       setDaySearch(openDaySearch(start, end));
       onDaysChanged?.();
     },
     [onDaysChanged]
   );
 
-  const chooseDay = useCallback((date: Date): void => chooseRange(date, date), [chooseRange]);
-
   // `search.appointments` is the settled result of the current window rather than an
-  // in-flight one, because the control that calls this is disabled while `loading`.
+  // in-flight one, because the control that calls this is disabled while `loadingMoreDays`.
   const showMoreDays = useCallback((): void => {
     setDaySearch((previous) => ({
       first: previous.first,
@@ -125,18 +121,19 @@ export function useDaySearch(options: UseDaySearchOptions): UseDaySearchResult {
     }));
   }, []);
 
+  // A spinner rather than empty days: only while the first window is still out, before
+  // "Show more days" has moved the search past it.
+  const loadingFirstDays = search.loading && daySearch.range.start.getTime() === daySearch.first.start.getTime();
+
   return {
-    shown,
-    days,
-    anyTimes,
-    // A spinner rather than empty days: only while the first window is still out, before
-    // "Show more days" has moved the search past it.
-    pending: search.loading && daySearch.range.start.getTime() === daySearch.first.start.getTime(),
-    loading: search.loading,
-    error: search.error,
+    selectedDayRange,
+    timeResultsByDay,
+    hasTimes,
+    loadingFirstDays,
+    loadingMoreDays: search.loading && !loadingFirstDays,
+    findRequestError: search.error,
     windowError: search.windowError,
-    chooseDay,
-    chooseRange,
+    chooseDayRange,
     showMoreDays,
     reset,
   };

--- a/packages/react-scheduling/src/AppointmentFinder/useDaySearch.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/useDaySearch.ts
@@ -83,8 +83,8 @@ export function useDaySearch(options: UseDaySearchOptions): UseDaySearchResult {
   });
 
   const selectedDayRange = useMemo(
-    () => ({ start: daySearch.first.start, end: daySearch.range.end }),
-    [daySearch.first.start, daySearch.range.end]
+    () => ({ start: daySearch.original.start, end: daySearch.range.end }),
+    [daySearch.original.start, daySearch.range.end]
   );
 
   const { timeResultsByDay, hasTimes } = useMemo(() => {
@@ -105,25 +105,25 @@ export function useDaySearch(options: UseDaySearchOptions): UseDaySearchResult {
   // in-flight one, because the control that calls this is disabled while `loadingMoreDays`.
   const showMoreDays = useCallback((): void => {
     setDaySearch((previous) => ({
-      first: previous.first,
+      original: previous.original,
       range: nextWindow(previous.range),
       found: [...previous.found, ...search.appointments],
     }));
   }, [search.appointments]);
 
-  // `first` is carried over, so the days picked stay picked and `onDaysChanged` does not
+  // `original` is carried over, so the days picked stay picked and `onDaysChanged` does not
   // fire: it is the extension that goes, not the choice of days.
   const reset = useCallback((): void => {
     setDaySearch((previous) => ({
-      first: previous.first,
-      range: previous.first,
+      original: previous.original,
+      range: previous.original,
       found: [],
     }));
   }, []);
 
   // A spinner rather than empty days: only while the first window is still out, before
   // "Show more days" has moved the search past it.
-  const loadingFirstDays = search.loading && daySearch.range.start.getTime() === daySearch.first.start.getTime();
+  const loadingFirstDays = search.loading && daySearch.range.start.getTime() === daySearch.original.start.getTime();
 
   return {
     selectedDayRange,
@@ -142,7 +142,7 @@ export function useDaySearch(options: UseDaySearchOptions): UseDaySearchResult {
 /** The days on offer, and the times the ones already answered came back with. */
 interface DaySearch {
   /** The window the search opened on, which is what putting the added days away goes back to. */
-  readonly first: DateTimeRange;
+  readonly original: DateTimeRange;
   /** The days being asked about now, which is the newest window alone. Both ends closed, as `$find` requires. */
   readonly range: DateTimeRange;
   /** Times the earlier windows offered, kept on screen while a further one is out. */
@@ -173,7 +173,7 @@ function floorToNow(date: Date): Date {
 function openDaySearch(start: Date, end: Date = start): DaySearch {
   const from = floorToNow(start);
   const window = { start: from, end: endOfDay(end > from ? end : from) };
-  return { first: window, range: window, found: [] };
+  return { original: window, range: window, found: [] };
 }
 
 /**

--- a/packages/react-scheduling/src/AppointmentFinder/useDaySearch.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/useDaySearch.ts
@@ -58,7 +58,11 @@ export interface UseDaySearchResult {
   readonly chooseRange: (start: Date, end: Date) => void;
   /** Reaches further than the days already answered, keeping them on screen. */
   readonly showMoreDays: () => void;
-  /** Puts the added days away, for an answer that changes what every day offers. */
+  /**
+   * Goes back to the days first picked, dropping the days "Show more days" reached for
+   * and every time found so far. For a change that makes those times wrong — a different
+   * service, or a different set of actors — rather than for a change of days.
+   */
   readonly reset: () => void;
 }
 
@@ -133,7 +137,8 @@ export function useDaySearch(options: UseDaySearchOptions): UseDaySearchResult {
     }));
   }, [search.appointments]);
 
-  // Which days were picked does not change, so nothing chosen from them goes stale.
+  // `first` is carried over, so the days picked stay picked and `onDaysChanged` does not
+  // fire: it is the extension that goes, not the choice of days.
   const reset = useCallback((): void => {
     setDaySearch((previous) => ({
       first: previous.first,

--- a/packages/react-scheduling/src/AppointmentFinder/useDaySearch.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/useDaySearch.ts
@@ -91,21 +91,14 @@ export function useDaySearch(options: UseDaySearchOptions): UseDaySearchResult {
 
   const windowError = getFindWindowError(daySearch.range);
 
-  // Gated here rather than by the caller, which cannot know the window is unanswerable
-  // until this hook has said so.
+  const dayCount = useMemo(() => enumerateDateRange(daySearch.range).length, [daySearch.range]);
+
   const search = useProposedAppointments({
     service,
-    combinations: windowError ? [] : combinations,
+    combinations,
     range: daySearch.range,
-    count: TIMES_PER_DAY * enumerateDateRange(daySearch.range).length,
+    count: TIMES_PER_DAY * dayCount,
   });
-
-  // While a further window is loading, `search.appointments` is that window's
-  // in-flight result, not yet part of `found`.
-  const times = useMemo(
-    () => (search.loading ? daySearch.found : [...daySearch.found, ...search.appointments]),
-    [search.loading, search.appointments, daySearch.found]
-  );
 
   const shown = useMemo(
     () => ({ start: daySearch.first.start, end: daySearch.range.end }),
@@ -113,18 +106,21 @@ export function useDaySearch(options: UseDaySearchOptions): UseDaySearchResult {
   );
 
   // Passing `shown` lists empty days too, so a day that came back with nothing still
-  // shows up rather than looking like nobody asked about it.
-  const days = useMemo(() => groupAppointmentsByDay(times, timezone, shown), [times, timezone, shown]);
-
-  const chooseDay = useCallback((date: Date): void => {
-    setDaySearch(openDaySearch(date));
-    onDaysChangedRef.current?.();
-  }, []);
+  // shows up rather than looking like nobody asked about it. While a further window is
+  // loading, `search.appointments` is that window's in-flight result, not yet part of
+  // `found`.
+  const { days, anyTimes } = useMemo(() => {
+    const times = search.loading ? daySearch.found : [...daySearch.found, ...search.appointments];
+    const grouped = groupAppointmentsByDay(times, timezone, shown);
+    return { days: grouped, anyTimes: grouped.some((day) => day.groups.length > 0) };
+  }, [search.loading, search.appointments, daySearch.found, timezone, shown]);
 
   const chooseRange = useCallback((start: Date, end: Date): void => {
     setDaySearch(openDaySearch(start, end));
     onDaysChangedRef.current?.();
   }, []);
+
+  const chooseDay = useCallback((date: Date): void => chooseRange(date, date), [chooseRange]);
 
   // `search.appointments` is the settled result of the current window rather than an
   // in-flight one, because the control that calls this is disabled while `loading`.
@@ -133,7 +129,6 @@ export function useDaySearch(options: UseDaySearchOptions): UseDaySearchResult {
       first: previous.first,
       range: nextWindow(previous.range),
       found: [...previous.found, ...search.appointments],
-      extended: true,
     }));
   }, [search.appointments]);
 
@@ -144,7 +139,6 @@ export function useDaySearch(options: UseDaySearchOptions): UseDaySearchResult {
       first: previous.first,
       range: previous.first,
       found: [],
-      extended: false,
     }));
   }, []);
 
@@ -154,9 +148,10 @@ export function useDaySearch(options: UseDaySearchOptions): UseDaySearchResult {
     // marked as the one picked once "Show more days" has widened what is around it.
     picked: isSameDay(daySearch.first.start, daySearch.first.end) ? daySearch.first.start : undefined,
     days,
-    anyTimes: days.some((day) => day.groups.length > 0),
-    // A spinner rather than empty days: only while the first window is still out.
-    pending: search.loading && !daySearch.extended,
+    anyTimes,
+    // A spinner rather than empty days: only while the first window is still out, i.e.
+    // `range` hasn't yet been extended past `first`.
+    pending: search.loading && daySearch.range === daySearch.first,
     loading: search.loading,
     error: search.error,
     windowError,
@@ -175,8 +170,6 @@ interface DaySearch {
   readonly range: DateTimeRange;
   /** Times the earlier windows offered, kept on screen while a further one is out. */
   readonly found: readonly Appointment[];
-  /** Whether days beyond the first window have been asked for. */
-  readonly extended: boolean;
 }
 
 /**
@@ -203,7 +196,7 @@ function floorToNow(date: Date): Date {
 function openDaySearch(start: Date, end: Date = start): DaySearch {
   const from = floorToNow(start);
   const window = { start: from, end: endOfDay(end > from ? end : from) };
-  return { first: window, range: window, found: [], extended: false };
+  return { first: window, range: window, found: [] };
 }
 
 /**

--- a/packages/react-scheduling/src/AppointmentFinder/useProposedAppointments.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/useProposedAppointments.ts
@@ -7,6 +7,7 @@ import { useMedplum } from '@medplum/react-hooks';
 import { useEffect, useState } from 'react';
 import type { ActorCombination } from './AppointmentFinder.schedules';
 import type { DateRange } from './AppointmentFinder.times';
+import { getFindWindowError } from './AppointmentFinder.times';
 
 /** `$find`'s own default page size, applied per combination. */
 const DEFAULT_COUNT = 20;
@@ -54,7 +55,7 @@ export function useProposedAppointments(options: UseProposedAppointmentsOptions)
   const { start, end } = range;
   const serviceReference = service && getReferenceString(service);
   const urls =
-    serviceReference && start && end
+    serviceReference && start && end && !getFindWindowError(range)
       ? combinations.map((combination) => buildFindUrl(medplum, serviceReference, combination, start, end, count))
       : [];
   const urlsKey = urls.join(URL_SEPARATOR);

--- a/packages/react-scheduling/src/AppointmentFinder/useProposedAppointments.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/useProposedAppointments.ts
@@ -40,10 +40,16 @@ export interface UseProposedAppointmentsResult {
   readonly loading: boolean;
   /** Set only when every combination failed. */
   readonly error: Error | undefined;
+  /** A window `$find` will not answer, caught before the request is made. */
+  readonly windowError: string | undefined;
 }
 
 /**
  * Searches for the times an appointment could be held at.
+ *
+ * A window `$find` would refuse is caught here rather than sent: this is the layer that
+ * decides whether the request is made, so it is the layer that says why it was not.
+ *
  * @param options - The service, actor combinations, days, and page size.
  * @returns The times offered, plus load and error state.
  */
@@ -53,9 +59,10 @@ export function useProposedAppointments(options: UseProposedAppointmentsOptions)
   const [answered, setAnswered] = useState<SearchState>(NOTHING_ASKED);
 
   const { start, end } = range;
+  const windowError = getFindWindowError(range);
   const serviceReference = service && getReferenceString(service);
   const urls =
-    serviceReference && start && end && !getFindWindowError(range)
+    serviceReference && start && end && !windowError
       ? combinations.map((combination) => buildFindUrl(medplum, serviceReference, combination, start, end, count))
       : [];
   const urlsKey = urls.join(URL_SEPARATOR);
@@ -100,6 +107,7 @@ export function useProposedAppointments(options: UseProposedAppointmentsOptions)
     requestCount: urls.length,
     loading: urls.length > 0 && stale,
     error: stale ? undefined : answered.error,
+    windowError,
   };
 }
 

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.module.css
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.module.css
@@ -25,6 +25,8 @@
 .bookingPane {
   flex-shrink: 0;
   width: 320px;
+  display: flex;
+  flex-direction: column;
   overflow-y: auto;
 }
 

--- a/packages/react-scheduling/src/test-utils/bookingForm.tsx
+++ b/packages/react-scheduling/src/test-utils/bookingForm.tsx
@@ -185,9 +185,9 @@ export async function dragDays(from: string, to: string): Promise<void> {
 /**
  * Shift-clicks a day, which moves the nearer end of the days on show to it.
  *
- * The click alone, since it is the click that carries the shift. Surviving the press a
- * real one follows — the same press that would otherwise begin a drag — is the
- * calendar's own concern, and is driven in `CalendarDateInput`'s tests.
+ * Fires only the click, which is what carries the shift: surviving the press that a
+ * real shift-click follows (the same press that would otherwise start a drag) is
+ * `CalendarDateInput`'s own concern, and is covered by its own tests.
  *
  * @param dayOfMonth - The number the cell is labelled with.
  */

--- a/packages/react-scheduling/src/test-utils/bookingForm.tsx
+++ b/packages/react-scheduling/src/test-utils/bookingForm.tsx
@@ -155,21 +155,27 @@ export async function chooseDay(dayOfMonth: string): Promise<void> {
 /**
  * Drags across the calendar, which asks for the stretch of days the drag covered.
  *
- * One step per act, because the days the drag has reached are read back out of state
- * on the next render. The release goes to the window, where the calendar listens for
- * it: a drag is let go of wherever the pointer has got to, which need not be a day.
+ * Only the two ends are travelled: a drag asks for the days between where it began and
+ * where it was let go, so the days passed over on the way change nothing but the band
+ * drawn mid-drag, which `CalendarDateInput` proves for itself. Don't restore a step per
+ * day here — it costs a render each and settles nothing.
  *
- * @param daysOfMonth - The numbers the cells are labelled with, in the order dragged over.
+ * One step per act, though, because the day a drag has reached is read back out of
+ * state on the next render: a press and a move inside one act would leave the move
+ * looking at a drag that had not begun, and the release would ask for a single day.
+ * The release goes to the window, where the calendar listens for it — a drag is let go
+ * of wherever the pointer has got to, which need not be a day.
+ *
+ * @param from - The number the cell the drag begins on is labelled with.
+ * @param to - The number the cell it is let go on is labelled with.
  */
-export async function dragDays(...daysOfMonth: string[]): Promise<void> {
-  for (const [index, day] of daysOfMonth.entries()) {
-    await act(async () => {
-      if (index === 0) {
-        fireEvent.pointerDown(dayCell(day));
-      }
-      fireEvent.pointerOver(dayCell(day));
-    });
-  }
+export async function dragDays(from: string, to: string): Promise<void> {
+  await act(async () => {
+    fireEvent.pointerDown(dayCell(from));
+  });
+  await act(async () => {
+    fireEvent.pointerOver(dayCell(to));
+  });
   await act(async () => {
     fireEvent.pointerUp(window);
   });
@@ -179,18 +185,13 @@ export async function dragDays(...daysOfMonth: string[]): Promise<void> {
 /**
  * Shift-clicks a day, which moves the nearer end of the days on show to it.
  *
- * Pressed and released as well as clicked: the press is what a shift-click has to
- * survive, since it is the same press that begins a drag.
+ * The click alone, since it is the click that carries the shift. Surviving the press a
+ * real one follows — the same press that would otherwise begin a drag — is the
+ * calendar's own concern, and is driven in `CalendarDateInput`'s tests.
  *
  * @param dayOfMonth - The number the cell is labelled with.
  */
 export async function shiftChooseDay(dayOfMonth: string): Promise<void> {
-  await act(async () => {
-    fireEvent.pointerDown(dayCell(dayOfMonth), { shiftKey: true });
-  });
-  await act(async () => {
-    fireEvent.pointerUp(window);
-  });
   await act(async () => {
     fireEvent.click(dayCell(dayOfMonth), { shiftKey: true });
   });

--- a/packages/react-scheduling/src/test-utils/bookingForm.tsx
+++ b/packages/react-scheduling/src/test-utils/bookingForm.tsx
@@ -152,6 +152,59 @@ export async function chooseDay(dayOfMonth: string): Promise<void> {
   await settleAutocomplete();
 }
 
+/**
+ * Drags across the calendar, which asks for the stretch of days the drag covered.
+ *
+ * One step per act, because the days the drag has reached are read back out of state
+ * on the next render. The release goes to the window, where the calendar listens for
+ * it: a drag is let go of wherever the pointer has got to, which need not be a day.
+ *
+ * @param daysOfMonth - The numbers the cells are labelled with, in the order dragged over.
+ */
+export async function dragDays(...daysOfMonth: string[]): Promise<void> {
+  for (const [index, day] of daysOfMonth.entries()) {
+    await act(async () => {
+      if (index === 0) {
+        fireEvent.pointerDown(dayCell(day));
+      }
+      fireEvent.pointerOver(dayCell(day));
+    });
+  }
+  await act(async () => {
+    fireEvent.pointerUp(window);
+  });
+  await settleAutocomplete();
+}
+
+/**
+ * Shift-clicks a day, which moves the nearer end of the days on show to it.
+ *
+ * Pressed and released as well as clicked: the press is what a shift-click has to
+ * survive, since it is the same press that begins a drag.
+ *
+ * @param dayOfMonth - The number the cell is labelled with.
+ */
+export async function shiftChooseDay(dayOfMonth: string): Promise<void> {
+  await act(async () => {
+    fireEvent.pointerDown(dayCell(dayOfMonth), { shiftKey: true });
+  });
+  await act(async () => {
+    fireEvent.pointerUp(window);
+  });
+  await act(async () => {
+    fireEvent.click(dayCell(dayOfMonth), { shiftKey: true });
+  });
+  await settleAutocomplete();
+}
+
+/** Pages the calendar on to the next month. */
+export async function showNextMonth(): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /next month/i }));
+  });
+  await settleAutocomplete();
+}
+
 /** Asks for the next couple of days under the ones already on screen. */
 export async function showMoreDays(): Promise<void> {
   await act(async () => {
@@ -222,15 +275,23 @@ export function isBefore(first: Element, second: Element): boolean {
 }
 
 /**
+ * Every `$find` the form has asked for, in the order it asked.
+ * @param get - A spy on the client's `get`.
+ * @returns The request urls.
+ */
+export function findRequests(get: MockInstance<MedplumClient['get']>): string[] {
+  return get.mock.calls
+    .map(([url]) => String(url))
+    .filter((url) => url.includes('Appointment/$find') || url.includes('Appointment/%24find'));
+}
+
+/**
  * What the most recent `$find` asked for.
  * @param get - A spy on the client's `get`.
  * @returns The search parameters, or undefined when nothing was asked.
  */
 export function lastFindParams(get: MockInstance<MedplumClient['get']>): URLSearchParams | undefined {
-  const urls = get.mock.calls
-    .map(([url]) => String(url))
-    .filter((url) => url.includes('Appointment/$find') || url.includes('Appointment/%24find'));
-  const last = urls.at(-1);
+  const last = findRequests(get).at(-1);
   return last ? new URL(last, 'https://example.com').searchParams : undefined;
 }
 

--- a/packages/react-scheduling/src/test-utils/bookingForm.tsx
+++ b/packages/react-scheduling/src/test-utils/bookingForm.tsx
@@ -133,12 +133,29 @@ export async function openTimeFinder(): Promise<void> {
 }
 
 /**
+ * A day in the time search's calendar.
+ * @param dayOfMonth - The number the cell is labelled with.
+ * @returns The button for that day.
+ */
+export function dayCell(dayOfMonth: string): HTMLElement {
+  return screen.getByRole('button', { name: dayOfMonth });
+}
+
+/**
  * Clicks a day in the time search's calendar.
  * @param dayOfMonth - The number the cell is labelled with.
  */
 export async function chooseDay(dayOfMonth: string): Promise<void> {
   await act(async () => {
-    fireEvent.click(screen.getByRole('button', { name: dayOfMonth }));
+    fireEvent.click(dayCell(dayOfMonth));
+  });
+  await settleAutocomplete();
+}
+
+/** Asks for the next couple of days under the ones already on screen. */
+export async function showMoreDays(): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /show more days/i }));
   });
   await settleAutocomplete();
 }
@@ -205,16 +222,25 @@ export function isBefore(first: Element, second: Element): boolean {
 }
 
 /**
+ * What the most recent `$find` asked for.
+ * @param get - A spy on the client's `get`.
+ * @returns The search parameters, or undefined when nothing was asked.
+ */
+export function lastFindParams(get: MockInstance<MedplumClient['get']>): URLSearchParams | undefined {
+  const urls = get.mock.calls
+    .map(([url]) => String(url))
+    .filter((url) => url.includes('Appointment/$find') || url.includes('Appointment/%24find'));
+  const last = urls.at(-1);
+  return last ? new URL(last, 'https://example.com').searchParams : undefined;
+}
+
+/**
  * The `start` the most recent `$find` asked for.
  * @param get - A spy on the client's `get`.
  * @returns The `start` parameter, or undefined when nothing was asked.
  */
 export function lastFindStart(get: MockInstance<MedplumClient['get']>): string | undefined {
-  const urls = get.mock.calls
-    .map(([url]) => String(url))
-    .filter((url) => url.includes('Appointment/$find') || url.includes('Appointment/%24find'));
-  const last = urls.at(-1);
-  return last ? (new URL(last, 'https://example.com').searchParams.get('start') ?? undefined) : undefined;
+  return lastFindParams(get)?.get('start') ?? undefined;
 }
 
 /**

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.stories.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.stories.tsx
@@ -88,6 +88,28 @@ export const Range = (): JSX.Element => {
 };
 
 /**
+ * A day picked, with the stretch shown alongside it banded out from there: the day picked keeps
+ * the darker mark, and the days that came with it are only on show.
+ * @returns The story.
+ */
+export const SelectedDayWithinAStretch = (): JSX.Element => {
+  const [selected, setSelected] = useState<Date>(weekdaysOfMonth()[2]);
+  const shown = { start: selected, end: new Date(selected.getFullYear(), selected.getMonth(), selected.getDate() + 2) };
+  return (
+    <Document>
+      <CalendarDateInput
+        availableDates={weekdaysOfMonth()}
+        selected={selected}
+        range={shown}
+        allowUnavailableDates
+        onChangeMonth={(date: Date) => console.log(date)}
+        onClick={setSelected}
+      />
+    </Document>
+  );
+};
+
+/**
  * A calendar that can be asked about a day with nothing on it.
  * @returns The story.
  */

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.test.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.test.tsx
@@ -154,6 +154,29 @@ describe('CalendarDateInput', () => {
     expect(screen.getByRole('button', { name: '10' }).className).toContain('available');
   });
 
+  test('Marks the day named rather than the ends when a range is on show around it', () => {
+    const month = getStartMonth();
+
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        selected={dayOf(month, 10)}
+        range={{ start: dayOf(month, 10), end: dayOf(month, 12) }}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+      />
+    );
+
+    // The band is what is on show; only the day named was picked, and the far end of
+    // the stretch is not a second thing to take hold of.
+    expect(screen.getByRole('button', { name: '10' }).className).toContain('selected');
+    expect(screen.getByRole('button', { name: '12' }).className).not.toContain('selected');
+    expect(cellOf('12').className).toContain('inRange');
+    expect(screen.getByRole('button', { name: '12' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
   test('Bands a range whose ends carry a time of day', () => {
     const month = getStartMonth();
     const start = dayOf(month, 10);

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.test.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.test.tsx
@@ -154,7 +154,7 @@ describe('CalendarDateInput', () => {
     expect(screen.getByRole('button', { name: '10' }).className).toContain('available');
   });
 
-  test('Marks the day named rather than the ends when a range is on show around it', () => {
+  test('Marks both ends of the range even when a day within it is named selected', () => {
     const month = getStartMonth();
 
     render(
@@ -169,11 +169,12 @@ describe('CalendarDateInput', () => {
       />
     );
 
-    // Only the day named was picked; the far end of the band is not itself selectable.
+    // A multi-day range on show always marks both its ends, whether or not one of
+    // them also happens to be named as the day picked.
     expect(screen.getByRole('button', { name: '10' }).className).toContain('selected');
-    expect(screen.getByRole('button', { name: '12' }).className).not.toContain('selected');
+    expect(screen.getByRole('button', { name: '12' }).className).toContain('selected');
     expect(cellOf('12').className).toContain('inRange');
-    expect(screen.getByRole('button', { name: '12' })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: '12' })).toHaveAttribute('aria-pressed', 'true');
   });
 
   test('Bands a range whose ends carry a time of day', () => {

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.test.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.test.tsx
@@ -169,8 +169,7 @@ describe('CalendarDateInput', () => {
       />
     );
 
-    // The band is what is on show; only the day named was picked, and the far end of
-    // the stretch is not a second thing to take hold of.
+    // Only the day named was picked; the far end of the band is not itself selectable.
     expect(screen.getByRole('button', { name: '10' }).className).toContain('selected');
     expect(screen.getByRole('button', { name: '12' }).className).not.toContain('selected');
     expect(cellOf('12').className).toContain('inRange');

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
@@ -199,10 +199,10 @@ function toDays(range: DayRange): DayRange {
  * @returns True when the day is one the calendar is anchored on.
  */
 function isAnchor(date: Date, range: DayRange, selected: Date | undefined): boolean {
-  if (selected) {
-    return isSameDay(date, selected);
+  if (range && !isSameDay(range.start, range.end)) {
+    return isSameDay(date, range.start) || isSameDay(date, range.end);
   }
-  return !!range && (isSameDay(date, range.start) || isSameDay(date, range.end));
+  return !!selected && isSameDay(date, selected);
 }
 
 /**
@@ -213,10 +213,10 @@ function isAnchor(date: Date, range: DayRange, selected: Date | undefined): bool
  * @returns True when the day falls within what is chosen.
  */
 function isChosen(date: Date, range: DayRange, selected: Date | undefined): boolean {
-  if (selected) {
-    return isSameDay(date, selected);
+  if (range && !isSameDay(range.start, range.end)) {
+    return date >= range.start && date <= range.end;
   }
-  return !!range && date >= range.start && date <= range.end;
+  return !!selected && isSameDay(date, selected);
 }
 
 /**

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
@@ -76,8 +76,7 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
   // blinks down to the day pressed on the way to every click.
   const dragging = drag.range && !isSameDay(drag.range.start, drag.range.end) ? drag.range : undefined;
   const range = toDays(dragging ?? props.range);
-  // What is being dragged out is what is on show, rather than whatever was picked before
-  // the drag began.
+  // Suppressed only while actively dragging, so a static range still shows its picked day.
   const selected = dragging ? undefined : props.selected;
 
   const grid = useMemo(() => buildGrid(month, props.availableDates), [month, props.availableDates]);

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
@@ -23,7 +23,6 @@ export interface CalendarDateInputProps {
   /** Called with the day picked. */
   readonly onClick: (date: Date) => void;
   readonly month?: Date;
-  /** The day chosen. Ignored while a range is given. */
   readonly selected?: Date;
   readonly allowUnavailableDates?: boolean;
   readonly earliestDate?: Date;
@@ -77,7 +76,9 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
   // blinks down to the day pressed on the way to every click.
   const dragging = drag.range && !isSameDay(drag.range.start, drag.range.end) ? drag.range : undefined;
   const range = toDays(dragging ?? props.range);
-  const selected = range ? undefined : props.selected;
+  // What is being dragged out is what is on show, rather than whatever was picked before
+  // the drag began.
+  const selected = dragging ? undefined : props.selected;
 
   const grid = useMemo(() => buildGrid(month, props.availableDates), [month, props.availableDates]);
 
@@ -133,7 +134,7 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
                       variant="light"
                       className={cx(
                         day.available && classes.available,
-                        isRangeEnd(day.date, range, selected) && classes.selected
+                        isAnchor(day.date, range, selected) && classes.selected
                       )}
                       aria-pressed={selected || range ? isChosen(day.date, range, selected) : undefined}
                       disabled={isDayDisabled(day)}
@@ -192,25 +193,31 @@ function toDays(range: DayRange): DayRange {
 }
 
 /**
- * Returns whether a day is one of the two a range is anchored on.
+ * Returns whether a day is one the calendar is anchored on, and so marked as picked.
  * @param date - Local midnight of the day in question.
- * @param range - The stretch of days asked for, if there is one.
+ * @param range - The stretch of days on show, if there is one.
  * @param selected - The single day chosen, if there is one.
- * @returns True when the day is an end of the range, or the day chosen.
+ * @returns True when the day is one the calendar is anchored on.
  */
-function isRangeEnd(date: Date, range: DayRange, selected: Date | undefined): boolean {
-  return isSameDay(date, selected) || (!!range && (isSameDay(date, range.start) || isSameDay(date, range.end)));
+function isAnchor(date: Date, range: DayRange, selected: Date | undefined): boolean {
+  if (selected) {
+    return isSameDay(date, selected);
+  }
+  return !!range && (isSameDay(date, range.start) || isSameDay(date, range.end));
 }
 
 /**
  * Returns whether a day is part of what has been chosen.
  * @param date - Local midnight of the day in question.
- * @param range - The stretch of days asked for, if there is one.
+ * @param range - The stretch of days on show, if there is one.
  * @param selected - The single day chosen, if there is one.
  * @returns True when the day falls within what is chosen.
  */
 function isChosen(date: Date, range: DayRange, selected: Date | undefined): boolean {
-  return isRangeEnd(date, range, selected) || (!!range && date > range.start && date < range.end);
+  if (selected) {
+    return isSameDay(date, selected);
+  }
+  return !!range && date >= range.start && date <= range.end;
 }
 
 /**

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
@@ -23,6 +23,7 @@ export interface CalendarDateInputProps {
   /** Called with the day picked. */
   readonly onClick: (date: Date) => void;
   readonly month?: Date;
+  /** An extra day to mark as picked, alongside any `range`. Ignored while a drag is under way. */
   readonly selected?: Date;
   readonly allowUnavailableDates?: boolean;
   readonly earliestDate?: Date;
@@ -196,13 +197,10 @@ function toDays(range: DayRange): DayRange {
  * @param date - Local midnight of the day in question.
  * @param range - The stretch of days on show, if there is one.
  * @param selected - The single day chosen, if there is one.
- * @returns True when the day is one the calendar is anchored on.
+ * @returns True when the day is an end of the range on show, or the day named as picked.
  */
 function isAnchor(date: Date, range: DayRange, selected: Date | undefined): boolean {
-  if (range && !isSameDay(range.start, range.end)) {
-    return isSameDay(date, range.start) || isSameDay(date, range.end);
-  }
-  return !!selected && isSameDay(date, selected);
+  return isSameDay(date, selected) || (!!range && (isSameDay(date, range.start) || isSameDay(date, range.end)));
 }
 
 /**
@@ -213,10 +211,7 @@ function isAnchor(date: Date, range: DayRange, selected: Date | undefined): bool
  * @returns True when the day falls within what is chosen.
  */
 function isChosen(date: Date, range: DayRange, selected: Date | undefined): boolean {
-  if (range && !isSameDay(range.start, range.end)) {
-    return date >= range.start && date <= range.end;
-  }
-  return !!selected && isSameDay(date, selected);
+  return isAnchor(date, range, selected) || (!!range && date > range.start && date < range.end);
 }
 
 /**


### PR DESCRIPTION
Clicking a day on the booking form's calendar searches that day and only that day. The days currently being searched are named in a line under the calendar, along with the gesture for asking about more of them, since dragging and shift-clicking leave nothing on screen to discover them from.

The time finder now has a **Show more days** button at the bottom. When clicked, two more days will be loaded and displayed. The column also now has its own scroll window, so viewing long results won't cause the form to be hidden.

https://github.com/user-attachments/assets/41b28b9f-d4b2-4184-98a6-77ceed9826ea

Only the days not already answered are requested, so the times already on screen stay put while the next ones load. A day that was searched and offered nothing is still listed under its own heading, so it reads as searched rather than skipped. The button has no end state: nothing in a `$find` response says how far ahead there is still something to find, so it stays offered even when every day on screen came back empty.

The booking form's calendar now supports ranged user input; the user can now drag their mouse over a date range, or shift+click a second date, to create a range and view all availability within that date range.

https://github.com/user-attachments/assets/4025c1f0-eeea-483b-b754-7596d0426165

How the calendar marks the days follows how they were asked for: a stretch picked on purpose marks both of its ends, and so does a day clicked on its own once **Show more days** widens the range around it. That needed a change to `CalendarDateInput`, whose `selected` prop previously took priority over `range` outright, so a day clicked kept only itself marked even after the range around it grew past a single day. A multi-day `range` now takes priority instead; `selected` still applies on its own when there is no such range, and is suppressed while a drag is under way.

The day search itself (which days are covered, which windows have already been answered, the `$find` each one costs, and the grouping the form renders) moved out of `AppointmentProposalForm` into a `useDaySearch` hook.

One known rough edge: `$find` has no pagination, so each window asks for a generous 50 times per day it covers. An oversized page is cheap, while an undersized one silently drops the later days in the window. Returning a truncation point from `$find` was raised in #10401 and closed as not planned.

**Out of scope:** Displaying indicators on the calendar for days that have availability, before the user clicks on them. This would definitely be a good user experience improvement, but will likely require separate server changes to `$find` to support a return shape that will not be as costly to the client.
