### PR TITLE
Add RFC 9116 /.well-known/security.txt

### DIFF
--- a/packages/docs/static/.well-known/security.txt
+++ b/packages/docs/static/.well-known/security.txt
@@ -1,0 +1,6 @@
+Contact: mailto:security@medplum.com
+Expires: 2027-02-28T00:00:00.000Z
+Encryption: https://www.medplum.com/medplum-security-public.asc
+Policy: https://www.medplum.com/security
+Preferred-Languages: en
+Canonical: https://www.medplum.com/.well-known/security.txt


### PR DESCRIPTION
Publishes a machine-readable vulnerability reporting policy at `https://www.medplum.com/.well-known/security.txt`, per [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116.html).

This is assembly, not new policy. Everything the file points at already exists and is already live:

- `security@medplum.com` — in `SECURITY.md`, `packages/docs/src/pages/security.md`, and `contact.md`
- The responsible disclosure policy (scope, out-of-scope, safe harbor, compensation stance) — `SECURITY.md`, mirrored at `/security`
- The PGP key — `packages/docs/static/medplum-security-public.asc`, serving today

Two files added. No changes to `vercel.json`, `docusaurus.config.ts`, or `staticDirectories`.