### PR TITLE
Estimate btree index bloat instead of expensive exact calculation

### DIFF
--- a/packages/server/src/admin/super.ts
+++ b/packages/server/src/admin/super.ts
@@ -475,17 +475,27 @@ superAdminRouter.post(
       return;
     }
 
+    const targets = req.body.targets as ReindexTarget[];
     const migrationActions = {
       preDeploy: [],
-      postDeploy: (req.body.targets as ReindexTarget[]).map((target) =>
+      postDeploy: targets.map((target) =>
         'table' in target
           ? { type: 'REINDEX_CONCURRENTLY' as const, target: 'TABLE' as const, name: target.table }
           : { type: 'REINDEX_CONCURRENTLY' as const, target: 'INDEX' as const, name: target.index }
       ),
     };
 
-    const exec = new AsyncJobExecutor(ctx.repo);
-    await exec.init(req.originalUrl);
+    const requestParams = new URLSearchParams();
+    for (const target of targets) {
+      if ('table' in target) {
+        requestParams.append('table', target.table);
+      } else {
+        requestParams.append('index', target.index);
+      }
+    }
+
+    const exec = new AsyncJobExecutor(ctx.systemRepo);
+    await exec.init(`${req.originalUrl}?${requestParams}`);
     await exec.run(async (asyncJob) => {
       const jobData = prepareDynamicMigrationJobData(asyncJob, migrationActions);
       await addPostDeployMigrationJobData(jobData);

--- a/packages/server/src/database-migration.test.ts
+++ b/packages/server/src/database-migration.test.ts
@@ -863,7 +863,8 @@ describe('Database migrations', () => {
         expect(res).toHaveStatus(202);
         expect(res.headers['content-location']).toBeDefined();
         expect(queueAddSpy).toHaveBeenCalledTimes(1);
-        expect(queueAddSpy.mock.calls[0][1]).toMatchObject({
+        const jobData = queueAddSpy.mock.calls[0][1];
+        expect(jobData).toMatchObject({
           type: 'dynamic',
           migrationActions: {
             preDeploy: [],
@@ -873,6 +874,9 @@ describe('Database migrations', () => {
             ],
           },
         });
+        const asyncJob = await systemRepo.readResource<AsyncJob>('AsyncJob', jobData.asyncJobId);
+        expect(asyncJob.request).toBe('/admin/super/reindex-database?index=Patient_name_idx&table=Observation');
+        expect(asyncJob.meta?.project).toBeUndefined();
       });
 
       test.each([

--- a/packages/server/src/fhir/operations/db-index-bloat.test.ts
+++ b/packages/server/src/fhir/operations/db-index-bloat.test.ts
@@ -5,7 +5,6 @@ import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
-import { DatabaseMode, getDatabasePool } from '../../database';
 import { initTestAuth } from '../../test.setup';
 import type { BtreeIndexStatsRow, GinIndexStatsRow } from './db-index-bloat';
 import { calculateBtreeBloat, calculateGinDensity } from './db-index-bloat';
@@ -16,8 +15,6 @@ describe('$db-index-bloat', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
     await initApp(app, config);
-    const client = getDatabasePool(DatabaseMode.WRITER);
-    await client.query('CREATE EXTENSION IF NOT EXISTS pgstattuple');
   });
 
   afterAll(async () => {
@@ -39,6 +36,16 @@ describe('$db-index-bloat', () => {
     expect(
       indexes.some((index) => index.part?.some((part) => part.name === 'indexType' && part.valueCode === 'gin'))
     ).toBe(true);
+    const btreeIndex = indexes.find((index) =>
+      index.part?.some((part) => part.name === 'indexType' && part.valueCode === 'btree')
+    );
+    expect(btreeIndex?.part).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'analysisMethod', valueCode: 'catalog-estimate' }),
+        expect.objectContaining({ name: 'estimatedBloatSize' }),
+        expect.objectContaining({ name: 'bloatPercent' }),
+      ])
+    );
   });
 
   test('Filters by table name', async () => {
@@ -88,26 +95,21 @@ describe('Index bloat calculations', () => {
     tableName: 'Observation',
     indexName: 'Observation_test_idx',
     indexSize: '1000',
-    blockSize: '100',
   };
 
-  test('Calculates B-tree bloat from density and unused pages', () => {
+  test('Calculates B-tree bloat from the catalog estimate', () => {
     const result = calculateBtreeBloat({
       ...base,
       fillFactor: 90,
-      leafPages: '8',
-      emptyPages: '1',
-      deletedPages: '1',
-      avgLeafDensity: 45,
-      leafFragmentation: 12.5,
+      estimatedBloatSize: '600',
     } satisfies BtreeIndexStatsRow);
 
     expect(result).toMatchObject({
       indexType: 'btree',
+      analysisMethod: 'catalog-estimate',
       estimatedBloatSize: 600,
       bloatPercent: 60,
       fillFactor: 90,
-      avgLeafDensity: 45,
     });
   });
 

--- a/packages/server/src/fhir/operations/db-index-bloat.ts
+++ b/packages/server/src/fhir/operations/db-index-bloat.ts
@@ -127,7 +127,7 @@ async function getBtreeIndexBloat(
     `WITH btree_indexes AS (
       SELECT
         n.nspname AS "schemaName", t.relname AS "tableName", i.relname AS "indexName",
-        i.oid AS "indexOid", t.oid AS "tableOid", GREATEST(i.reltuples, 0) AS "indexTuples",
+        i.oid AS "indexOid", t.oid AS "tableOid", i.reltuples AS "indexTuples",
         pg_relation_size(i.oid) AS "indexSize",
         COALESCE(
           (SELECT option_value::integer FROM pg_options_to_table(i.reloptions) WHERE option_name = 'fillfactor'),
@@ -144,6 +144,7 @@ async function getBtreeIndexBloat(
         AND ix.indisvalid
         AND ix.indisready
         AND ix.indislive
+        AND i.reltuples >= 0
         AND pg_relation_size(i.oid) >= $1::bigint
         AND ($2::text[] IS NULL OR t.relname = ANY($2::text[]))
     ), index_columns AS (
@@ -179,7 +180,7 @@ async function getBtreeIndexBloat(
           AND attribute.attnum = columns."statsAttributeNumber"
         JOIN pg_class stats_relation ON stats_relation.oid = columns."statsRelationOid"
         JOIN pg_namespace stats_namespace ON stats_namespace.oid = stats_relation.relnamespace
-        JOIN pg_stats stats
+        LEFT JOIN pg_stats stats
           ON stats.schemaname = stats_namespace.nspname
           AND stats.tablename = stats_relation.relname
           AND stats.attname = attribute.attname

--- a/packages/server/src/fhir/operations/db-index-bloat.ts
+++ b/packages/server/src/fhir/operations/db-index-bloat.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import { allOk, badRequest, EMPTY, OperationOutcomeError } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { Pool } from 'pg';
 import { requireSuperAdmin } from '../../context';
 import { DatabaseMode, getDatabasePool } from '../../database';
+import type { PgQueryable } from '../sql';
 import { isValidPostgresIdentifier } from '../sql';
 import { makeOperationDefinition } from './definitions';
 import {
@@ -35,10 +35,6 @@ const operation = makeOperationDefinition(
         param('out', 'estimatedBloatSize', 'decimal', 0, '1'),
         param('out', 'bloatPercent', 'decimal', 0, '1'),
         param('out', 'fillFactor', 'integer', 0, '1'),
-        param('out', 'avgLeafDensity', 'decimal', 0, '1'),
-        param('out', 'leafFragmentation', 'decimal', 0, '1'),
-        param('out', 'emptyPages', 'decimal', 0, '1'),
-        param('out', 'deletedPages', 'decimal', 0, '1'),
         param('out', 'liveTuples', 'decimal', 0, '1'),
         param('out', 'allocatedPages', 'decimal', 0, '1'),
         param('out', 'liveTuplesPerPage', 'decimal', 0, '1'),
@@ -52,13 +48,8 @@ export interface BtreeIndexStatsRow {
   tableName: string;
   indexName: string;
   indexSize: string;
-  blockSize: string;
   fillFactor: number;
-  leafPages: string;
-  emptyPages: string;
-  deletedPages: string;
-  avgLeafDensity: number;
-  leafFragmentation: number;
+  estimatedBloatSize: string;
 }
 
 export interface GinIndexStatsRow {
@@ -75,15 +66,11 @@ export interface IndexBloatInfo {
   tableName: string;
   indexName: string;
   indexType: 'btree' | 'gin';
-  analysisMethod: 'pgstatindex' | 'catalog-density';
+  analysisMethod: 'catalog-estimate' | 'catalog-density';
   indexSize: number;
   estimatedBloatSize?: number;
   bloatPercent?: number;
   fillFactor?: number;
-  avgLeafDensity?: number;
-  leafFragmentation?: number;
-  emptyPages?: number;
-  deletedPages?: number;
   liveTuples?: number;
   allocatedPages?: number;
   liveTuplesPerPage?: number;
@@ -108,11 +95,12 @@ export async function dbIndexBloatHandler(req: FhirRequest): Promise<FhirRespons
   validateThresholds(minBloatPercent, minIndexSize);
 
   const client = getDatabasePool(DatabaseMode.WRITER);
-  const btreeIndexes = (await getBtreeIndexBloat(client, minIndexSize, tableNames)).filter(
-    (index) => (index.bloatPercent ?? 0) >= minBloatPercent
-  );
-  const ginIndexes = await getGinIndexDensity(client, minIndexSize, tableNames);
-  const indexes = [...btreeIndexes, ...ginIndexes].sort((a, b) => b.indexSize - a.indexSize);
+  const [btreeIndexes, ginIndexes] = await Promise.all([
+    getBtreeIndexBloat(client, minIndexSize, tableNames),
+    getGinIndexDensity(client, minIndexSize, tableNames),
+  ]);
+  const filteredBtreeIndexes = btreeIndexes.filter((index) => (index.bloatPercent ?? 0) >= minBloatPercent);
+  const indexes = [...filteredBtreeIndexes, ...ginIndexes].sort((a, b) => b.indexSize - a.indexSize);
 
   return [allOk, buildOutputParameters(operation, { index: indexes })];
 }
@@ -126,49 +114,131 @@ function validateThresholds(minBloatPercent: number, minIndexSize: number): void
   }
 }
 
-async function getBtreeIndexBloat(client: Pool, minIndexSize: number, tableNames: string[]): Promise<IndexBloatInfo[]> {
+async function getBtreeIndexBloat(
+  client: PgQueryable,
+  minIndexSize: number,
+  tableNames: string[]
+): Promise<IndexBloatInfo[]> {
+  // Adapts the B-tree tuple-width and expected-page formula from
+  // https://github.com/ioguix/pgsql-bloat-estimation/blob/master/btree/btree_bloat.sql
+  // A bounded pageinspect.bt_page_stats sample could refine this estimate without a full scan, but would need
+  // validation against localized bloat before being used here.
   const result = await client.query<BtreeIndexStatsRow>(
-    `SELECT
-      n.nspname AS "schemaName",
-      t.relname AS "tableName",
-      i.relname AS "indexName",
-      pg_relation_size(i.oid)::text AS "indexSize",
-      current_setting('block_size')::text AS "blockSize",
-      COALESCE(
-        (SELECT option_value::integer FROM pg_options_to_table(i.reloptions) WHERE option_name = 'fillfactor'),
-        90
-      ) AS "fillFactor",
-      stats.leaf_pages::text AS "leafPages",
-      stats.empty_pages::text AS "emptyPages",
-      stats.deleted_pages::text AS "deletedPages",
-      stats.avg_leaf_density AS "avgLeafDensity",
-      stats.leaf_fragmentation AS "leafFragmentation"
-    FROM pg_index ix
-      JOIN pg_class i ON i.oid = ix.indexrelid
-      JOIN pg_class t ON t.oid = ix.indrelid
-      JOIN pg_namespace n ON n.oid = t.relnamespace
-      JOIN pg_am am ON am.oid = i.relam
-      CROSS JOIN LATERAL pgstatindex(i.oid::regclass) stats
-    WHERE n.nspname = 'public'
-      AND am.amname = 'btree'
-      AND ix.indisvalid
-      AND ix.indisready
-      AND ix.indislive
-      AND pg_relation_size(i.oid) >= $1::bigint
-      AND ($2::text[] IS NULL OR t.relname = ANY($2::text[]))`,
+    `WITH btree_indexes AS (
+      SELECT
+        n.nspname AS "schemaName", t.relname AS "tableName", i.relname AS "indexName",
+        i.oid AS "indexOid", t.oid AS "tableOid", GREATEST(i.reltuples, 0) AS "indexTuples",
+        pg_relation_size(i.oid) AS "indexSize",
+        COALESCE(
+          (SELECT option_value::integer FROM pg_options_to_table(i.reloptions) WHERE option_name = 'fillfactor'),
+          90
+        ) AS "fillFactor",
+        string_to_array(ix.indkey::text, ' ')::integer[] AS "attributeNumbers", ix.indnatts AS "attributeCount"
+      FROM pg_index ix
+        JOIN pg_class i ON i.oid = ix.indexrelid
+        JOIN pg_class t ON t.oid = ix.indrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        JOIN pg_am am ON am.oid = i.relam
+      WHERE n.nspname = 'public'
+        AND am.amname = 'btree'
+        AND ix.indisvalid
+        AND ix.indisready
+        AND ix.indislive
+        AND pg_relation_size(i.oid) >= $1::bigint
+        AND ($2::text[] IS NULL OR t.relname = ANY($2::text[]))
+    ), index_columns AS (
+      SELECT
+        idx.*,
+        CASE
+          WHEN idx."attributeNumbers"[position] = 0 THEN idx."indexOid"
+          ELSE idx."tableOid"
+        END AS "statsRelationOid",
+        CASE
+          WHEN idx."attributeNumbers"[position] = 0 THEN position
+          ELSE idx."attributeNumbers"[position]
+        END AS "statsAttributeNumber"
+      FROM btree_indexes idx
+        CROSS JOIN LATERAL generate_series(1, idx."attributeCount") position
+    ), index_widths AS (
+      SELECT
+        columns."schemaName", columns."tableName", columns."indexName",
+        columns."indexTuples", columns."indexSize", columns."fillFactor",
+        current_setting('block_size')::numeric AS "blockSize",
+        CASE
+          WHEN version() ~ 'mingw32|64-bit|x86_64|ppc64|ia64|amd64' THEN 8
+          ELSE 4
+        END AS "maxAlign",
+        CASE
+          WHEN MAX(COALESCE(stats.null_frac, 0)) = 0 THEN 8
+          ELSE 8 + ((32 + 8 - 1) / 8)
+        END AS "indexTupleHeader",
+        SUM((1 - COALESCE(stats.null_frac, 0)) * COALESCE(stats.avg_width, 1024)) AS "dataWidth"
+      FROM index_columns columns
+        JOIN pg_attribute attribute
+          ON attribute.attrelid = columns."statsRelationOid"
+          AND attribute.attnum = columns."statsAttributeNumber"
+        JOIN pg_class stats_relation ON stats_relation.oid = columns."statsRelationOid"
+        JOIN pg_namespace stats_namespace ON stats_namespace.oid = stats_relation.relnamespace
+        JOIN pg_stats stats
+          ON stats.schemaname = stats_namespace.nspname
+          AND stats.tablename = stats_relation.relname
+          AND stats.attname = attribute.attname
+      GROUP BY
+        columns."schemaName", columns."tableName", columns."indexName",
+        columns."indexTuples", columns."indexSize", columns."fillFactor"
+      HAVING NOT BOOL_OR(attribute.atttypid = 'pg_catalog.name'::regtype)
+    ), aligned_widths AS (
+      SELECT
+        widths.*,
+        widths."indexTupleHeader" + widths."maxAlign" -
+          CASE
+            WHEN widths."indexTupleHeader" % widths."maxAlign" = 0 THEN widths."maxAlign"
+            ELSE widths."indexTupleHeader" % widths."maxAlign"
+          END +
+        widths."dataWidth" + widths."maxAlign" -
+          CASE
+            WHEN widths."dataWidth" = 0 THEN 0
+            WHEN widths."dataWidth"::integer % widths."maxAlign" = 0 THEN widths."maxAlign"
+            ELSE widths."dataWidth"::integer % widths."maxAlign"
+          END AS "indexTupleWidth"
+      FROM index_widths widths
+    ), estimates AS (
+      SELECT
+        aligned.*,
+        COALESCE(
+          1 + CEIL(
+            aligned."indexTuples" /
+            NULLIF(FLOOR(
+              (aligned."blockSize" - 16 - 24) * aligned."fillFactor" /
+              (100 * (4 + aligned."indexTupleWidth"))
+            ), 0)
+          ),
+          0
+        ) AS "estimatedPages"
+      FROM aligned_widths aligned
+    )
+    SELECT
+      estimates."schemaName", estimates."tableName", estimates."indexName",
+      estimates."indexSize"::text AS "indexSize", estimates."fillFactor",
+      GREATEST(
+        estimates."indexSize"::numeric - estimates."estimatedPages" * estimates."blockSize",
+        0
+      )::bigint::text AS "estimatedBloatSize"
+    FROM estimates`,
     [minIndexSize, tableNames.length > 0 ? tableNames : null]
   );
   return result.rows.map(calculateBtreeBloat);
 }
 
-async function getGinIndexDensity(client: Pool, minIndexSize: number, tableNames: string[]): Promise<IndexBloatInfo[]> {
+async function getGinIndexDensity(
+  client: PgQueryable,
+  minIndexSize: number,
+  tableNames: string[]
+): Promise<IndexBloatInfo[]> {
   const result = await client.query<GinIndexStatsRow>(
     `SELECT
-      n.nspname AS "schemaName",
-      t.relname AS "tableName",
-      i.relname AS "indexName",
-      pg_relation_size(i.oid)::text AS "indexSize",
-      GREATEST(t.reltuples, 0)::bigint::text AS "liveTuples",
+      n.nspname AS "schemaName", t.relname AS "tableName", i.relname AS "indexName",
+      pg_relation_size(i.oid)::text AS "indexSize", GREATEST(t.reltuples, 0)::bigint::text AS "liveTuples",
       CEIL(
         pg_relation_size(i.oid)::numeric / current_setting('block_size')::numeric
       )::bigint::text AS "allocatedPages"
@@ -191,32 +261,18 @@ async function getGinIndexDensity(client: Pool, minIndexSize: number, tableNames
 
 export function calculateBtreeBloat(row: BtreeIndexStatsRow): IndexBloatInfo {
   const indexSize = Number(row.indexSize);
-  const blockSize = Number(row.blockSize);
-  const leafPages = Number(row.leafPages);
-  const emptyPages = Number(row.emptyPages);
-  const deletedPages = Number(row.deletedPages);
-  const avgLeafDensity = Number.isFinite(row.avgLeafDensity) ? row.avgLeafDensity : row.fillFactor;
-  const leafFragmentation = Number.isFinite(row.leafFragmentation) ? row.leafFragmentation : 0;
-  const leafBloatFraction = Math.max(0, 1 - avgLeafDensity / row.fillFactor);
-  const estimatedBloatSize = Math.min(
-    indexSize,
-    Math.max(0, Math.round((leafPages * leafBloatFraction + emptyPages + deletedPages) * blockSize))
-  );
+  const estimatedBloatSize = Math.min(indexSize, Math.max(0, Number(row.estimatedBloatSize)));
 
   return {
     schemaName: row.schemaName,
     tableName: row.tableName,
     indexName: row.indexName,
     indexType: 'btree',
-    analysisMethod: 'pgstatindex',
+    analysisMethod: 'catalog-estimate',
     indexSize,
     estimatedBloatSize,
     bloatPercent: calculatePercent(estimatedBloatSize, indexSize),
     fillFactor: row.fillFactor,
-    avgLeafDensity,
-    leafFragmentation,
-    emptyPages,
-    deletedPages,
   };
 }
 


### PR DESCRIPTION
Previous approach not viable for a 60s timeout nor was it totally necessary; an estimate is fine for our purposes