### PR TITLE
Add useStabilizedCallback hook

### DIFF
--- a/packages/react-hooks/src/index.ts
+++ b/packages/react-hooks/src/index.ts
@@ -17,6 +17,7 @@ export * from './useResource/useResource';
 export * from './useResourceBoard/useResourceBoard';
 export * from './useResourceModified/useResourceModified';
 export * from './useSearch/useSearch';
+export * from './useStabilizedCallback/useStabilizedCallback';
 export * from './useSubscription/useSubscription';
 export * from './useSyncOrderSet/useSyncOrderSet';
 export * from './useThreadInbox/useThreadInbox';

--- a/packages/react-hooks/src/useMedicationIFrame/useMedicationIFrame.ts
+++ b/packages/react-hooks/src/useMedicationIFrame/useMedicationIFrame.ts
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import { resolveId } from '@medplum/core';
 import type { Identifier, Organization, Reference } from '@medplum/fhirtypes';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
+import { useStabilizedCallback } from '../useStabilizedCallback/useStabilizedCallback';
 
 export interface MedicationIFrameOptions {
   readonly patientId?: string;
@@ -35,19 +36,13 @@ export function useMedicationIFrame(
   options: MedicationIFrameOptions
 ): string | undefined {
   const medplum = useMedplum();
-  const { patientId, organization, onPatientSyncSuccess, onIframeSuccess, onError } = options;
+  const { patientId, organization } = options;
   const organizationId = resolveId(organization);
   const [iframeUrl, setIframeUrl] = useState<string | undefined>(undefined);
 
-  const onPatientSyncSuccessRef = useRef(onPatientSyncSuccess);
-  const onIframeSuccessRef = useRef(onIframeSuccess);
-  const onErrorRef = useRef(onError);
-
-  useEffect(() => {
-    onPatientSyncSuccessRef.current = onPatientSyncSuccess;
-    onIframeSuccessRef.current = onIframeSuccess;
-    onErrorRef.current = onError;
-  }, [onPatientSyncSuccess, onIframeSuccess, onError]);
+  const onPatientSyncSuccess = useStabilizedCallback(options.onPatientSyncSuccess);
+  const onIframeSuccess = useStabilizedCallback(options.onIframeSuccess);
+  const onError = useStabilizedCallback(options.onError);
 
   useEffect(() => {
     let cancelled = false;
@@ -59,7 +54,7 @@ export function useMedicationIFrame(
           if (cancelled) {
             return;
           }
-          onPatientSyncSuccessRef.current?.();
+          onPatientSyncSuccess();
         }
         const result = await medplum.executeBot(iframeBotIdentifier, { patientId, organizationId });
         if (cancelled) {
@@ -67,23 +62,32 @@ export function useMedicationIFrame(
         }
         if (result.url) {
           setIframeUrl(result.url);
-          onIframeSuccessRef.current?.(result.url);
+          onIframeSuccess(result.url);
         }
       } catch (err: unknown) {
         if (!cancelled) {
-          onErrorRef.current?.(err);
+          onError(err);
         }
       }
     };
 
     run().catch(() => {
-      // Handled via onErrorRef when !cancelled
+      // Already reported via onError when !cancelled
     });
 
     return (): void => {
       cancelled = true;
     };
-  }, [medplum, syncBotIdentifier, iframeBotIdentifier, patientId, organizationId]);
+  }, [
+    medplum,
+    syncBotIdentifier,
+    iframeBotIdentifier,
+    patientId,
+    organizationId,
+    onPatientSyncSuccess,
+    onIframeSuccess,
+    onError,
+  ]);
 
   return iframeUrl;
 }

--- a/packages/react-hooks/src/useResourceModified/useResourceModified.ts
+++ b/packages/react-hooks/src/useResourceModified/useResourceModified.ts
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { MedplumClientEventMap, ResourceModifiedEvent } from '@medplum/core';
 import type { ExtractResource, ResourceType } from '@medplum/fhirtypes';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
+import { useStabilizedCallback } from '../useStabilizedCallback/useStabilizedCallback';
 
 /**
  * React hook for observing FHIR resource modifications made through the Medplum client.
@@ -32,10 +33,7 @@ export function useResourceModified<K extends ResourceType>(
   callback: (event: ResourceModifiedEvent<ExtractResource<K>>) => void
 ): void {
   const medplum = useMedplum();
-  const callbackRef = useRef(callback);
-  useEffect(() => {
-    callbackRef.current = callback;
-  });
+  const onModified = useStabilizedCallback(callback);
 
   const typesKey = Array.isArray(resourceType) ? resourceType.join(',') : resourceType;
 
@@ -44,10 +42,10 @@ export function useResourceModified<K extends ResourceType>(
     const listener = (event: MedplumClientEventMap['resourceModified']): void => {
       if (types.has(event.payload.resourceType)) {
         // Guarded above: the payload's resourceType is one of `K`, so this narrowing holds.
-        callbackRef.current(event.payload as ResourceModifiedEvent<ExtractResource<K>>);
+        onModified(event.payload as ResourceModifiedEvent<ExtractResource<K>>);
       }
     };
     medplum.addEventListener('resourceModified', listener);
     return () => medplum.removeEventListener('resourceModified', listener);
-  }, [medplum, typesKey]);
+  }, [medplum, typesKey, onModified]);
 }

--- a/packages/react-hooks/src/useStabilizedCallback/useStabilizedCallback.test.tsx
+++ b/packages/react-hooks/src/useStabilizedCallback/useStabilizedCallback.test.tsx
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { render, renderHook } from '@testing-library/react';
+import type { JSX } from 'react';
+import { useEffect } from 'react';
+import { useStabilizedCallback } from './useStabilizedCallback';
+
+describe('useStabilizedCallback', () => {
+  test('returns the same function across rerenders', () => {
+    const { result, rerender } = renderHook(({ callback }) => useStabilizedCallback(callback), {
+      initialProps: { callback: (): void => undefined },
+    });
+
+    const first = result.current;
+    rerender({ callback: (): void => undefined });
+    rerender({ callback: (): void => undefined });
+    expect(result.current).toBe(first);
+  });
+
+  test('invokes the most recent callback', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { result, rerender } = renderHook(({ callback }) => useStabilizedCallback(callback), {
+      initialProps: { callback: first },
+    });
+
+    result.current();
+    expect(first).toHaveBeenCalledTimes(1);
+
+    rerender({ callback: second });
+    result.current();
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  test('forwards arguments and return value', () => {
+    const { result } = renderHook(() => useStabilizedCallback((a: number, b: string) => `${a}-${b}`));
+    expect(result.current(1, 'two')).toBe('1-two');
+  });
+
+  test('is callable when the callback is undefined', () => {
+    const { result } = renderHook(() => useStabilizedCallback<[], string>(undefined));
+    // The wrapper is always defined, so it can never be used as a "was a handler provided?" signal.
+    expect(typeof result.current).toBe('function');
+    expect(result.current()).toBeUndefined();
+  });
+
+  test('handles a callback that becomes defined and then undefined', () => {
+    const callback = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ callback }: { callback: (() => void) | undefined }) => useStabilizedCallback(callback),
+      { initialProps: { callback: undefined as (() => void) | undefined } }
+    );
+
+    result.current();
+    expect(callback).not.toHaveBeenCalled();
+
+    rerender({ callback });
+    result.current();
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    rerender({ callback: undefined });
+    result.current();
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  test('is current when invoked from a descendant effect in the same commit', () => {
+    // Child effects flush before parent effects, so updating the ref in a useEffect would leave
+    // the child calling the previous render's callback.
+    function Child({ fire }: { fire: () => void }): JSX.Element {
+      useEffect(() => {
+        fire();
+      });
+      return <div />;
+    }
+
+    function Parent({ onEvent }: { onEvent: () => void }): JSX.Element {
+      return <Child fire={useStabilizedCallback(onEvent)} />;
+    }
+
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = render(<Parent onEvent={first} />);
+    expect(first).toHaveBeenCalledTimes(1);
+
+    rerender(<Parent onEvent={second} />);
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-hooks/src/useStabilizedCallback/useStabilizedCallback.ts
+++ b/packages/react-hooks/src/useStabilizedCallback/useStabilizedCallback.ts
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { useCallback, useInsertionEffect, useRef } from 'react';
+
+/**
+ * Returns a referentially stable wrapper around `callback` that always invokes the most recent
+ * value passed in. This allows consumers to pass inline callbacks without invalidating effects
+ * that depend on them.
+ *
+ * The returned function is always defined, even when `callback` is undefined; in that case it
+ * is a no-op returning undefined. Do not use the result as a "was a handler provided?" signal.
+ *
+ * The returned function may not be current during rendering. Synchronous usage in renders
+ * should invoke the original function instead of the stabilized wrapper.
+ *
+ * In React v19.2+, when the callback is only used in effects, this can be replaced with
+ * `useEffectEvent`. This package supports embedding in applications using React 18.0, so that
+ * technique can not be used in this library yet.
+ *
+ * @param callback - The callback to stabilize. May be undefined.
+ * @returns A stable function that forwards to the latest `callback`.
+ */
+export function useStabilizedCallback<Args extends unknown[], R>(
+  callback: ((...args: Args) => R) | undefined
+): (...args: Args) => R | undefined {
+  const callbackRef = useRef(callback);
+
+  // useInsertionEffect runs before any layout or passive effect in the commit, including those of
+  // descendants, so the ref is current by the time either kind of effect can call the wrapper.
+  // It is NOT current during render, nor in a descendant's own useInsertionEffect, since insertion
+  // effects commit child-first.
+  useInsertionEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  return useCallback((...args: Args) => callbackRef.current?.(...args), []);
+}

--- a/packages/react-hooks/src/useSubscription/useSubscription.ts
+++ b/packages/react-hooks/src/useSubscription/useSubscription.ts
@@ -5,6 +5,7 @@ import { deepEquals } from '@medplum/core';
 import type { Bundle, Subscription } from '@medplum/fhirtypes';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useMedplum, useMedplumProfile } from '../MedplumProvider/MedplumProvider.context';
+import { useStabilizedCallback } from '../useStabilizedCallback/useStabilizedCallback';
 
 const SUBSCRIPTION_DEBOUNCE_MS = 3000;
 
@@ -65,24 +66,6 @@ export function useSubscription(
   const prevCriteriaRef = useRef<string | undefined>(undefined);
   const prevMemoizedSubPropsRef = useRef<UseSubscriptionOptions['subscriptionProps']>(undefined);
 
-  const callbackRef = useRef(callback);
-  callbackRef.current = callback;
-
-  const onWebSocketOpenRef = useRef(options?.onWebSocketOpen);
-  onWebSocketOpenRef.current = options?.onWebSocketOpen;
-
-  const onWebSocketCloseRef = useRef(options?.onWebSocketClose);
-  onWebSocketCloseRef.current = options?.onWebSocketClose;
-
-  const onSubscriptionConnectRef = useRef(options?.onSubscriptionConnect);
-  onSubscriptionConnectRef.current = options?.onSubscriptionConnect;
-
-  const onSubscriptionDisconnectRef = useRef(options?.onSubscriptionDisconnect);
-  onSubscriptionDisconnectRef.current = options?.onSubscriptionDisconnect;
-
-  const onErrorRef = useRef(options?.onError);
-  onErrorRef.current = options?.onError;
-
   useEffect(() => {
     // Deep equals checks referential equality first
     if (!deepEquals(options?.subscriptionProps, memoizedSubProps)) {
@@ -128,36 +111,48 @@ export function useSubscription(
     };
   }, [medplum, effectiveCriteria, memoizedSubProps]);
 
-  const emitterCallback = useCallback((event: SubscriptionEventMap['message']) => {
-    callbackRef.current?.(event.payload);
-  }, []);
+  // Stabilize input callbacks
+  const handleMessage = useStabilizedCallback(callback);
+  const handleWebSocketOpen = useStabilizedCallback(options?.onWebSocketOpen);
+  const handleWebSocketClose = useStabilizedCallback(options?.onWebSocketClose);
+  const handleSubscriptionConnect = useStabilizedCallback(options?.onSubscriptionConnect);
+  const handleSubscriptionDisconnect = useStabilizedCallback(options?.onSubscriptionDisconnect);
+  const handleError = useStabilizedCallback(options?.onError);
 
-  const onWebSocketOpen = useCallback(() => {
-    onWebSocketOpenRef.current?.();
-  }, []);
+  // Explicitly choose parameters forwarded to event callbacks
+  const onMessage = useCallback(
+    (event: SubscriptionEventMap['message']) => handleMessage(event.payload),
+    [handleMessage]
+  );
 
-  const onWebSocketClose = useCallback(() => {
-    onWebSocketCloseRef.current?.();
-  }, []);
+  const onWebSocketOpen = useCallback(
+    (_event: SubscriptionEventMap['open']) => handleWebSocketOpen(),
+    [handleWebSocketOpen]
+  );
 
-  const onSubscriptionConnect = useCallback((event: SubscriptionEventMap['connect']) => {
-    onSubscriptionConnectRef.current?.(event.payload.subscriptionId);
-  }, []);
+  const onWebSocketClose = useCallback(
+    (_event: SubscriptionEventMap['close']) => handleWebSocketClose(),
+    [handleWebSocketClose]
+  );
 
-  const onSubscriptionDisconnect = useCallback((event: SubscriptionEventMap['disconnect']) => {
-    onSubscriptionDisconnectRef.current?.(event.payload.subscriptionId);
-  }, []);
+  const onSubscriptionConnect = useCallback(
+    (event: SubscriptionEventMap['connect']) => handleSubscriptionConnect(event.payload.subscriptionId),
+    [handleSubscriptionConnect]
+  );
 
-  const onError = useCallback((event: SubscriptionEventMap['error']) => {
-    onErrorRef.current?.(event.payload);
-  }, []);
+  const onSubscriptionDisconnect = useCallback(
+    (event: SubscriptionEventMap['disconnect']) => handleSubscriptionDisconnect(event.payload.subscriptionId),
+    [handleSubscriptionDisconnect]
+  );
+
+  const onError = useCallback((event: SubscriptionEventMap['error']) => handleError(event.payload), [handleError]);
 
   useEffect(() => {
     if (!emitter) {
       return () => undefined;
     }
     if (!listeningRef.current) {
-      emitter.addEventListener('message', emitterCallback);
+      emitter.addEventListener('message', onMessage);
       emitter.addEventListener('open', onWebSocketOpen);
       emitter.addEventListener('close', onWebSocketClose);
       emitter.addEventListener('connect', onSubscriptionConnect);
@@ -167,20 +162,12 @@ export function useSubscription(
     }
     return () => {
       listeningRef.current = false;
-      emitter.removeEventListener('message', emitterCallback);
+      emitter.removeEventListener('message', onMessage);
       emitter.removeEventListener('open', onWebSocketOpen);
       emitter.removeEventListener('close', onWebSocketClose);
       emitter.removeEventListener('connect', onSubscriptionConnect);
       emitter.removeEventListener('disconnect', onSubscriptionDisconnect);
       emitter.removeEventListener('error', onError);
     };
-  }, [
-    emitter,
-    emitterCallback,
-    onWebSocketOpen,
-    onWebSocketClose,
-    onSubscriptionConnect,
-    onSubscriptionDisconnect,
-    onError,
-  ]);
+  }, [emitter, onMessage, onWebSocketOpen, onWebSocketClose, onSubscriptionConnect, onSubscriptionDisconnect, onError]);
 }

--- a/packages/react-hooks/src/useWhisper/useWhisper.ts
+++ b/packages/react-hooks/src/useWhisper/useWhisper.ts
@@ -4,6 +4,7 @@
 import { ReconnectingWebSocket, sleep } from '@medplum/core';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
+import { useStabilizedCallback } from '../useStabilizedCallback/useStabilizedCallback';
 
 export type WhisperStatus =
   | 'idle'
@@ -55,10 +56,7 @@ export function useWhisper({
   idleTimeoutMs = DEFAULT_IDLE_TIMEOUT_MS,
 }: UseWhisperOptions): UseWhisperResult {
   const medplum = useMedplum();
-  const onTranscriptRef = useRef(onTranscript);
-  useEffect(() => {
-    onTranscriptRef.current = onTranscript;
-  }, [onTranscript]);
+  const emitTranscript = useStabilizedCallback(onTranscript);
   const [status, setStatus] = useState<WhisperStatus>('idle');
   const [error, setError] = useState<unknown>(undefined);
   const [transcripts, setTranscripts] = useState<TranscriptItem[]>([]);
@@ -260,7 +258,7 @@ export function useWhisper({
             };
 
             setTranscripts((prev) => [...prev, item]);
-            onTranscriptRef.current?.(message.transcript);
+            emitTranscript(message.transcript);
           }
           break;
 
@@ -280,7 +278,7 @@ export function useWhisper({
           break;
       }
     },
-    [setupSession, maybeStartAudioCapture]
+    [setupSession, maybeStartAudioCapture, emitTranscript]
   );
 
   const acquireMicrophone = useCallback(async (): Promise<MediaStream> => {

--- a/packages/react/src/ListWithDetailPane/ListWithDetailPane.tsx
+++ b/packages/react/src/ListWithDetailPane/ListWithDetailPane.tsx
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Box, Center, Divider, Flex, Group, Pagination, ScrollArea, Stack, Tabs, Text } from '@mantine/core';
 import type { Resource } from '@medplum/fhirtypes';
+import { useStabilizedCallback } from '@medplum/react-hooks';
 import cx from 'clsx';
 import type { JSX, ReactNode } from 'react';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { MedplumLink } from '../MedplumLink/MedplumLink';
 import classes from './ListWithDetailPane.module.css';
 import { ListWithDetailPaneSkeleton } from './ListWithDetailPaneSkeleton';
@@ -133,20 +134,17 @@ export function ListWithDetailPane<T extends { id?: string } = Resource>(
     onPageChange,
   } = props;
 
-  // Latest-ref pattern: consumers routinely pass onSelectFirst as an inline arrow, and a
-  // changing identity must not refire the auto-select effect (firing on every render
-  // would loop with consumers that navigate on select).
-  const onSelectFirstRef = useRef(onSelectFirst);
-  useEffect(() => {
-    onSelectFirstRef.current = onSelectFirst;
-  });
+  // Consumers routinely pass onSelectFirst as an inline arrow, and a changing identity must not
+  // refire the auto-select effect (firing on every render would loop with consumers that
+  // navigate on select).
+  const selectFirst = useStabilizedCallback(onSelectFirst);
 
   // Auto-select the first item when a load settles with items and no selection intended.
   useEffect(() => {
     if (!loading && selectedKey === undefined && items.length > 0) {
-      onSelectFirstRef.current?.(items[0]);
+      selectFirst(items[0]);
     }
-  }, [loading, selectedKey, items]);
+  }, [loading, selectedKey, items, selectFirst]);
 
   let headerLeft: ReactNode = <span />;
   if (tabs) {

--- a/packages/react/src/QrCodeScanner/QrCodeScanner.tsx
+++ b/packages/react/src/QrCodeScanner/QrCodeScanner.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Alert, Box, Center, Loader, Stack, Text } from '@mantine/core';
 import { normalizeErrorString } from '@medplum/core';
+import { useStabilizedCallback } from '@medplum/react-hooks';
 import type { JSX } from 'react';
 import { useEffect, useRef, useState } from 'react';
 
@@ -25,18 +26,10 @@ export interface QrCodeScannerProps {
 export function QrCodeScanner({ onScan, onError, scanOnce = true }: QrCodeScannerProps): JSX.Element {
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const onScanRef = useRef(onScan);
-  const onErrorRef = useRef(onError);
+  const emitScan = useStabilizedCallback(onScan);
+  const emitError = useStabilizedCallback(onError);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
-
-  useEffect(() => {
-    onScanRef.current = onScan;
-  }, [onScan]);
-
-  useEffect(() => {
-    onErrorRef.current = onError;
-  }, [onError]);
 
   useEffect(() => {
     const video = videoRef.current;
@@ -65,7 +58,7 @@ export function QrCodeScanner({ onScan, onError, scanOnce = true }: QrCodeScanne
       if (!cancelled) {
         setLoading(false);
         setError(normalizeErrorString(normalized));
-        onErrorRef.current?.(normalized);
+        emitError(normalized);
       }
     }
 
@@ -84,7 +77,7 @@ export function QrCodeScanner({ onScan, onError, scanOnce = true }: QrCodeScanne
           const code = jsQr(imageData.data, imageData.width, imageData.height, { inversionAttempts: 'attemptBoth' });
           if (code?.data) {
             scanned = scanOnce;
-            onScanRef.current(code.data);
+            emitScan(code.data);
             if (scanOnce) {
               stopStream();
               return;
@@ -128,7 +121,7 @@ export function QrCodeScanner({ onScan, onError, scanOnce = true }: QrCodeScanne
       cancelAnimationFrame(rafId);
       stopStream();
     };
-  }, [scanOnce]);
+  }, [scanOnce, emitScan, emitError]);
 
   return (
     <Stack gap="sm">

--- a/packages/react/src/SignatureInput/SignatureInput.tsx
+++ b/packages/react/src/SignatureInput/SignatureInput.tsx
@@ -5,10 +5,10 @@ import { Button, Paper } from '@mantine/core';
 import type { ProfileResource } from '@medplum/core';
 import { createReference, HTTP_HL7_ORG } from '@medplum/core';
 import type { Reference, Signature } from '@medplum/fhirtypes';
-import { useMedplum } from '@medplum/react-hooks';
+import { useMedplum, useStabilizedCallback } from '@medplum/react-hooks';
 import { IconTrash } from '@tabler/icons-react';
 import type { JSX } from 'react';
-import { useEffect, useLayoutEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import SignaturePad from 'signature_pad';
 
 export interface SignatureInputProps extends PaperProps {
@@ -25,14 +25,11 @@ export function SignatureInput(props: SignatureInputProps): JSX.Element {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const signaturePadRef = useRef<SignaturePad>(null);
 
-  const onChangeRef = useRef(onChange);
-  useLayoutEffect(() => {
-    onChangeRef.current = onChange;
-  });
+  const emitChange = useStabilizedCallback(onChange);
 
   useEffect(() => {
     function handleEndStroke(): void {
-      onChangeRef.current?.({
+      emitChange({
         type: [
           {
             system: HTTP_HL7_ORG + '/fhir/signature-type',
@@ -60,13 +57,13 @@ export function SignatureInput(props: SignatureInputProps): JSX.Element {
         signaturePadRef.current.removeEventListener('beginStroke', handleEndStroke);
       }
     };
-  }, [medplum, defaultValue, who]);
+  }, [medplum, defaultValue, who, emitChange]);
 
   const clearSignature = (): void => {
     if (signaturePadRef.current) {
       signaturePadRef.current.clear();
     }
-    onChangeRef.current?.(undefined);
+    emitChange(undefined);
   };
 
   return (


### PR DESCRIPTION
Components and hooks in this libraries are intended to be safely and easily used by the consuming applications. One nicety that we provide in a number of places is the ability to provide a callback that is unstable, most typically as a result of an inline arrow function:

```tsx
  <SignatureInput onChange={(signature) => doWork(signture)} />
```

When we want to use those callbacks outside of the immediate render, we can run into rough edges - as input to dependency arrays of other hooks, this can cause those to also re-compute every render.

To that end, we often use a pattern of capturing the latest version of these callbacks into a Ref, which lets us opt them out of the dependency arrays. That works, but it is not very intention revealing, and it can be hard to understand why the Ref is being used without verbose comments. There also were a number of variants used around the codebase: render-time ref assignment, useEffect, or useLayoutEffect.

In this commit we extract that latest-ref pattern into a reusable hook. The hook updates a ref in useInsertionEffect, which runs before every layout and passive effect in the commit, so a callback fired from a descendant effect is never a render behind.

Converts useMedicationIFrame, useSubscription, useWhisper, ListWithDetailPane, QrCodeScanner, and SignatureInput to use the new hook.