### PR TITLE
Fix C-CDA problem conversion: honor negationInd and concern act status in both directions

### DIFF
--- a/packages/ccda/src/ccda-to-fhir.ts
+++ b/packages/ccda/src/ccda-to-fhir.ts
@@ -607,7 +607,7 @@ class CcdaToFhirConverter {
     // Per C-CDA R2.1, negationInd="true" on the Problem Observation means the problem
     // was ruled out, i.e. the condition was refuted.
     // The negation indicator may also appear on the wrapping Problem Concern Act.
-    if (act['@_negationInd'] === 'true' || observation['@_negationInd'] === 'true') {
+    if (isNegationIndTrue(act['@_negationInd']) || isNegationIndTrue(observation['@_negationInd'])) {
       return {
         coding: [
           {
@@ -1561,6 +1561,18 @@ class CcdaToFhirConverter {
       },
     ];
   }
+}
+
+/**
+ * Returns true if a `negationInd` attribute value asserts negation.
+ * `negationInd` is an XML Schema `xs:boolean`, so "1" is a valid true value
+ * alongside "true".
+ *
+ * @param value - The raw negationInd attribute value.
+ * @returns True if the value asserts negation.
+ */
+function isNegationIndTrue(value: string | undefined): boolean {
+  return value === 'true' || value === '1';
 }
 
 function nodeToString(node: CcdaText | string | undefined): string | undefined {

--- a/packages/ccda/src/ccda-to-fhir.ts
+++ b/packages/ccda/src/ccda-to-fhir.ts
@@ -58,6 +58,7 @@ import {
   OID_PLAN_OF_CARE_SECTION,
   OID_PROBLEMS_SECTION_ENTRIES_OPTIONAL,
   OID_PROBLEMS_SECTION_ENTRIES_REQUIRED,
+  OID_PROBLEM_STATUS_OBSERVATION,
   OID_PROBLEMS_SECTION_V2_ENTRIES_OPTIONAL,
   OID_PROBLEMS_SECTION_V2_ENTRIES_REQUIRED,
   OID_PROCEDURES_SECTION_ENTRIES_REQUIRED,
@@ -86,7 +87,7 @@ import {
   MEDICATION_STATUS_MAPPER,
   OBSERVATION_CATEGORY_MAPPER,
   PARTICIPATION_CODE_SYSTEM,
-  PROBLEM_STATUS_MAPPER,
+  PROBLEM_STATUS_OBSERVATION_MAPPER,
   PROCEDURE_STATUS_MAPPER,
   TELECOM_USE_MAPPER,
   US_CORE_CONDITION_URL,
@@ -521,14 +522,7 @@ class CcdaToFhirConverter {
       meta: {
         profile: [US_CORE_CONDITION_URL],
       },
-      clinicalStatus: {
-        coding: [
-          {
-            system: CLINICAL_CONDITION_CODE_SYSTEM,
-            code: PROBLEM_STATUS_MAPPER.mapCcdaToFhirWithDefault(act.statusCode?.['@_code'], 'active'),
-          },
-        ],
-      },
+      clinicalStatus: this.createConditionClinicalStatus(act, observation),
       verificationStatus: this.createConditionVerificationStatus(act, observation),
       category: [
         {
@@ -553,6 +547,60 @@ class CcdaToFhirConverter {
     result.extension = this.mapTextReference(observation.text);
 
     return result;
+  }
+
+  private createConditionClinicalStatus(act: CcdaAct, observation: CcdaObservation): CodeableConcept {
+    return {
+      coding: [
+        {
+          system: CLINICAL_CONDITION_CODE_SYSTEM,
+          code: this.mapConditionClinicalStatusCode(act, observation),
+        },
+      ],
+    };
+  }
+
+  private mapConditionClinicalStatusCode(act: CcdaAct, observation: CcdaObservation): string {
+    // The Problem Status observation (2.16.840.1.113883.10.20.22.4.6, LOINC 33999-4),
+    // when present, is the most direct statement of the problem's clinical status,
+    // so it takes precedence over the status inferred from the Problem Concern Act.
+    const problemStatus = this.getProblemStatusObservationValue(observation);
+    if (problemStatus) {
+      return problemStatus;
+    }
+
+    // Otherwise, infer the clinical status from the Problem Concern Act statusCode.
+    // Per C-CDA R2.1, the concern act statusCode reflects whether the concern is still
+    // being tracked, while the nested Problem Observation statusCode is always
+    // "completed" (the state of the recording act itself), so it is not used here.
+    switch (act.statusCode?.['@_code']) {
+      case 'active':
+        return 'active';
+      case 'suspended':
+      case 'aborted':
+        return 'inactive';
+      case 'completed':
+        // A closed concern with a known end date is resolved; otherwise inactive.
+        return act.effectiveTime?.[0]?.high?.['@_value'] || observation.effectiveTime?.[0]?.high?.['@_value']
+          ? 'resolved'
+          : 'inactive';
+      default:
+        return 'active';
+    }
+  }
+
+  private getProblemStatusObservationValue(observation: CcdaObservation): string | undefined {
+    for (const relationship of observation.entryRelationship ?? EMPTY) {
+      for (const child of relationship.observation ?? EMPTY) {
+        if (child.templateId?.some((templateId) => templateId['@_root'] === OID_PROBLEM_STATUS_OBSERVATION)) {
+          const code = (child.value as CcdaCode | undefined)?.['@_code'];
+          if (code) {
+            return PROBLEM_STATUS_OBSERVATION_MAPPER.mapCcdaToFhir(code);
+          }
+        }
+      }
+    }
+    return undefined;
   }
 
   private createConditionVerificationStatus(act: CcdaAct, observation: CcdaObservation): CodeableConcept {

--- a/packages/ccda/src/ccda-to-fhir.ts
+++ b/packages/ccda/src/ccda-to-fhir.ts
@@ -56,9 +56,9 @@ import {
   OID_NOTES_SECTION,
   OID_PAYERS_SECTION,
   OID_PLAN_OF_CARE_SECTION,
+  OID_PROBLEM_STATUS_OBSERVATION,
   OID_PROBLEMS_SECTION_ENTRIES_OPTIONAL,
   OID_PROBLEMS_SECTION_ENTRIES_REQUIRED,
-  OID_PROBLEM_STATUS_OBSERVATION,
   OID_PROBLEMS_SECTION_V2_ENTRIES_OPTIONAL,
   OID_PROBLEMS_SECTION_V2_ENTRIES_REQUIRED,
   OID_PROCEDURES_SECTION_ENTRIES_REQUIRED,
@@ -561,18 +561,16 @@ class CcdaToFhirConverter {
   }
 
   private mapConditionClinicalStatusCode(act: CcdaAct, observation: CcdaObservation): string {
-    // The Problem Status observation (2.16.840.1.113883.10.20.22.4.6, LOINC 33999-4),
-    // when present, is the most direct statement of the problem's clinical status,
-    // so it takes precedence over the status inferred from the Problem Concern Act.
+    // The Problem Status observation (2.16.840.1.113883.10.20.22.4.6, LOINC 33999-4) is the
+    // most direct statement of clinical status, so it takes precedence over the concern act.
     const problemStatus = this.getProblemStatusObservationValue(observation);
     if (problemStatus) {
       return problemStatus;
     }
 
-    // Otherwise, infer the clinical status from the Problem Concern Act statusCode.
-    // Per C-CDA R2.1, the concern act statusCode reflects whether the concern is still
-    // being tracked, while the nested Problem Observation statusCode is always
-    // "completed" (the state of the recording act itself), so it is not used here.
+    // Per C-CDA R2.1, the concern act statusCode tracks the concern, while the nested Problem
+    // Observation statusCode is the state of the recording act (conventionally "completed") and
+    // never the clinical status — so it is deliberately not consulted here.
     switch (act.statusCode?.['@_code']) {
       case 'active':
         return 'active';
@@ -580,7 +578,8 @@ class CcdaToFhirConverter {
       case 'aborted':
         return 'inactive';
       case 'completed':
-        // A closed concern with a known end date is resolved; otherwise inactive.
+        // Only a closed concern with an asserted end date is "resolved" — a document cannot
+        // assert abatement without a date, so completed-without-high maps to "inactive".
         return act.effectiveTime?.[0]?.high?.['@_value'] || observation.effectiveTime?.[0]?.high?.['@_value']
           ? 'resolved'
           : 'inactive';
@@ -604,9 +603,8 @@ class CcdaToFhirConverter {
   }
 
   private createConditionVerificationStatus(act: CcdaAct, observation: CcdaObservation): CodeableConcept {
-    // Per C-CDA R2.1, negationInd="true" on the Problem Observation means the problem
-    // was ruled out, i.e. the condition was refuted.
-    // The negation indicator may also appear on the wrapping Problem Concern Act.
+    // Per C-CDA R2.1, negationInd="true" means the problem was ruled out (refuted); the
+    // indicator may appear on the Problem Observation or the wrapping concern act.
     if (isNegationIndTrue(act['@_negationInd']) || isNegationIndTrue(observation['@_negationInd'])) {
       return {
         coding: [
@@ -1564,9 +1562,8 @@ class CcdaToFhirConverter {
 }
 
 /**
- * Returns true if a `negationInd` attribute value asserts negation.
- * `negationInd` is an XML Schema `xs:boolean`, so "1" is a valid true value
- * alongside "true".
+ * Returns true if a `negationInd` attribute asserts negation.
+ * `negationInd` is an XML Schema `xs:boolean`, so "1" is valid alongside "true".
  *
  * @param value - The raw negationInd attribute value.
  * @returns True if the value asserts negation.

--- a/packages/ccda/src/ccda-to-fhir.ts
+++ b/packages/ccda/src/ccda-to-fhir.ts
@@ -529,14 +529,7 @@ class CcdaToFhirConverter {
           },
         ],
       },
-      verificationStatus: {
-        coding: [
-          {
-            system: CONDITION_VERIFICATION_CODE_SYSTEM,
-            code: 'confirmed',
-          },
-        ],
-      },
+      verificationStatus: this.createConditionVerificationStatus(act, observation),
       category: [
         {
           coding: [
@@ -560,6 +553,30 @@ class CcdaToFhirConverter {
     result.extension = this.mapTextReference(observation.text);
 
     return result;
+  }
+
+  private createConditionVerificationStatus(act: CcdaAct, observation: CcdaObservation): CodeableConcept {
+    // Per C-CDA R2.1, negationInd="true" on the Problem Observation means the problem
+    // was ruled out, i.e. the condition was refuted.
+    // The negation indicator may also appear on the wrapping Problem Concern Act.
+    if (act['@_negationInd'] === 'true' || observation['@_negationInd'] === 'true') {
+      return {
+        coding: [
+          {
+            system: CONDITION_VER_STATUS_CODE_SYSTEM,
+            code: 'refuted',
+          },
+        ],
+      };
+    }
+    return {
+      coding: [
+        {
+          system: CONDITION_VERIFICATION_CODE_SYSTEM,
+          code: 'confirmed',
+        },
+      ],
+    };
   }
 
   private processCarePlanAct(act: CcdaAct): Resource | undefined {

--- a/packages/ccda/src/fhir-to-ccda/entries/condition.test.ts
+++ b/packages/ccda/src/fhir-to-ccda/entries/condition.test.ts
@@ -140,7 +140,7 @@ describe('Condition Entry Functions', () => {
       expect(act?.statusCode?.['@_code']).toBe('active'); // Default status
     });
 
-    test('should handle condition with clinical status', () => {
+    test('should map inactive clinical status to a completed concern act', () => {
       const condition: Condition = {
         id: 'condition-1',
         resourceType: 'Condition',
@@ -156,7 +156,90 @@ describe('Condition Entry Functions', () => {
       const result = createProblemEntry(converter, condition);
 
       const act = result.act?.[0];
-      expect(act?.statusCode?.['@_code']).toBe('inactive');
+      expect(act?.statusCode?.['@_code']).toBe('completed');
+    });
+
+    test('should map resolved clinical status to a completed concern act with an end date', () => {
+      const condition: Condition = {
+        id: 'condition-1',
+        resourceType: 'Condition',
+        subject: createReference(patient),
+        clinicalStatus: {
+          coding: [{ system: 'http://terminology.hl7.org/CodeSystem/condition-clinical', code: 'resolved' }],
+        },
+        recordedDate: '2024-01-01',
+        abatementDateTime: '2024-06-01',
+        code: {
+          coding: [{ system: 'http://snomed.info/sct', code: '233604007', display: 'Pneumonia' }],
+        },
+      };
+
+      const result = createProblemEntry(converter, condition);
+
+      const act = result.act?.[0];
+      expect(act?.statusCode?.['@_code']).toBe('completed');
+      expect(act?.effectiveTime?.[0]?.low?.['@_value']).toBe('20240101');
+      expect(act?.effectiveTime?.[0]?.high?.['@_value']).toBe('20240601');
+    });
+
+    test('should not emit a concern act end date for an active condition', () => {
+      const condition: Condition = {
+        id: 'condition-1',
+        resourceType: 'Condition',
+        subject: createReference(patient),
+        clinicalStatus: {
+          coding: [{ system: 'http://terminology.hl7.org/CodeSystem/condition-clinical', code: 'active' }],
+        },
+        recordedDate: '2024-01-01',
+        abatementDateTime: '2024-06-01',
+        code: {
+          coding: [{ system: 'http://snomed.info/sct', code: '233604007', display: 'Pneumonia' }],
+        },
+      };
+
+      const result = createProblemEntry(converter, condition);
+
+      const act = result.act?.[0];
+      expect(act?.statusCode?.['@_code']).toBe('active');
+      expect(act?.effectiveTime?.[0]?.high).toBeUndefined();
+    });
+
+    test('should emit negationInd on the problem observation for a refuted condition', () => {
+      const condition: Condition = {
+        id: 'condition-1',
+        resourceType: 'Condition',
+        subject: createReference(patient),
+        verificationStatus: {
+          coding: [{ system: 'http://terminology.hl7.org/CodeSystem/condition-ver-status', code: 'refuted' }],
+        },
+        code: {
+          coding: [{ system: 'http://snomed.info/sct', code: '233604007', display: 'Pneumonia' }],
+        },
+      };
+
+      const result = createProblemEntry(converter, condition);
+
+      const observation = result.act?.[0]?.entryRelationship?.[0]?.observation?.[0];
+      expect(observation?.['@_negationInd']).toBe('true');
+    });
+
+    test('should not emit negationInd for a confirmed condition', () => {
+      const condition: Condition = {
+        id: 'condition-1',
+        resourceType: 'Condition',
+        subject: createReference(patient),
+        verificationStatus: {
+          coding: [{ system: 'http://terminology.hl7.org/CodeSystem/condition-verification', code: 'confirmed' }],
+        },
+        code: {
+          coding: [{ system: 'http://snomed.info/sct', code: '233604007', display: 'Pneumonia' }],
+        },
+      };
+
+      const result = createProblemEntry(converter, condition);
+
+      const observation = result.act?.[0]?.entryRelationship?.[0]?.observation?.[0];
+      expect(observation?.['@_negationInd']).toBeUndefined();
     });
 
     test('should handle condition with dates', () => {
@@ -252,7 +335,7 @@ describe('Condition Entry Functions', () => {
       expect(act?.entryRelationship).toEqual([]);
     });
 
-    test('should handle health concern with clinical status', () => {
+    test('should map inactive clinical status to a completed health concern act', () => {
       const condition: Condition = {
         id: 'condition-1',
         resourceType: 'Condition',
@@ -268,7 +351,7 @@ describe('Condition Entry Functions', () => {
       const result = createHealthConcernEntry(converter, condition);
 
       const act = result.act?.[0];
-      expect(act?.statusCode?.['@_code']).toBe('inactive');
+      expect(act?.statusCode?.['@_code']).toBe('completed');
     });
 
     test('should handle health concern with evidence observations', () => {

--- a/packages/ccda/src/fhir-to-ccda/entries/condition.ts
+++ b/packages/ccda/src/fhir-to-ccda/entries/condition.ts
@@ -26,19 +26,12 @@ import { createTextFromExtensions, mapEffectivePeriod, mapIdentifiers } from '..
 /**
  * Maps a FHIR `Condition.clinicalStatus` to a C-CDA concern act `statusCode`.
  *
- * Per C-CDA R2.1, the Problem Concern Act statusCode is drawn from the
- * ProblemAct statusCode value set (2.16.840.1.113883.11.20.9.19:
- * active | suspended | aborted | completed) and reflects whether the concern
- * is still being tracked, not the clinical course of the problem itself.
- * A condition that is no longer active ("inactive" or "resolved") is a closed
- * concern, for which "completed" is the normal terminal state; "suspended"
- * and "aborted" describe exceptional interruptions of the tracking workflow
- * and are not implied by any FHIR condition-clinical code. Everything else
- * ("active", "recurrence", "relapse", "remission", or an absent/unrecognized
- * status) exports as an "active" concern, preserving the previous default.
- *
- * This mirrors the import direction, which maps "completed" back to
- * "resolved" when an effectiveTime high is asserted and "inactive" otherwise.
+ * The concern act statusCode (ProblemAct value set 2.16.840.1.113883.11.20.9.19) tracks the
+ * concern, not the clinical course. A no-longer-active condition is a closed concern, whose
+ * normal terminal state is "completed" — "suspended"/"aborted" are workflow interruptions and
+ * are not implied by any FHIR condition-clinical code. Must stay symmetric with the import
+ * direction, which maps "completed" to "resolved" when an effectiveTime high is asserted and
+ * "inactive" otherwise.
  *
  * @param condition - The FHIR Condition.
  * @returns The C-CDA concern act statusCode value.

--- a/packages/ccda/src/fhir-to-ccda/entries/condition.ts
+++ b/packages/ccda/src/fhir-to-ccda/entries/condition.ts
@@ -18,11 +18,50 @@ import {
   LOINC_HEALTH_CONCERNS_SECTION,
   LOINC_PROBLEMS_SECTION,
   mapCodeableConceptToCcdaValue,
-  PROBLEM_STATUS_MAPPER,
 } from '../../systems';
 import type { CcdaEntry, CcdaEntryRelationship } from '../../types';
 import type { FhirToCcdaConverter } from '../convert';
 import { createTextFromExtensions, mapEffectivePeriod, mapIdentifiers } from '../utils';
+
+/**
+ * Maps a FHIR `Condition.clinicalStatus` to a C-CDA concern act `statusCode`.
+ *
+ * Per C-CDA R2.1, the Problem Concern Act statusCode is drawn from the
+ * ProblemAct statusCode value set (2.16.840.1.113883.11.20.9.19:
+ * active | suspended | aborted | completed) and reflects whether the concern
+ * is still being tracked, not the clinical course of the problem itself.
+ * A condition that is no longer active ("inactive" or "resolved") is a closed
+ * concern, for which "completed" is the normal terminal state; "suspended"
+ * and "aborted" describe exceptional interruptions of the tracking workflow
+ * and are not implied by any FHIR condition-clinical code. Everything else
+ * ("active", "recurrence", "relapse", "remission", or an absent/unrecognized
+ * status) exports as an "active" concern, preserving the previous default.
+ *
+ * This mirrors the import direction, which maps "completed" back to
+ * "resolved" when an effectiveTime high is asserted and "inactive" otherwise.
+ *
+ * @param condition - The FHIR Condition.
+ * @returns The C-CDA concern act statusCode value.
+ */
+function mapClinicalStatusToConcernActStatus(condition: Condition): 'active' | 'completed' {
+  switch (condition.clinicalStatus?.coding?.[0]?.code) {
+    case 'inactive':
+    case 'resolved':
+      return 'completed';
+    default:
+      return 'active';
+  }
+}
+
+/**
+ * Returns true if the FHIR Condition is refuted (ruled out).
+ *
+ * @param condition - The FHIR Condition.
+ * @returns True if `Condition.verificationStatus` contains the "refuted" code.
+ */
+function isConditionRefuted(condition: Condition): boolean {
+  return !!condition.verificationStatus?.coding?.some((coding) => coding.code === 'refuted');
+}
 
 export function createConditionEntry(
   converter: FhirToCcdaConverter,
@@ -40,6 +79,7 @@ export function createConditionEntry(
 }
 
 export function createProblemEntry(converter: FhirToCcdaConverter, problem: Condition): CcdaEntry {
+  const concernStatus = mapClinicalStatusToConcernActStatus(problem);
   return {
     act: [
       {
@@ -52,9 +92,14 @@ export function createProblemEntry(converter: FhirToCcdaConverter, problem: Cond
           '@_codeSystem': OID_ACT_CLASS_CODE_SYSTEM,
         },
         statusCode: {
-          '@_code': PROBLEM_STATUS_MAPPER.mapFhirToCcdaWithDefault(problem.clinicalStatus?.coding?.[0]?.code, 'active'),
+          '@_code': concernStatus,
         },
-        effectiveTime: mapEffectivePeriod(problem.recordedDate, undefined),
+        // A closed concern carries its end date, so that the import direction
+        // ("completed" + effectiveTime high => resolved) can round-trip it.
+        effectiveTime: mapEffectivePeriod(
+          problem.recordedDate,
+          concernStatus === 'completed' ? problem.abatementDateTime : undefined
+        ),
         entryRelationship: [
           {
             '@_typeCode': 'SUBJ',
@@ -62,6 +107,7 @@ export function createProblemEntry(converter: FhirToCcdaConverter, problem: Cond
               {
                 '@_classCode': 'OBS',
                 '@_moodCode': 'EVN',
+                '@_negationInd': isConditionRefuted(problem) ? 'true' : undefined,
                 templateId: [
                   { '@_root': OID_PROBLEM_OBSERVATION },
                   { '@_root': OID_PROBLEM_OBSERVATION, '@_extension': '2015-08-01' },
@@ -169,10 +215,7 @@ export function createHealthConcernEntry(converter: FhirToCcdaConverter, healthC
           '@_displayName': 'Health Concern',
         },
         statusCode: {
-          '@_code': PROBLEM_STATUS_MAPPER.mapFhirToCcdaWithDefault(
-            healthConcern.clinicalStatus?.coding?.[0]?.code,
-            'active'
-          ),
+          '@_code': mapClinicalStatusToConcernActStatus(healthConcern),
         },
         effectiveTime: mapEffectivePeriod(healthConcern.recordedDate, undefined),
         entryRelationship,

--- a/packages/ccda/src/negation.test.ts
+++ b/packages/ccda/src/negation.test.ts
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { Condition } from '@medplum/fhirtypes';
+import { convertCcdaToFhir } from './ccda-to-fhir';
+import { convertXmlToCcda } from './xml';
+
+/**
+ * Builds a minimal C-CDA document containing a single Problem Concern Act
+ * (2.16.840.1.113883.10.20.22.4.3) wrapping a single Problem Observation
+ * (2.16.840.1.113883.10.20.22.4.4).
+ *
+ * @param options - Optional negation indicators for the act and the observation.
+ * @param options.actNegationInd - Optional negationInd attribute for the Problem Concern Act.
+ * @param options.observationNegationInd - Optional negationInd attribute for the Problem Observation.
+ * @returns The C-CDA XML string.
+ */
+function createProblemDocument(options?: { actNegationInd?: string; observationNegationInd?: string }): string {
+  const actNegation = options?.actNegationInd ? ` negationInd="${options.actNegationInd}"` : '';
+  const observationNegation = options?.observationNegationInd
+    ? ` negationInd="${options.observationNegationInd}"`
+    : '';
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <realmCode code="US"/>
+  <typeId extension="POCD_HD000040" root="2.16.840.1.113883.1.3"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.2"/>
+  <id root="8542cef2-4d2f-4a02-9d9f-2f2e94e5b485"/>
+  <code code="34133-9" codeSystem="2.16.840.1.113883.6.1"/>
+  <title>Negation Test</title>
+  <effectiveTime value="20240101"/>
+  <recordTarget>
+    <patientRole>
+      <id root="c2b31c22-2b17-4a21-9d77-e58bd8a3a3f4"/>
+      <patient>
+        <name>
+          <given>Jane</given>
+          <family>Doe</family>
+        </name>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <component>
+    <structuredBody>
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
+          <code code="11450-4" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Problems</title>
+          <text>Problems</text>
+          <entry>
+            <act classCode="ACT" moodCode="EVN"${actNegation}>
+              <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+              <id root="7f3a1c9e-9c3c-4f6e-8f4a-1f2b3c4d5e6f"/>
+              <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+              <statusCode code="active"/>
+              <effectiveTime>
+                <low value="20240101"/>
+              </effectiveTime>
+              <entryRelationship typeCode="SUBJ">
+                <observation classCode="OBS" moodCode="EVN"${observationNegation}>
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                  <id root="1d8a5c3b-6e4f-4a2b-9c8d-7e6f5a4b3c2d"/>
+                  <code code="55607006" codeSystem="2.16.840.1.113883.6.96"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime>
+                    <low value="20240101"/>
+                  </effectiveTime>
+                  <value xsi:type="CD" code="233604007" codeSystem="2.16.840.1.113883.6.96" displayName="Pneumonia"/>
+                </observation>
+              </entryRelationship>
+            </act>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>`;
+}
+
+function convertToCondition(xml: string): Condition {
+  const bundle = convertCcdaToFhir(convertXmlToCcda(xml));
+  const condition = bundle.entry?.find((e) => e.resource?.resourceType === 'Condition')?.resource as Condition;
+  expect(condition).toBeDefined();
+  return condition;
+}
+
+describe('Problem Observation negationInd', () => {
+  test('without negationInd, verification status is confirmed', () => {
+    const condition = convertToCondition(createProblemDocument());
+    expect(condition.verificationStatus?.coding?.[0]?.code).toBe('confirmed');
+  });
+
+  test('negationInd="true" on the observation produces refuted verification status', () => {
+    const condition = convertToCondition(createProblemDocument({ observationNegationInd: 'true' }));
+    expect(condition.verificationStatus?.coding?.[0]?.code).toBe('refuted');
+    expect(condition.verificationStatus?.coding?.[0]?.system).toBe(
+      'http://terminology.hl7.org/CodeSystem/condition-ver-status'
+    );
+  });
+
+  test('negationInd="true" on the concern act produces refuted verification status', () => {
+    const condition = convertToCondition(createProblemDocument({ actNegationInd: 'true' }));
+    expect(condition.verificationStatus?.coding?.[0]?.code).toBe('refuted');
+    expect(condition.verificationStatus?.coding?.[0]?.system).toBe(
+      'http://terminology.hl7.org/CodeSystem/condition-ver-status'
+    );
+  });
+
+  test('negationInd="false" is treated as not negated', () => {
+    const condition = convertToCondition(createProblemDocument({ observationNegationInd: 'false' }));
+    expect(condition.verificationStatus?.coding?.[0]?.code).toBe('confirmed');
+  });
+});

--- a/packages/ccda/src/negation.test.ts
+++ b/packages/ccda/src/negation.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Condition } from '@medplum/fhirtypes';
 import { convertCcdaToFhir } from './ccda-to-fhir';
+import { convertFhirToCcda } from './fhir-to-ccda/convert';
 import { convertXmlToCcda } from './xml';
 
 /**
@@ -109,5 +110,51 @@ describe('Problem Observation negationInd', () => {
   test('negationInd="false" is treated as not negated', () => {
     const condition = convertToCondition(createProblemDocument({ observationNegationInd: 'false' }));
     expect(condition.verificationStatus?.coding?.[0]?.code).toBe('confirmed');
+  });
+
+  test('negationInd="1" (xs:boolean) produces refuted verification status', () => {
+    const condition = convertToCondition(createProblemDocument({ observationNegationInd: '1' }));
+    expect(condition.verificationStatus?.coding?.[0]?.code).toBe('refuted');
+  });
+
+  test('negationInd="0" (xs:boolean) is treated as not negated', () => {
+    const condition = convertToCondition(createProblemDocument({ observationNegationInd: '0' }));
+    expect(condition.verificationStatus?.coding?.[0]?.code).toBe('confirmed');
+  });
+
+  describe('Round trip', () => {
+    test('refuted survives import -> export -> re-import', () => {
+      // Import: negated problem observation => refuted.
+      const bundle = convertCcdaToFhir(convertXmlToCcda(createProblemDocument({ observationNegationInd: 'true' })));
+      const condition = bundle.entry?.find((e) => e.resource?.resourceType === 'Condition')?.resource as Condition;
+      expect(condition.verificationStatus?.coding?.[0]?.code).toBe('refuted');
+
+      // Export: refuted => negationInd="true" on the problem observation.
+      const exported = convertFhirToCcda(bundle);
+      const observation =
+        exported.component?.structuredBody?.component?.[0]?.section?.[0]?.entry?.[0]?.act?.[0]?.entryRelationship?.[0]
+          ?.observation?.[0];
+      expect(observation?.['@_negationInd']).toBe('true');
+
+      // Re-import: still refuted.
+      const reimported = convertCcdaToFhir(exported);
+      const condition2 = reimported.entry?.find((e) => e.resource?.resourceType === 'Condition')
+        ?.resource as Condition;
+      expect(condition2.verificationStatus?.coding?.[0]?.code).toBe('refuted');
+    });
+
+    test('confirmed conditions export without negationInd', () => {
+      const bundle = convertCcdaToFhir(convertXmlToCcda(createProblemDocument()));
+      const exported = convertFhirToCcda(bundle);
+      const observation =
+        exported.component?.structuredBody?.component?.[0]?.section?.[0]?.entry?.[0]?.act?.[0]?.entryRelationship?.[0]
+          ?.observation?.[0];
+      expect(observation?.['@_negationInd']).toBeUndefined();
+
+      const reimported = convertCcdaToFhir(exported);
+      const condition = reimported.entry?.find((e) => e.resource?.resourceType === 'Condition')
+        ?.resource as Condition;
+      expect(condition.verificationStatus?.coding?.[0]?.code).toBe('confirmed');
+    });
   });
 });

--- a/packages/ccda/src/problem-status.test.ts
+++ b/packages/ccda/src/problem-status.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Condition } from '@medplum/fhirtypes';
 import { convertCcdaToFhir } from './ccda-to-fhir';
+import { convertFhirToCcda } from './fhir-to-ccda/convert';
 import { convertXmlToCcda } from './xml';
 
 /**
@@ -154,6 +155,64 @@ describe('Condition clinical status', () => {
         createProblemDocument({ actStatusCode: 'active', problemStatusCode: '999999999' })
       );
       expect(condition.clinicalStatus?.coding?.[0]?.code).toBe('active');
+    });
+  });
+
+  describe('Round trip', () => {
+    test('resolved survives import -> export -> re-import', () => {
+      // Import: completed concern act + effectiveTime high => resolved.
+      const bundle = convertCcdaToFhir(
+        convertXmlToCcda(createProblemDocument({ actStatusCode: 'completed', observationHigh: '20240601' }))
+      );
+      const condition = bundle.entry?.find((e) => e.resource?.resourceType === 'Condition')?.resource as Condition;
+      expect(condition.clinicalStatus?.coding?.[0]?.code).toBe('resolved');
+      expect(condition.abatementDateTime).toBe('2024-06-01T00:00:00Z');
+
+      // Export: resolved => completed concern act carrying the end date.
+      const exported = convertFhirToCcda(bundle);
+      const act = exported.component?.structuredBody?.component?.[0]?.section?.[0]?.entry?.[0]?.act?.[0];
+      expect(act?.statusCode?.['@_code']).toBe('completed');
+      expect(act?.effectiveTime?.[0]?.high?.['@_value']).toBeDefined();
+
+      // Re-import: still resolved.
+      const reimported = convertCcdaToFhir(exported);
+      const condition2 = reimported.entry?.find((e) => e.resource?.resourceType === 'Condition')
+        ?.resource as Condition;
+      expect(condition2.clinicalStatus?.coding?.[0]?.code).toBe('resolved');
+    });
+
+    test('inactive survives import -> export -> re-import', () => {
+      // Import: completed concern act without an effectiveTime high => inactive.
+      const bundle = convertCcdaToFhir(convertXmlToCcda(createProblemDocument({ actStatusCode: 'completed' })));
+      const condition = bundle.entry?.find((e) => e.resource?.resourceType === 'Condition')?.resource as Condition;
+      expect(condition.clinicalStatus?.coding?.[0]?.code).toBe('inactive');
+
+      // Export: inactive => completed concern act without an end date.
+      const exported = convertFhirToCcda(bundle);
+      const act = exported.component?.structuredBody?.component?.[0]?.section?.[0]?.entry?.[0]?.act?.[0];
+      expect(act?.statusCode?.['@_code']).toBe('completed');
+      expect(act?.effectiveTime?.[0]?.high).toBeUndefined();
+
+      // Re-import: still inactive.
+      const reimported = convertCcdaToFhir(exported);
+      const condition2 = reimported.entry?.find((e) => e.resource?.resourceType === 'Condition')
+        ?.resource as Condition;
+      expect(condition2.clinicalStatus?.coding?.[0]?.code).toBe('inactive');
+    });
+
+    test('active survives import -> export -> re-import', () => {
+      const bundle = convertCcdaToFhir(convertXmlToCcda(createProblemDocument({ actStatusCode: 'active' })));
+      const condition = bundle.entry?.find((e) => e.resource?.resourceType === 'Condition')?.resource as Condition;
+      expect(condition.clinicalStatus?.coding?.[0]?.code).toBe('active');
+
+      const exported = convertFhirToCcda(bundle);
+      const act = exported.component?.structuredBody?.component?.[0]?.section?.[0]?.entry?.[0]?.act?.[0];
+      expect(act?.statusCode?.['@_code']).toBe('active');
+
+      const reimported = convertCcdaToFhir(exported);
+      const condition2 = reimported.entry?.find((e) => e.resource?.resourceType === 'Condition')
+        ?.resource as Condition;
+      expect(condition2.clinicalStatus?.coding?.[0]?.code).toBe('active');
     });
   });
 });

--- a/packages/ccda/src/problem-status.test.ts
+++ b/packages/ccda/src/problem-status.test.ts
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { Condition } from '@medplum/fhirtypes';
+import { convertCcdaToFhir } from './ccda-to-fhir';
+import { convertXmlToCcda } from './xml';
+
+/**
+ * Builds a minimal C-CDA document containing a single Problem Concern Act
+ * (2.16.840.1.113883.10.20.22.4.3) wrapping a single Problem Observation
+ * (2.16.840.1.113883.10.20.22.4.4).
+ *
+ * @param options - Optional variations of the concern act and observation.
+ * @param options.actStatusCode - Optional statusCode for the Problem Concern Act; omitted entirely when not provided.
+ * @param options.observationHigh - Optional effectiveTime/high value for the Problem Observation.
+ * @param options.problemStatusCode - Optional SNOMED CT code for a nested Problem Status observation.
+ * @returns The C-CDA XML string.
+ */
+function createProblemDocument(options?: {
+  actStatusCode?: string;
+  observationHigh?: string;
+  problemStatusCode?: string;
+}): string {
+  const actStatus = options?.actStatusCode ? `<statusCode code="${options.actStatusCode}"/>` : '';
+  const observationHigh = options?.observationHigh ? `<high value="${options.observationHigh}"/>` : '';
+  const problemStatus = options?.problemStatusCode
+    ? `<entryRelationship typeCode="REFR">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.22.4.6"/>
+                      <code code="33999-4" codeSystem="2.16.840.1.113883.6.1"/>
+                      <statusCode code="completed"/>
+                      <value xsi:type="CD" code="${options.problemStatusCode}" codeSystem="2.16.840.1.113883.6.96"/>
+                    </observation>
+                  </entryRelationship>`
+    : '';
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <realmCode code="US"/>
+  <typeId extension="POCD_HD000040" root="2.16.840.1.113883.1.3"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.2"/>
+  <id root="0e1cb6cd-4c22-4b12-9c37-1cf1e4d1a6c8"/>
+  <code code="34133-9" codeSystem="2.16.840.1.113883.6.1"/>
+  <title>Problem Status Test</title>
+  <effectiveTime value="20240101"/>
+  <recordTarget>
+    <patientRole>
+      <id root="8f0b6ce7-9d4e-4a95-96b2-6a4c1d3e2f10"/>
+      <patient>
+        <name>
+          <given>Jane</given>
+          <family>Doe</family>
+        </name>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <component>
+    <structuredBody>
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
+          <code code="11450-4" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Problems</title>
+          <text>Problems</text>
+          <entry>
+            <act classCode="ACT" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+              <id root="3e2d1c0b-9a8f-4e7d-b6c5-a4b3c2d1e0f9"/>
+              <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+              ${actStatus}
+              <effectiveTime>
+                <low value="20240101"/>
+              </effectiveTime>
+              <entryRelationship typeCode="SUBJ">
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                  <id root="5a4b3c2d-1e0f-4a9b-8c7d-6e5f4a3b2c1d"/>
+                  <code code="55607006" codeSystem="2.16.840.1.113883.6.96"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime>
+                    <low value="20240101"/>
+                    ${observationHigh}
+                  </effectiveTime>
+                  <value xsi:type="CD" code="233604007" codeSystem="2.16.840.1.113883.6.96" displayName="Pneumonia"/>
+                  ${problemStatus}
+                </observation>
+              </entryRelationship>
+            </act>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>`;
+}
+
+function convertToCondition(xml: string): Condition {
+  const bundle = convertCcdaToFhir(convertXmlToCcda(xml));
+  const condition = bundle.entry?.find((e) => e.resource?.resourceType === 'Condition')?.resource as Condition;
+  expect(condition).toBeDefined();
+  return condition;
+}
+
+describe('Condition clinical status', () => {
+  describe('Problem Concern Act statusCode', () => {
+    test('active concern produces active clinical status', () => {
+      const condition = convertToCondition(createProblemDocument({ actStatusCode: 'active' }));
+      expect(condition.clinicalStatus?.coding?.[0]?.code).toBe('active');
+      expect(condition.clinicalStatus?.coding?.[0]?.system).toBe(
+        'http://terminology.hl7.org/CodeSystem/condition-clinical'
+      );
+    });
+
+    test('completed concern with an effectiveTime high produces resolved clinical status', () => {
+      const condition = convertToCondition(
+        createProblemDocument({ actStatusCode: 'completed', observationHigh: '20240601' })
+      );
+      expect(condition.clinicalStatus?.coding?.[0]?.code).toBe('resolved');
+    });
+
+    test('completed concern without an effectiveTime high produces inactive clinical status', () => {
+      const condition = convertToCondition(createProblemDocument({ actStatusCode: 'completed' }));
+      expect(condition.clinicalStatus?.coding?.[0]?.code).toBe('inactive');
+    });
+
+    test('suspended concern produces inactive clinical status', () => {
+      const condition = convertToCondition(createProblemDocument({ actStatusCode: 'suspended' }));
+      expect(condition.clinicalStatus?.coding?.[0]?.code).toBe('inactive');
+    });
+
+    test('concern without a statusCode defaults to active clinical status', () => {
+      // The Problem Observation's own statusCode ("completed") describes the recording
+      // act, not the problem, so it must not influence the clinical status.
+      const condition = convertToCondition(createProblemDocument());
+      expect(condition.clinicalStatus?.coding?.[0]?.code).toBe('active');
+    });
+  });
+
+  describe('Problem Status observation', () => {
+    test('SNOMED 55561003 (Active) takes precedence over a completed concern', () => {
+      const condition = convertToCondition(
+        createProblemDocument({ actStatusCode: 'completed', problemStatusCode: '55561003' })
+      );
+      expect(condition.clinicalStatus?.coding?.[0]?.code).toBe('active');
+    });
+
+    test('SNOMED 413322009 (Resolved) takes precedence over an active concern', () => {
+      const condition = convertToCondition(
+        createProblemDocument({ actStatusCode: 'active', problemStatusCode: '413322009' })
+      );
+      expect(condition.clinicalStatus?.coding?.[0]?.code).toBe('resolved');
+    });
+
+    test('unrecognized problem status code falls back to the concern act statusCode', () => {
+      const condition = convertToCondition(
+        createProblemDocument({ actStatusCode: 'active', problemStatusCode: '999999999' })
+      );
+      expect(condition.clinicalStatus?.coding?.[0]?.code).toBe('active');
+    });
+  });
+});

--- a/packages/ccda/src/systems.ts
+++ b/packages/ccda/src/systems.ts
@@ -640,6 +640,21 @@ export const PROBLEM_STATUS_MAPPER = new EnumMapper<string, string>(
   ]
 );
 
+// Problem Status observation (2.16.840.1.113883.10.20.22.4.6) value
+// C-CDA uses SNOMED CT codes from the Problem Status value set (2.16.840.1.113883.3.88.12.80.68)
+// FHIR uses: https://hl7.org/fhir/R4/valueset-condition-clinical.html
+export const PROBLEM_STATUS_OBSERVATION_MAPPER = new EnumMapper<string, string>(
+  {
+    ccdaSystemOid: OID_SNOMED_CT_CODE_SYSTEM,
+    fhirSystemUrl: CLINICAL_CONDITION_CODE_SYSTEM,
+  },
+  [
+    { ccdaValue: '55561003', fhirValue: 'active', displayName: 'Active' },
+    { ccdaValue: '73425007', fhirValue: 'inactive', displayName: 'Inactive' },
+    { ccdaValue: '413322009', fhirValue: 'resolved', displayName: 'Resolved' },
+  ]
+);
+
 // FHIR Immunization Status: https://hl7.org/fhir/R4/valueset-immunization-status.html
 // C-CDA Act Status: https://terminology.hl7.org/5.5.0/ValueSet-v3-ActStatus.html
 export const IMMUNIZATION_STATUS_MAPPER = new EnumMapper<

--- a/packages/ccda/src/types.ts
+++ b/packages/ccda/src/types.ts
@@ -161,6 +161,7 @@ export interface CcdaProcedure {
 export interface CcdaAct {
   '@_classCode': string;
   '@_moodCode': string;
+  '@_negationInd'?: string;
   templateId?: CcdaTemplateId[];
   id?: CcdaId[];
   code: CcdaCode;


### PR DESCRIPTION
Fixes #10377

## Commit 1 — Honor `negationInd` when importing C-CDA Problem Observations

### Title

Honor negationInd when importing C-CDA Problem Observations

### Body

**Problem**

The C-CDA → FHIR importer never reads the `negationInd` attribute. A Problem
Observation (templateId `2.16.840.1.113883.10.20.22.4.4`) with
`negationInd="true"` — the C-CDA R2.1 representation of "condition ruled out"
(see the Problem Observation template `2.16.840.1.113883.10.20.22.4.4` and the
HL7 CDA R2 definition of `Act.negationInd`) — currently imports as an ordinary
Condition with `verificationStatus` hardcoded to `confirmed`.

This inverts the meaning of the source document: "pneumonia ruled out" becomes
"confirmed pneumonia" on the patient's problem list.

**Fix**

When `negationInd="true"` is present on the Problem Observation, or on the
wrapping Problem Concern Act (`2.16.840.1.113883.10.20.22.4.3`), emit the
Condition with:

```json
"verificationStatus": {
  "coding": [{
    "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
    "code": "refuted"
  }]
}
```

`refuted` is the FHIR R4 concept defined for exactly this case ("This condition
has been ruled out by diagnostic and clinical evidence"). Non-negated problems
import exactly as before.

**Changes**

- `types.ts`: add the optional `@_negationInd` attribute to `CcdaAct`
  (`CcdaObservation` already declared it).
- `ccda-to-fhir.ts`: new `createConditionVerificationStatus(act, observation)`
  helper replaces the hardcoded `confirmed` in `processConditionAct`.
- `negation.test.ts`: unit tests with minimal inline C-CDA documents covering
  observation-level negation, act-level negation, `negationInd="false"`, and
  the unchanged non-negated default.

**Notes for reviewers**

- Only the negated path uses `condition-ver-status`; the non-negated path keeps
  the existing system to leave current output byte-for-byte unchanged. Aligning
  the confirmed path to `condition-ver-status` (the system FHIR R4 binds for
  `Condition.verificationStatus`) is arguably also correct, but it changes
  existing output and test fixtures, so it is left for a separate discussion.
- Refuted conditions deliberately retain their `clinicalStatus`: FHIR R4
  invariant con-3 requires `clinicalStatus` on problem-list-item conditions
  unless `verificationStatus` is `entered-in-error`, so a refuted condition
  must still carry one.
- No change to the FHIR → C-CDA direction in this commit (the export
  counterpart lands in the third commit).

---

## Commit 2 — Derive Condition clinicalStatus from C-CDA Problem Concern Act semantics

### Title

Derive Condition clinicalStatus from C-CDA Problem Concern Act semantics

### Body

**Problem**

`processConditionAct` maps `Condition.clinicalStatus` through
`PROBLEM_STATUS_MAPPER` keyed on the concern act `statusCode`, defaulting to
`active`. That mapper's vocabulary does not match Problem Concern Act
semantics:

- The ProblemAct statusCode value set (`2.16.840.1.113883.11.20.9.19`) contains
  `active | suspended | aborted | completed`. `completed` — the normal state
  for a concern the clinician has closed — is not in the mapper, so a closed
  concern falls through to the default and imports as an **active** condition.
- `aborted` maps to a literal `aborted` code, which is not in the required
  FHIR R4 `condition-clinical` value set.

In C-CDA R2.1 the concern act's `statusCode` describes whether the concern is
still being tracked (Problem Concern Act template
`2.16.840.1.113883.10.20.22.4.3`: "the statusCode of the Problem Concern Act
is the definitive indication of the status of the concern"), while the nested
Problem Observation's (`2.16.840.1.113883.10.20.22.4.4`) own `statusCode` is
fixed at `completed` because it describes the recording act, not the problem.
The importer already reads the correct element; the mapping itself is what's
wrong.

**Fix**

Infer `clinicalStatus` (system
`http://terminology.hl7.org/CodeSystem/condition-clinical`) from the concern
act `statusCode`:

| Concern act statusCode | Condition.clinicalStatus |
| --- | --- |
| `active` | `active` |
| `suspended`, `aborted` | `inactive` |
| `completed`, with an `effectiveTime/high` on the concern act or problem observation | `resolved` |
| `completed`, without an `effectiveTime/high` | `inactive` |
| absent / unrecognized | `active` (previous default preserved) |

The `resolved` vs `inactive` split follows the FHIR definitions: `resolved`
asserts the condition has abated, which the document only supports when an end
date (`effectiveTime/high`) is asserted; a closed concern without an end date
is only known to be no longer tracked (`inactive`). This also keeps
`clinicalStatus=resolved` consistent with `Condition.abatementDateTime`, which
the importer already populates from the observation `effectiveTime/high`.

Additionally, when the optional Problem Status observation
(Problem Status template `2.16.840.1.113883.10.20.22.4.6`, LOINC `33999-4`) is present
inside the Problem Observation, its SNOMED CT value takes precedence over the
concern-act inference, since it is the document's direct statement of the
problem's status:

| SNOMED CT value | Condition.clinicalStatus |
| --- | --- |
| `55561003` (Active) | `active` |
| `73425007` (Inactive) | `inactive` |
| `413322009` (Resolved) | `resolved` |

An unrecognized Problem Status value falls back to the concern-act inference.

**Changes**

- `systems.ts`: new `PROBLEM_STATUS_OBSERVATION_MAPPER` (SNOMED CT Problem
  Status value set `2.16.840.1.113883.3.88.12.80.68` → FHIR
  `condition-clinical`), following the existing `EnumMapper` pattern.
- `ccda-to-fhir.ts`: new `createConditionClinicalStatus` /
  `mapConditionClinicalStatusCode` / `getProblemStatusObservationValue`
  helpers replace the `PROBLEM_STATUS_MAPPER` lookup in `processConditionAct`.
- `problem-status.test.ts`: unit tests with minimal inline C-CDA documents for
  each row of both tables above, plus the no-statusCode default and the
  unrecognized-code fallback.

**Notes for reviewers**

- The FHIR → C-CDA direction gets the matching mapping in the third commit,
  so the two directions are symmetric: `resolved`/`inactive` export as a
  `completed` concern act (with the end date carried on the act when known)
  and import back as `resolved`/`inactive`; `active` round-trips as `active`.
- Existing test data is unaffected: `ProblemPneumonia` uses an `active`
  concern act and continues to import as `active`.
- Health Concern Act entries route through the same code path and get the same
  corrected inference.

---

## Commit 3 — Make C-CDA problem export symmetric with concern act import semantics

### Title

Make C-CDA problem export symmetric with concern act import semantics

### Body

**Problem**

After the import fixes, the FHIR → C-CDA direction was still asymmetric.
`createProblemEntry` / `createHealthConcernEntry` mapped
`Condition.clinicalStatus` through `PROBLEM_STATUS_MAPPER`, which:

- has no entry for `resolved`, so a resolved Condition fell through the
  default and exported as an **active** concern act — a round trip silently
  reactivated resolved problems;
- exported `inactive` as `statusCode="inactive"`, which is not in the
  ProblemAct statusCode value set (`2.16.840.1.113883.11.20.9.19`:
  `active | suspended | aborted | completed`).

A refuted Condition also exported without `negationInd`, so "ruled out"
re-imported as confirmed.

**Fix**

Derive the concern act `statusCode` from `clinicalStatus`:

| Condition.clinicalStatus | Concern act statusCode |
| --- | --- |
| `inactive`, `resolved` | `completed` |
| `active`, `recurrence`, `relapse`, `remission`, absent, unrecognized | `active` (previous default preserved) |

`completed` is chosen for `inactive` (rather than `suspended`) because the
concern act statusCode tracks whether the concern is still being followed:
`completed` is the normal terminal state of a closed concern, while
`suspended`/`aborted` describe exceptional interruptions of the tracking
workflow that no FHIR condition-clinical code implies. It also mirrors the
import direction (`completed` + `effectiveTime/high` → `resolved`, without →
`inactive`), so both statuses survive a round trip.

A `completed` concern act carries `effectiveTime/high` from
`Condition.abatementDateTime` when present, and a refuted Condition
(`verificationStatus` containing `refuted`) exports `negationInd="true"` on
the Problem Observation, making negation symmetric as well.

The import comparison additionally accepts `negationInd="1"`, the other valid
`xs:boolean` true literal.

**Changes**

- `fhir-to-ccda/entries/condition.ts`: new
  `mapClinicalStatusToConcernActStatus` / `isConditionRefuted` helpers replace
  the `PROBLEM_STATUS_MAPPER` lookup in both the Problem Concern Act and
  Health Concern Act paths; concern act end date; observation `negationInd`.
- `ccda-to-fhir.ts`: `isNegationIndTrue` helper accepts `"true"` and `"1"`.
- `fhir-to-ccda/entries/condition.test.ts`: export unit tests for the new
  mapping, the concern act end date, and `negationInd`.
- `problem-status.test.ts` / `negation.test.ts`: round-trip tests proving
  `resolved`, `inactive`, `active`, and `refuted` survive
  import → export → re-import; xs:boolean `"1"`/`"0"` import tests.

**Notes for reviewers**

- `PROBLEM_STATUS_MAPPER` remains exported from `systems.ts` for API
  compatibility but is no longer used by either converter direction.
- A resolved Condition without an `abatementDateTime` exports as a
  `completed` concern act with no end date, which re-imports as `inactive` —
  the document has no element that asserts abatement without a date, so this
  is the closest faithful representation.
- Existing golden fixtures are unaffected (`ProblemPneumonia` is `active`).

---

## Test plan (all three commits)

- `npx vitest run` in `packages/ccda`: 289 passed, 1 skipped (existing suite
  green; 23 new tests: 8 in `negation.test.ts`, 11 in `problem-status.test.ts`,
  4 export tests in `fhir-to-ccda/entries/condition.test.ts`).
- `npx eslint .` and `npx tsc --noEmit` clean.
- `npm run build` (tsc + esbuild + api-extractor) succeeds.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
