### PR TITLE
refactor: consolidate landing page CTA buttons

### DIFF
--- a/packages/docs/src/components/landing/LandingPage.module.css
+++ b/packages/docs/src/components/landing/LandingPage.module.css
@@ -126,43 +126,14 @@
     width: 100%;
   }
 
-  .heroButtons > a,
-  .heroButtons > button {
+  .heroButtons>a,
+  .heroButtons>button {
     width: 100%;
   }
 }
 
-.heroButtons > a,
-.heroButtons > button {
-  display: inline-flex;
-  font-family: inherit;
-  font-weight: 500;
-  padding: 1.25rem 2rem;
-  gap: 0.5rem;
-  transition: all 200ms ease;
-  font-size: 1rem;
-  text-decoration: none;
-  align-items: center;
-  border: none;
-  border-radius: 2.5rem;
-  text-align: center;
-  justify-content: center;
-  cursor: pointer;
-}
 
-.heroButtons > a:hover,
-.heroButtons > button:hover {
-  text-decoration: none;
-}
 
-.purpleButton {
-  background-color: var(--oc-grape-8);
-  color: #fff;
-}
-
-.purpleButton:hover {
-  background-color: var(--oc-grape-9);
-}
 
 .ctaBanner {
   position: relative;
@@ -234,27 +205,6 @@
   }
 }
 
-.ctaWhiteButton {
-  background-color: white;
-  color: var(--oc-gray-8);
-  box-shadow: 0px 8px 16px rgba(var(--oc-violet-1-rgb), 0.5), 0px -1px 16px rgba(var(--oc-violet-1-rgb), 0.75);
-}
-
-.ctaWhiteButton:hover {
-  background-color: white;
-  color: var(--oc-grape-8);
-}
-
-[data-theme='dark'] .ctaWhiteButton {
-  background-color: #1B1B1D;
-  color: var(--oc-gray-2);
-  box-shadow: 0px 8px 16px rgba(var(--oc-grape-8-rgb), 0.25), 0px -1px 16px rgba(var(--oc-grape-8-rgb), 0.5);
-}
-
-[data-theme='dark'] .ctaWhiteButton:hover {
-  background-color: #1B1B1D;
-  color: var(--oc-grape-5);
-}
 
 .masonryGrid {
   column-count: 3;
@@ -263,7 +213,7 @@
   margin: 0;
 }
 
-.masonryGrid > p {
+.masonryGrid>p {
   margin: 0;
 }
 
@@ -281,7 +231,7 @@
   color: var(--oc-gray-4);
 }
 
-.masonryGrid > * {
+.masonryGrid>* {
   break-inside: avoid;
   margin-bottom: 1.5rem;
 }
@@ -297,4 +247,3 @@
     column-count: 1;
   }
 }
-

--- a/packages/docs/src/components/landing/LandingPage.tsx
+++ b/packages/docs/src/components/landing/LandingPage.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import Link from '@docusaurus/Link';
+// import Link from '@docusaurus/Link';
 import {
   IconApps,
   IconBrandOpenSource,
@@ -21,6 +21,7 @@ import { useNavbarScroll } from '../../hooks/useNavbarScroll';
 import { Card } from '../Card';
 import { BuildDropdown } from './BuildDropdown';
 import { Feature, FeatureGrid } from './FeatureGrid';
+import { LandingButton } from './LandingButton';
 import styles from './LandingPage.module.css';
 import { LogoScroller } from './LogoScroller';
 import { Section } from './Section';
@@ -28,7 +29,6 @@ import { SectionHeader } from './SectionHeader';
 import { SolutionAccordion } from './SolutionAccordion';
 import { StatsBento } from './StatsBento';
 import { TestimonialHeader } from './TestimonialHeader';
-
 export function LandingPage(): JSX.Element {
   useNavbarScroll();
 
@@ -45,11 +45,11 @@ export function LandingPage(): JSX.Element {
                 Start with our production-ready apps, then customize them to fit your needs.
               </p>
               <div className={styles.heroButtons}>
-                <Link to="/docs/provider" className={styles.purpleButton}>
-                  Explore the Provider App
-                </Link>
-                <BuildDropdown />
-              </div>
+  <LandingButton to="/docs/provider" variant="purple">
+    Explore the Provider App
+  </LandingButton>
+  <BuildDropdown />
+</div>
             </div>
             <div className={styles.heroImageContainer}>
               <img
@@ -248,13 +248,13 @@ export function LandingPage(): JSX.Element {
               compliant healthcare apps.
             </p>
             <div className={styles.heroButtons}>
-              <Link to="/docs" className={styles.ctaWhiteButton}>
-                See Documentation
-              </Link>
-              <Link to="https://cal.com/forms/9da7bfa2-40f5-461d-ad64-33d20bd32a7a" className={styles.purpleButton}>
-                Book a Demo
-              </Link>
-            </div>
+  <LandingButton to="/docs" variant="white">
+    See Documentation
+  </LandingButton>
+  <LandingButton to="https://cal.com/forms/9da7bfa2-40f5-461d-ad64-33d20bd32a7a" variant="purple">
+    Book a Demo
+  </LandingButton>
+</div>
           </div>
         </div>
       </Layout>

--- a/packages/docs/src/components/landing/ProductsCta.module.css
+++ b/packages/docs/src/components/landing/ProductsCta.module.css
@@ -68,45 +68,6 @@
 }
 
 /* Primary dropdown trigger (passed to BuildDropdown) + secondary link share one shape. */
-.startButton,
-.whiteButton {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--landing-btn-gap);
-  font-family: var(--landing-font-display);
-  font-weight: var(--landing-btn-weight);
-  font-size: var(--landing-btn-size);
-  padding: var(--landing-btn-padding);
-  border-radius: var(--landing-btn-radius);
-  border: none;
-  text-decoration: none;
-  cursor: pointer;
-  transition: all var(--landing-transition);
-  text-align: center;
-  justify-content: center;
-}
-
-.startButton {
-  background: var(--oc-grape-8);
-  color: #fff;
-}
-
-.startButton:hover {
-  background: var(--oc-grape-9);
-  color: #fff;
-}
-
-.whiteButton {
-  background: #fff;
-  color: var(--landing-color-heading);
-  box-shadow: var(--landing-shadow-cta-white);
-}
-
-.whiteButton:hover {
-  background: #fff;
-  color: var(--oc-grape-8);
-  text-decoration: none;
-}
 
 [data-theme='dark'] .section {
   background: var(--oc-gray-9);
@@ -116,16 +77,6 @@
   background: linear-gradient(to bottom, transparent, var(--oc-gray-9));
 }
 
-[data-theme='dark'] .whiteButton {
-  background: var(--landing-surface-elevated);
-  color: var(--oc-gray-2);
-  box-shadow: var(--landing-shadow-cta-white);
-}
-
-[data-theme='dark'] .whiteButton:hover {
-  background: var(--landing-surface-elevated);
-  color: var(--oc-grape-5);
-}
 
 [data-theme='dark'] .body {
   color: var(--landing-color-body-alt);

--- a/packages/docs/src/components/landing/ProductsCta.tsx
+++ b/packages/docs/src/components/landing/ProductsCta.tsx
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import Link from '@docusaurus/Link';
 import type { JSX } from 'react';
 import { useEffect, useState } from 'react';
 import { BuildDropdown } from './BuildDropdown';
+import { LandingButton } from './LandingButton';
+import { landingButtonClass } from './landingButtonClass';
 import styles from './ProductsCta.module.css';
 import { WindowChrome } from './WindowChrome';
 
@@ -70,10 +71,11 @@ export function ProductsCta(): JSX.Element {
               model, auth, and APIs. You own the experience and we&apos;ll handle the infrastructure underneath.
             </p>
             <div className={styles.buttons}>
-              <BuildDropdown label="Start Building" triggerClassName={styles.startButton} />
-              <Link to="/case-studies" className={styles.whiteButton}>
-                View Case Studies
-              </Link>
+              <BuildDropdown label="Start Building" triggerClassName={landingButtonClass('purple')} />
+
+<LandingButton to="/case-studies" variant="white">
+  View Case Studies
+</LandingButton>
             </div>
           </div>
 

--- a/packages/docs/src/components/landing/ProductsHero.module.css
+++ b/packages/docs/src/components/landing/ProductsHero.module.css
@@ -73,28 +73,6 @@
   gap: var(--landing-stack-gap);
 }
 
-.primaryButton {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--landing-btn-gap);
-  font-family: inherit;
-  font-weight: var(--landing-btn-weight);
-  font-size: var(--landing-btn-size);
-  padding: var(--landing-btn-padding);
-  border-radius: var(--landing-btn-radius);
-  border: none;
-  background: var(--oc-grape-8);
-  color: #fff;
-  text-decoration: none;
-  cursor: pointer;
-  transition: all var(--landing-transition);
-}
-
-.primaryButton:hover {
-  background: var(--oc-grape-9);
-  color: #fff;
-  text-decoration: none;
-}
 
 /* ── Hero composition: browser window at centre, capability/foundation chips around it ──
    A fixed 600×500 design space, scaled fluidly. Chips are placed by percentage so they

--- a/packages/docs/src/components/landing/ProductsHero.tsx
+++ b/packages/docs/src/components/landing/ProductsHero.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import Link from '@docusaurus/Link';
+import { LandingButton } from './LandingButton';
 import {
   IconCalendar,
   IconDatabase,
@@ -167,9 +167,12 @@ export function ProductsHero(): JSX.Element {
           <h1 className={styles.headline}>{HERO_HEADLINE}</h1>
           <p className={styles.lead}>{HERO_SUB}</p>
           <div className={styles.cta}>
-            <Link to="https://cal.com/forms/9da7bfa2-40f5-461d-ad64-33d20bd32a7a" className={styles.primaryButton}>
-              Book a Demo
-            </Link>
+            <LandingButton
+  to="https://cal.com/forms/9da7bfa2-40f5-461d-ad64-33d20bd32a7a"
+  variant="purple"
+>
+  Book a Demo
+</LandingButton>
             <BuildDropdown />
           </div>
         </div>


### PR DESCRIPTION
## Summary

Fixes #10340

Migrates all three remaining duplicated marketing CTA button implementations onto the shared `LandingButton` primitive and removes the duplicate button CSS.

### Changes

* **LandingPage**

  * Replaced the `purpleButton` hero CTA with `LandingButton`.
  * Replaced the `ctaWhiteButton` and `purpleButton` CTA banner buttons with `LandingButton`.
  * Kept `.heroButtons` responsible only for button-row layout.
  * Removed the duplicated button shape, variant, hover, and responsive styling.

* **ProductsHero**

  * Replaced the `primaryButton` CTA with `LandingButton`.
  * Removed the duplicated `.primaryButton` styling.

* **ProductsCta**

  * Updated the `BuildDropdown` trigger to use the shared landing button styling.
  * Replaced the `whiteButton` CTA with `LandingButton`.
  * Removed the duplicated `.startButton` and `.whiteButton` styling.

### Behavior

* Preserves the existing purple and white CTA variants.
* Preserves hover states and dark-theme styling.
* Preserves the existing responsive button layout.
* No new files or dependencies were added.

### Testing

* `git diff --check` passes.
* Verified the old CTA class names are no longer used by the affected landing-page components.
* No dependency changes.
