### PR TITLE
fix(agent): name the upgrader log at spawn time, not module load

### DIFF
--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -64,7 +64,7 @@ import type { AgentRetryDefaults, ChannelQueueWorker } from './queue/worker';
 import { isRetryMode, parseDispatchCallback } from './queue/worker';
 import { getCurrentStats, updateStat } from './stats';
 import type { HeartbeatEmitter } from './types';
-import { UPGRADER_LOG_PATH, UPGRADE_MANIFEST_PATH, parseDownloadUrl } from './upgrader-utils';
+import { UPGRADE_MANIFEST_PATH, getUpgraderLogPath, parseDownloadUrl } from './upgrader-utils';
 
 async function execAsync(
   command: string,
@@ -1609,7 +1609,7 @@ export class App {
 
     try {
       const command = __filename;
-      const logFile = openSync(UPGRADER_LOG_PATH, 'w+');
+      const logFile = openSync(getUpgraderLogPath(), 'w+');
       child = spawn(command, message.version ? ['--upgrade', message.version] : ['--upgrade'], {
         detached: true,
         stdio: ['ignore', logFile, logFile, 'ipc'],

--- a/packages/agent/src/upgrader-utils.test.ts
+++ b/packages/agent/src/upgrader-utils.test.ts
@@ -6,7 +6,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { platform } from 'node:os';
 import { resolve } from 'node:path';
 import { buildManifest } from './upgrader-test-utils';
-import { downloadRelease, getReleaseBinPath, parseDownloadUrl } from './upgrader-utils';
+import { downloadRelease, getReleaseBinPath, getUpgraderLogPath, parseDownloadUrl } from './upgrader-utils';
 
 const ALL_PLATFORMS_LIST = ['win32', 'linux', 'darwin'];
 const VALID_PLATFORMS_LIST = ['win32', 'linux'];
@@ -257,4 +257,18 @@ describe.each(VALID_PLATFORMS_LIST)('Upgrader Utils -- Valid Platforms -- %s', (
       fetchSpy.mockRestore();
     });
   });
+});
+
+test('getUpgraderLogPath -- timestamped per call, not per process', () => {
+  vi.useFakeTimers();
+  try {
+    vi.setSystemTime(new Date('2026-08-27T00:00:25.946Z'));
+    expect(getUpgraderLogPath()).toStrictEqual(resolve(__dirname, 'upgrader-logs-2026-08-27T00-00-25.946Z.txt'));
+
+    // A second upgrade from the same long-lived agent must land in its own file
+    vi.setSystemTime(new Date('2026-08-30T07:19:34.120Z'));
+    expect(getUpgraderLogPath()).toStrictEqual(resolve(__dirname, 'upgrader-logs-2026-08-30T07-19-34.120Z.txt'));
+  } finally {
+    vi.useRealTimers();
+  }
 });

--- a/packages/agent/src/upgrader-utils.ts
+++ b/packages/agent/src/upgrader-utils.ts
@@ -10,11 +10,20 @@ import { pipeline } from 'node:stream/promises';
 import type streamWeb from 'node:stream/web';
 
 export const UPGRADE_MANIFEST_PATH = resolve(__dirname, 'upgrade.json');
-export const UPGRADER_LOG_PATH = resolve(
-  __dirname,
-  `upgrader-logs-${new Date().toISOString().replaceAll(/:\s*/g, '-')}.txt`
-);
 export const RELEASES_PATH = resolve(__dirname);
+
+/**
+ * Builds the log file path for an upgrader process, timestamped at call time.
+ *
+ * Deliberately a function, not a module-level constant: an agent process can live for days between
+ * upgrades, so a load-time timestamp names the file after the agent's start rather than the upgrade,
+ * and every attempt by that agent truncates the same file.
+ *
+ * @returns The absolute path to the log file for this upgrade attempt.
+ */
+export function getUpgraderLogPath(): string {
+  return resolve(__dirname, `upgrader-logs-${new Date().toISOString().replaceAll(/:\s*/g, '-')}.txt`);
+}
 
 export async function downloadRelease(version: string, path: string): Promise<void> {
   const release = await fetchVersionManifest('agent-upgrader', version);


### PR DESCRIPTION
## Problem

`UPGRADER_LOG_PATH` was a module-level `const`, so the `new Date()` inside it was evaluated once at import — capturing when the **agent process started**, not when an upgrade ran. `tryUpgradeAgent` then reopens that same path with `'w+'` on every attempt.

Two consequences:

1. **The filename lies.** An agent process lives until the next release replaces it, so the log is named after that process's birth. On a real host the filenames and mtimes form a chain where each file's mtime equals the *next* file's filename:

   | filename (process start) | mtime (upgrade it actually recorded) |
   |---|---|
   | `upgrader-logs-2026-08-14T00-00-26.683Z.txt` | 8/21 00:00 |
   | `upgrader-logs-2026-08-21T00-00-23.138Z.txt` | 8/27 00:00 |
   | `upgrader-logs-2026-08-27T00-00-25.946Z.txt` | 8/30 07:19 |

2. **Retries destroy the evidence.** One log per process lifetime, truncated on each attempt. An agent that failed to hand off — e.g. one left orphaned by a stalled zero-downtime upgrade, which keeps accepting upgrade commands — overwrites the log of the attempt that first went wrong every time it retries. That's precisely the situation where the upgrader output is worth having.

## Change

Replace the const with `getUpgraderLogPath()`, called at spawn. Each attempt gets its own file, dated to the attempt.

`main.ts`'s `TEMP_LOG_FILE` is built the same way but left alone: `--remove-old-services` is a short-lived process, so its name and mtime already agree.

## Test plan

- New unit test pins the naming to call time via fake timers, so a future hoist back to a const fails.
- `src/app.test.ts`, `src/main.test.ts`, `src/upgrader.test.ts`, `src/upgrader-utils.test.ts` — 93 passed.
- `tsc --noEmit`, `eslint`, `prettier --check` clean.
