### PR TITLE
Update registerEnabled in new project flow

### DIFF
--- a/packages/docs/docs/self-hosting/server-config.md
+++ b/packages/docs/docs/self-hosting/server-config.md
@@ -282,7 +282,7 @@ Optional AWS CloudWatch Log Stream name for `AuditEvent` logs. Only applies if `
 
 ### registerEnabled
 
-Optional flag whether new user registration is enabled. See [Open Patient Registration](/docs/user-management/open-patient-registration) for more details.
+Optional flag whether new user registration is enabled. When `false`, the server rejects both new user registration (`/auth/newuser`) and new project creation (`/auth/newproject`). See [Open Patient Registration](/docs/user-management/open-patient-registration) for more details.
 
 **Default:** `true`
 

--- a/packages/server/src/auth/newproject.test.ts
+++ b/packages/server/src/auth/newproject.test.ts
@@ -28,6 +28,7 @@ describe('New project', () => {
 
   beforeEach(async () => {
     getConfig().requireVerifiedEmailForProjectCreation = undefined;
+    getConfig().registerEnabled = undefined;
     fetchMock.mockClear();
     setupRecaptchaMock(true);
   });
@@ -415,5 +416,46 @@ describe('New project', () => {
       projectName: 'Hamilton Project',
     });
     expect(res2).toHaveStatus(200);
+  });
+
+  test('Register disabled', async () => {
+    // Create the user while registration is still enabled
+    const email = `alex${randomUUID()}@example.com`;
+    const res1 = await request(app).post('/auth/newuser').type('json').send({
+      firstName: 'Alexander',
+      lastName: 'Hamilton',
+      email,
+      password: 'password!@#',
+      recaptchaToken: 'xyz',
+      codeChallenge: 'xyz',
+      codeChallengeMethod: 'plain',
+    });
+    expect(res1).toHaveStatus(200);
+
+    getConfig().registerEnabled = false;
+
+    const res2 = await request(app).post('/auth/newproject').type('json').send({
+      login: res1.body.login,
+      projectName: 'Hamilton Project',
+    });
+    expect(res2).toHaveStatus(400);
+    expect(res2.body).toMatchObject(badRequest('Registration is disabled'));
+
+    // An existing user must not be able to bypass the check by logging in with projectId "new"
+    const res3 = await request(app).post('/auth/login').type('json').send({
+      email,
+      password: 'password!@#',
+      projectId: 'new',
+      codeChallenge: 'xyz',
+      codeChallengeMethod: 'plain',
+    });
+    expect(res3).toHaveStatus(200);
+
+    const res4 = await request(app).post('/auth/newproject').type('json').send({
+      login: res3.body.login,
+      projectName: 'Hamilton Project',
+    });
+    expect(res4).toHaveStatus(400);
+    expect(res4.body).toMatchObject(badRequest('Registration is disabled'));
   });
 });

--- a/packages/server/src/auth/newproject.ts
+++ b/packages/server/src/auth/newproject.ts
@@ -31,6 +31,13 @@ export const newProjectValidator = makeValidationMiddleware([
  * @param res - The HTTP response.
  */
 export async function newProjectHandler(req: Request, res: Response): Promise<void> {
+  const config = getConfig();
+  if (config.registerEnabled === false) {
+    // Explicitly check for "false" because the config value may be undefined
+    sendOutcome(res, badRequest('Registration is disabled'));
+    return;
+  }
+
   const systemRepo = getGlobalSystemRepo();
   const login = await systemRepo.readResource<Login>('Login', req.body.login);
 
@@ -41,7 +48,7 @@ export async function newProjectHandler(req: Request, res: Response): Promise<vo
 
   const user = await systemRepo.readReference<User>(login.user as Reference<User>);
 
-  if (getConfig().requireVerifiedEmailForProjectCreation && !user.emailVerified) {
+  if (config.requireVerifiedEmailForProjectCreation && !user.emailVerified) {
     sendOutcome(res, badRequest('Email verification is required to create a project'));
     return;
   }


### PR DESCRIPTION
The `registerEnabled` server config setting is checked when a new user is created, but not when a new project is created. This PR adds the check to `POST /auth/newproject` so the setting covers the whole registration flow.

`registerEnabled` is currently enforced in two places:

- `POST /auth/newuser` — `packages/server/src/auth/newuser.ts`
- `POST /auth/google` — `packages/server/src/auth/google.ts`, when the user does not already exist

Self-hosted registration is a two-step flow: create the user, then create the project. Only the first step consults the setting. A user account that already exists can obtain a partial login with no membership by signing in with `projectId: 'new'` (`allowNoMembership` in `login.ts` and `google.ts`), and then call `/auth/newproject` successfully. That includes users created before the setting was turned off, and users who belong to a project via invite or patient registration.
