### PR TITLE
Check for email domain in user creation flows

### DIFF
--- a/packages/server/src/admin/invite.test.ts
+++ b/packages/server/src/admin/invite.test.ts
@@ -2,7 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 import { SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2';
 import type { WithId } from '@medplum/core';
-import { allOk, badRequest, ContentType, createReference, getReferenceString, normalizeErrorString } from '@medplum/core';
+import {
+  allOk,
+  badRequest,
+  ContentType,
+  createReference,
+  getReferenceString,
+  normalizeErrorString,
+} from '@medplum/core';
 import type {
   AccessPolicy,
   BundleEntry,

--- a/packages/server/src/admin/invite.test.ts
+++ b/packages/server/src/admin/invite.test.ts
@@ -1,12 +1,14 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2';
-import { allOk, ContentType, createReference, getReferenceString, normalizeErrorString } from '@medplum/core';
+import type { WithId } from '@medplum/core';
+import { allOk, badRequest, ContentType, createReference, getReferenceString, normalizeErrorString } from '@medplum/core';
 import type {
   AccessPolicy,
   BundleEntry,
   Patient,
   Practitioner,
+  Project,
   ProjectMembership,
   Reference,
   RelatedPerson,
@@ -23,7 +25,7 @@ import request from 'supertest';
 import { vi } from 'vitest';
 import { initApp, shutdownApp } from '../app';
 import { registerNew } from '../auth/register';
-import { loadTestConfig } from '../config/loader';
+import { getConfig, loadTestConfig } from '../config/loader';
 import { DatabaseMode, getDatabasePool } from '../database';
 import { getProjectSystemRepo } from '../fhir/repo';
 import { SelectQuery } from '../fhir/sql';
@@ -32,6 +34,16 @@ import { inviteUser } from './invite';
 
 const fetchMock = vi.spyOn(globalThis, 'fetch');
 const app = express();
+
+async function addAllowedEmailDomain(project: WithId<Project>, domain: string): Promise<WithId<Project>> {
+  const systemRepo = await getProjectSystemRepo(project);
+  return withTestContext(() =>
+    systemRepo.updateResource<Project>({
+      ...project,
+      setting: [...(project.setting ?? []), { name: 'allowedEmailDomain', valueString: domain }],
+    })
+  );
+}
 
 describe('Admin Invite', () => {
   let mockSESv2Client: AwsClientStub<SESv2Client>;
@@ -52,6 +64,7 @@ describe('Admin Invite', () => {
 
     fetchMock.mockClear();
     setupRecaptchaMock(true);
+    getConfig().blockedEmailDomains = undefined;
   });
 
   afterEach(() => {
@@ -2115,4 +2128,165 @@ describe('Admin Invite', () => {
 
       expect(membership.accessPolicy).toBeUndefined();
     }));
+
+  test('Invite with allowed email domain succeeds', async () => {
+    const { project, accessToken } = await withTestContext(() =>
+      registerNew({
+        firstName: 'Alice',
+        lastName: 'Smith',
+        projectName: 'Alice Project',
+        email: `alice${randomUUID()}@example.com`,
+        password: 'password!@#',
+      })
+    );
+    const restricted = await addAllowedEmailDomain(project, 'allowed.example.com');
+
+    const res = await request(app)
+      .post('/admin/projects/' + restricted.id + '/invite')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        resourceType: 'Practitioner',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        email: `bob${randomUUID()}@allowed.example.com`,
+        sendEmail: false,
+      });
+
+    expect(res).toHaveStatus(200);
+  });
+
+  test('Invite with disallowed email domain is rejected', async () => {
+    const { project, accessToken } = await withTestContext(() =>
+      registerNew({
+        firstName: 'Alice',
+        lastName: 'Smith',
+        projectName: 'Alice Project',
+        email: `alice${randomUUID()}@example.com`,
+        password: 'password!@#',
+      })
+    );
+    const restricted = await addAllowedEmailDomain(project, 'allowed.example.com');
+
+    const res = await request(app)
+      .post('/admin/projects/' + restricted.id + '/invite')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        resourceType: 'Practitioner',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        email: `bob${randomUUID()}@other.example.com`,
+        sendEmail: false,
+      });
+
+    expect(res).toHaveStatus(400);
+    expect(res.body).toMatchObject(badRequest('Email domain is not allowed for this project', 'email'));
+  });
+
+  test('Invite by externalId is unaffected by allowed domain restrictions', async () => {
+    const { project, accessToken } = await withTestContext(() =>
+      registerNew({
+        firstName: 'Alice',
+        lastName: 'Smith',
+        projectName: 'Alice Project',
+        email: `alice${randomUUID()}@example.com`,
+        password: 'password!@#',
+      })
+    );
+    const restricted = await addAllowedEmailDomain(project, 'allowed.example.com');
+
+    const res = await request(app)
+      .post('/admin/projects/' + restricted.id + '/invite')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        resourceType: 'Practitioner',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        externalId: randomUUID(),
+        sendEmail: false,
+      });
+
+    expect(res).toHaveStatus(200);
+  });
+
+  test('Super admin invite bypasses allowed domain restriction', async () => {
+    const { project } = await withTestContext(() =>
+      registerNew({
+        firstName: 'Alice',
+        lastName: 'Smith',
+        projectName: 'Alice Project',
+        email: `alice${randomUUID()}@example.com`,
+        password: 'password!@#',
+      })
+    );
+    const restricted = await addAllowedEmailDomain(project, 'allowed.example.com');
+
+    const superAdminAccessToken = await initTestAuth({ superAdmin: true });
+    const res = await request(app)
+      .post('/admin/projects/' + restricted.id + '/invite')
+      .set('Authorization', 'Bearer ' + superAdminAccessToken)
+      .send({
+        resourceType: 'Practitioner',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        email: `bob${randomUUID()}@other.example.com`,
+        sendEmail: false,
+      });
+
+    expect(res).toHaveStatus(200);
+  });
+
+  test('Invite with blocked email domain is rejected even without project restrictions', async () => {
+    const { project, accessToken } = await withTestContext(() =>
+      registerNew({
+        firstName: 'Alice',
+        lastName: 'Smith',
+        projectName: 'Alice Project',
+        email: `alice${randomUUID()}@example.com`,
+        password: 'password!@#',
+      })
+    );
+    getConfig().blockedEmailDomains = ['blocked.example.com'];
+
+    const res = await request(app)
+      .post('/admin/projects/' + project.id + '/invite')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        resourceType: 'Practitioner',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        email: `bob${randomUUID()}@blocked.example.com`,
+        sendEmail: false,
+      });
+
+    expect(res).toHaveStatus(400);
+    expect(res.body).toMatchObject(badRequest('Email domain is not allowed for this project', 'email'));
+  });
+
+  test('Invite with blocked email domain takes precedence over an allowed domain setting', async () => {
+    const { project, accessToken } = await withTestContext(() =>
+      registerNew({
+        firstName: 'Alice',
+        lastName: 'Smith',
+        projectName: 'Alice Project',
+        email: `alice${randomUUID()}@example.com`,
+        password: 'password!@#',
+      })
+    );
+    const restricted = await addAllowedEmailDomain(project, 'blocked.example.com');
+    getConfig().blockedEmailDomains = ['blocked.example.com'];
+
+    const res = await request(app)
+      .post('/admin/projects/' + restricted.id + '/invite')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        resourceType: 'Practitioner',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        email: `bob${randomUUID()}@blocked.example.com`,
+        sendEmail: false,
+      });
+
+    expect(res).toHaveStatus(400);
+    expect(res.body).toMatchObject(badRequest('Email domain is not allowed for this project', 'email'));
+  });
 });

--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -29,7 +29,7 @@ import { body, oneOf } from 'express-validator';
 import type Mail from 'nodemailer/lib/mailer';
 import { authenticator } from 'otplib';
 import { resetPassword } from '../auth/resetpassword';
-import { bcryptHashPassword, createProjectMembership } from '../auth/utils';
+import { bcryptHashPassword, createProjectMembership, isEmailDomainAllowed } from '../auth/utils';
 import { getConfig } from '../config/loader';
 import { MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH } from '../constants';
 import { getAuthenticatedContext, tryGetRequestContext } from '../context';
@@ -98,6 +98,11 @@ export async function inviteUser(request: ServerInviteRequest): Promise<ServerIn
   }
 
   const { project, email } = request;
+  const invitedBySuperAdmin = tryGetRequestContext()?.authState?.project?.superAdmin;
+  if (email && !invitedBySuperAdmin && !isEmailDomainAllowed(email, project, getConfig().blockedEmailDomains)) {
+    throw new OperationOutcomeError(badRequest('Email domain is not allowed for this project', 'email'));
+  }
+
   let existingUser = false;
   let passwordResetUrl: string | undefined;
 

--- a/packages/server/src/auth/newuser.test.ts
+++ b/packages/server/src/auth/newuser.test.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
 import { Operator, badRequest } from '@medplum/core';
-import type { OperationOutcome, User } from '@medplum/fhirtypes';
+import type { OperationOutcome, Project, User } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import { pwnedPassword } from 'hibp';
@@ -17,6 +18,16 @@ import { registerNew } from './register';
 const fetchMock = vi.spyOn(globalThis, 'fetch');
 const app = express();
 
+async function addAllowedEmailDomain(project: WithId<Project>, domain: string): Promise<WithId<Project>> {
+  const systemRepo = await getProjectSystemRepo(project);
+  return withTestContext(() =>
+    systemRepo.updateResource<Project>({
+      ...project,
+      setting: [...(project.setting ?? []), { name: 'allowedEmailDomain', valueString: domain }],
+    })
+  );
+}
+
 describe('New user', () => {
   let prevRecaptchaSecretKey: string | undefined;
   beforeAll(async () => {
@@ -28,6 +39,7 @@ describe('New user', () => {
   beforeEach(() => {
     getConfig().registerEnabled = undefined;
     getConfig().requireVerifiedEmailForProjectCreation = undefined;
+    getConfig().blockedEmailDomains = undefined;
   });
 
   afterAll(async () => {
@@ -665,5 +677,175 @@ describe('New user', () => {
     expect(res.body.login).toBeDefined();
     expect(res.body.code).toBeUndefined();
     expect(res.body.emailVerificationRequired).toBe(true);
+  });
+
+  test('Allowed email domain succeeds', async () => {
+    const { project } = await withTestContext(() =>
+      registerNew({
+        firstName: 'Owner',
+        lastName: 'Owner',
+        projectName: 'AllowedDomainTest',
+        email: `owner${randomUUID()}@example.com`,
+        password: 'password!@#',
+      })
+    );
+    const restricted = await addAllowedEmailDomain(project, 'allowed.example.com');
+
+    const res = await request(app)
+      .post('/auth/newuser')
+      .type('json')
+      .send({
+        projectId: restricted.id,
+        firstName: 'Patient',
+        lastName: 'Allowed',
+        email: `patient${randomUUID()}@allowed.example.com`,
+        password: 'password!@#',
+        recaptchaToken: 'xyz',
+      });
+
+    expect(res).toHaveStatus(200);
+    expect(res.body.login).toBeDefined();
+  });
+
+  test('Disallowed email domain is rejected', async () => {
+    const { project } = await withTestContext(() =>
+      registerNew({
+        firstName: 'Owner',
+        lastName: 'Owner',
+        projectName: 'DisallowedDomainTest',
+        email: `owner${randomUUID()}@example.com`,
+        password: 'password!@#',
+      })
+    );
+    const restricted = await addAllowedEmailDomain(project, 'allowed.example.com');
+
+    const res = await request(app)
+      .post('/auth/newuser')
+      .type('json')
+      .send({
+        projectId: restricted.id,
+        firstName: 'Patient',
+        lastName: 'Disallowed',
+        email: `patient${randomUUID()}@other.example.com`,
+        password: 'password!@#',
+        recaptchaToken: 'xyz',
+      });
+
+    expect(res).toHaveStatus(400);
+    expect(res.body).toMatchObject(badRequest('Email domain is not allowed for this project', 'email'));
+  });
+
+  test('Email matching either of multiple allowed domains succeeds', async () => {
+    const { project } = await withTestContext(() =>
+      registerNew({
+        firstName: 'Owner',
+        lastName: 'Owner',
+        projectName: 'MultiDomainTest',
+        email: `owner${randomUUID()}@example.com`,
+        password: 'password!@#',
+      })
+    );
+    let restricted = await addAllowedEmailDomain(project, 'first.example.com');
+    restricted = await addAllowedEmailDomain(restricted, 'second.example.com');
+
+    const res1 = await request(app)
+      .post('/auth/newuser')
+      .type('json')
+      .send({
+        projectId: restricted.id,
+        firstName: 'Patient',
+        lastName: 'One',
+        email: `patient${randomUUID()}@first.example.com`,
+        password: 'password!@#',
+        recaptchaToken: 'xyz',
+      });
+    expect(res1).toHaveStatus(200);
+
+    const res2 = await request(app)
+      .post('/auth/newuser')
+      .type('json')
+      .send({
+        projectId: restricted.id,
+        firstName: 'Patient',
+        lastName: 'Two',
+        email: `patient${randomUUID()}@second.example.com`,
+        password: 'password!@#',
+        recaptchaToken: 'xyz',
+      });
+    expect(res2).toHaveStatus(200);
+  });
+
+  test('New project registration is unaffected by allowed domain restrictions', async () => {
+    const res = await request(app)
+      .post('/auth/newuser')
+      .type('json')
+      .send({
+        firstName: 'Brand',
+        lastName: 'New',
+        email: `brandnew${randomUUID()}@anydomain.com`,
+        password: 'password!@#',
+        recaptchaToken: 'xyz',
+        projectId: 'new',
+      });
+
+    expect(res).toHaveStatus(200);
+    expect(res.body.login).toBeDefined();
+  });
+
+  test('Blocked email domain is rejected even without project restrictions', async () => {
+    const { project } = await withTestContext(() =>
+      registerNew({
+        firstName: 'Owner',
+        lastName: 'Owner',
+        projectName: 'BlockedDomainTest',
+        email: `owner${randomUUID()}@example.com`,
+        password: 'password!@#',
+      })
+    );
+    getConfig().blockedEmailDomains = ['blocked.example.com'];
+
+    const res = await request(app)
+      .post('/auth/newuser')
+      .type('json')
+      .send({
+        projectId: project.id,
+        firstName: 'Patient',
+        lastName: 'Blocked',
+        email: `patient${randomUUID()}@blocked.example.com`,
+        password: 'password!@#',
+        recaptchaToken: 'xyz',
+      });
+
+    expect(res).toHaveStatus(400);
+    expect(res.body).toMatchObject(badRequest('Email domain is not allowed for this project', 'email'));
+  });
+
+  test('Blocked email domain takes precedence over an allowed domain setting', async () => {
+    const { project } = await withTestContext(() =>
+      registerNew({
+        firstName: 'Owner',
+        lastName: 'Owner',
+        projectName: 'BlockedOverridesAllowedTest',
+        email: `owner${randomUUID()}@example.com`,
+        password: 'password!@#',
+      })
+    );
+    const restricted = await addAllowedEmailDomain(project, 'blocked.example.com');
+    getConfig().blockedEmailDomains = ['blocked.example.com'];
+
+    const res = await request(app)
+      .post('/auth/newuser')
+      .type('json')
+      .send({
+        projectId: restricted.id,
+        firstName: 'Patient',
+        lastName: 'Blocked',
+        email: `patient${randomUUID()}@blocked.example.com`,
+        password: 'password!@#',
+        recaptchaToken: 'xyz',
+      });
+
+    expect(res).toHaveStatus(400);
+    expect(res.body).toMatchObject(badRequest('Email domain is not allowed for this project', 'email'));
   });
 });

--- a/packages/server/src/auth/newuser.ts
+++ b/packages/server/src/auth/newuser.ts
@@ -15,7 +15,7 @@ import { getGlobalSystemRepo } from '../fhir/repo';
 import { globalLogger } from '../logger';
 import { getUserByEmailInProject, getUserByEmailWithoutProject, tryLogin } from '../oauth/utils';
 import { makeValidationMiddleware } from '../util/validator';
-import { bcryptHashPassword } from './utils';
+import { bcryptHashPassword, isEmailDomainAllowed } from './utils';
 import { verifyEmail } from './verifyemail';
 
 export const newUserValidator = makeValidationMiddleware([
@@ -66,6 +66,21 @@ export async function newUserHandler(req: Request, res: Response): Promise<void>
   // If the user is a practitioner, then projectId should be undefined
   // If the user is a patient, then projectId must be set
   const email = req.body.email.toLowerCase();
+
+  if (projectId && projectId !== 'new') {
+    let project: Project;
+    try {
+      project = await getGlobalSystemRepo().readResource<Project>('Project', projectId);
+    } catch (err) {
+      sendOutcome(res, normalizeOperationOutcome(err));
+      return;
+    }
+    if (!isEmailDomainAllowed(email, project, config.blockedEmailDomains)) {
+      sendOutcome(res, badRequest('Email domain is not allowed for this project', 'email'));
+      return;
+    }
+  }
+
   let existingUser = undefined;
   if (req.body.projectId && req.body.projectId !== 'new') {
     existingUser = await getUserByEmailInProject(email, req.body.projectId);

--- a/packages/server/src/auth/utils.test.ts
+++ b/packages/server/src/auth/utils.test.ts
@@ -3,7 +3,7 @@
 import { OperationOutcomeError } from '@medplum/core';
 import type { Project, User } from '@medplum/fhirtypes';
 import { MAX_PASSWORD_LENGTH } from '../constants';
-import { bcryptHashPassword, isMfaRequired } from './utils';
+import { bcryptHashPassword, isEmailDomainAllowed, isMfaRequired } from './utils';
 
 describe('isMfaRequired', () => {
   function createMfaTestUser(mfaRequired?: boolean): User {
@@ -40,6 +40,84 @@ describe('isMfaRequired', () => {
     expect(isMfaRequired(createMfaTestUser(true), undefined)).toBe(true);
     // A project that does not require MFA leaves an unset user unaffected.
     expect(isMfaRequired(createMfaTestUser(), projectWithSetting(false))).toBe(false);
+  });
+});
+
+describe('isEmailDomainAllowed', () => {
+  function projectWithAllowedDomains(...domains: (string | undefined)[]): Project {
+    return {
+      resourceType: 'Project',
+      setting: domains.map((valueString) => ({ name: 'allowedEmailDomain', valueString })),
+    };
+  }
+
+  test('Allows any domain when project is unset', () => {
+    expect(isEmailDomainAllowed('user@acme.com', undefined)).toBe(true);
+  });
+
+  test('Allows any domain when project has no settings', () => {
+    expect(isEmailDomainAllowed('user@acme.com', { resourceType: 'Project' })).toBe(true);
+  });
+
+  test('Allows any domain when project has unrelated settings only', () => {
+    const project: Project = { resourceType: 'Project', setting: [{ name: 'mfaRequired', valueBoolean: true }] };
+    expect(isEmailDomainAllowed('user@acme.com', project)).toBe(true);
+  });
+
+  test('Allows a matching domain and rejects a non-matching one', () => {
+    const project = projectWithAllowedDomains('acme.com');
+    expect(isEmailDomainAllowed('user@acme.com', project)).toBe(true);
+    expect(isEmailDomainAllowed('user@other.com', project)).toBe(false);
+  });
+
+  test('Allows an email matching any of multiple repeated settings', () => {
+    const project = projectWithAllowedDomains('acme.com', 'example.org');
+    expect(isEmailDomainAllowed('user@acme.com', project)).toBe(true);
+    expect(isEmailDomainAllowed('user@example.org', project)).toBe(true);
+    expect(isEmailDomainAllowed('user@other.com', project)).toBe(false);
+  });
+
+  test('Does not allow subdomains of an allowed domain', () => {
+    const project = projectWithAllowedDomains('acme.com');
+    expect(isEmailDomainAllowed('user@mail.acme.com', project)).toBe(false);
+  });
+
+  test('Matches case-insensitively on both sides', () => {
+    const project = projectWithAllowedDomains('Acme.COM');
+    expect(isEmailDomainAllowed('user@acme.com', project)).toBe(true);
+    expect(isEmailDomainAllowed('USER@ACME.COM', project)).toBe(true);
+  });
+
+  test('Ignores an empty or missing valueString', () => {
+    const onlyEmpty = projectWithAllowedDomains('', undefined);
+    expect(isEmailDomainAllowed('user@anything.com', onlyEmpty)).toBe(true);
+
+    const mixed = projectWithAllowedDomains('', 'acme.com');
+    expect(isEmailDomainAllowed('user@acme.com', mixed)).toBe(true);
+    expect(isEmailDomainAllowed('user@other.com', mixed)).toBe(false);
+  });
+
+  test('Trims whitespace around a configured domain', () => {
+    const project = projectWithAllowedDomains(' acme.com ');
+    expect(isEmailDomainAllowed('user@acme.com', project)).toBe(true);
+  });
+
+  test('Allows any domain when the blocked list is empty', () => {
+    expect(isEmailDomainAllowed('user@acme.com', undefined, [])).toBe(true);
+  });
+
+  test('Rejects a domain on the blocked list even when the project has no restrictions', () => {
+    expect(isEmailDomainAllowed('user@blocked.com', undefined, ['blocked.com'])).toBe(false);
+    expect(isEmailDomainAllowed('user@acme.com', undefined, ['blocked.com'])).toBe(true);
+  });
+
+  test('Rejects a blocked domain even when it is in the project allowed list', () => {
+    const project = projectWithAllowedDomains('acme.com');
+    expect(isEmailDomainAllowed('user@acme.com', project, ['acme.com'])).toBe(false);
+  });
+
+  test('Matches blocked domains case-insensitively and trims whitespace', () => {
+    expect(isEmailDomainAllowed('USER@BLOCKED.COM', undefined, [' Blocked.COM '])).toBe(false);
   });
 });
 

--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -63,6 +63,45 @@ export function getAllowedMfaMethods(project: Project | undefined): MfaMethod[] 
   return methods.length > 0 ? methods : ['totp'];
 }
 
+export function getAllowedEmailDomains(project: Project | undefined): string[] {
+  return (
+    project?.setting
+      ?.filter((s) => s.name === 'allowedEmailDomain')
+      .map((s) => s.valueString?.trim().toLowerCase())
+      .filter((domain): domain is string => !!domain) ?? []
+  );
+}
+
+/**
+ * Determines whether an email address is allowed to be used for a new user or invite.
+ *
+ * `blockedDomains` (typically the server-wide `blockedEmailDomains` config setting) always
+ * takes precedence: a blocked domain is rejected even if it also appears in the project's
+ * `allowedEmailDomain` setting.
+ * @param email - The email address to check.
+ * @param project - The project the email is being used with, if known.
+ * @param blockedDomains - Domains that are never allowed, regardless of project settings.
+ * @returns True if the email's domain is allowed.
+ */
+export function isEmailDomainAllowed(
+  email: string,
+  project: Project | undefined,
+  blockedDomains: string[] = []
+): boolean {
+  const atIndex = email.lastIndexOf('@');
+  const domain = atIndex === -1 ? '' : email.slice(atIndex + 1).toLowerCase();
+
+  if (blockedDomains.some((blocked) => blocked.trim().toLowerCase() === domain)) {
+    return false;
+  }
+
+  const allowedDomains = getAllowedEmailDomains(project);
+  if (allowedDomains.length === 0) {
+    return true;
+  }
+  return allowedDomains.includes(domain);
+}
+
 /**
  * Determines whether MFA is required for a user logging in to a project.
  *

--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -229,6 +229,13 @@ export interface MedplumServerConfig {
   requireVerifiedEmailForProjectCreation?: boolean;
 
   /**
+   * Optional list of email domains that are blocked server-wide, regardless of
+   * any project-level `allowedEmailDomain` setting (e.g. disposable email providers).
+   * Matched case-insensitively against the domain portion of the email address.
+   */
+  blockedEmailDomains?: string[];
+
+  /**
    * Optional flag to allow outbound fetch requests to private/local networks.
    * Intended only for on-premises deployments that connect to trusted local services.
    * Do not enable in hosted or cloud-managed environments.

--- a/packages/server/src/config/utils.test.ts
+++ b/packages/server/src/config/utils.test.ts
@@ -98,6 +98,14 @@ describe('utils', () => {
     });
   });
 
+  test('setValue stores blockedEmailDomains as comma-separated list', () => {
+    const config = {};
+    setValue(config, 'blockedEmailDomains', 'example.com,test.com');
+    expect(config).toEqual({
+      blockedEmailDomains: ['example.com', 'test.com'],
+    });
+  });
+
   test('setValue parses objects', () => {
     const config = {};
     const jsonData = '{"host":"smtp.example.com","port":587,"username":"username","password":"p@ssw0rd"}';

--- a/packages/server/src/config/utils.ts
+++ b/packages/server/src/config/utils.ts
@@ -230,7 +230,11 @@ export function isObjectConfig(key: string): boolean {
   return objectKeys.has(key);
 }
 
-const arrayKeys = new Set(['dataWarehouse.includeResourceTypes', 'dataWarehouse.excludeResourceTypes']);
+const arrayKeys = new Set([
+  'dataWarehouse.includeResourceTypes',
+  'dataWarehouse.excludeResourceTypes',
+  'blockedEmailDomains',
+]);
 
 export function isArrayConfig(key: string): boolean {
   return arrayKeys.has(key);


### PR DESCRIPTION
Adds both a Project-level allowlist and a server-level blocklist for email domains in registration and invite flows