### PR TITLE
Remove inadvertant BullMQ dedupe IDs

### DIFF
--- a/packages/app/src/admin/SuperAdminPage.test.tsx
+++ b/packages/app/src/admin/SuperAdminPage.test.tsx
@@ -286,7 +286,7 @@ describe('SuperAdminPage', () => {
     startAsyncRequestSpy.mockRestore();
   });
 
-  test('Reindex database', async () => {
+  test('Rebuild Indexes', async () => {
     setup();
     const startAsyncRequestSpy = vi.spyOn(medplum, 'startAsyncRequest').mockResolvedValueOnce({
       resourceType: 'AsyncJob',
@@ -302,11 +302,11 @@ describe('SuperAdminPage', () => {
       fireEvent.change(screen.getByLabelText('Target name 2 *'), { target: { value: 'Patient_name_idx' } });
     });
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: 'Reindex Database' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Rebuild Indexes' }));
     });
 
     expect(screen.getByText('View AsyncJob')).toBeInTheDocument();
-    expect(startAsyncRequestSpy).toHaveBeenCalledWith('admin/super/reindex-database', {
+    expect(startAsyncRequestSpy).toHaveBeenCalledWith('admin/super/rebuild-index', {
       method: 'POST',
       pollStatusOnAccepted: true,
       body: JSON.stringify({ targets: [{ table: 'Observation' }, { index: 'Patient_name_idx' }] }),
@@ -314,7 +314,7 @@ describe('SuperAdminPage', () => {
     startAsyncRequestSpy.mockRestore();
   });
 
-  test('Reindex database limits targets to 10', async () => {
+  test('Rebuild index limits targets to 10', async () => {
     setup();
     const addTargetButton = screen.getByRole('button', { name: 'Add Target' });
 

--- a/packages/app/src/admin/SuperAdminPage.tsx
+++ b/packages/app/src/admin/SuperAdminPage.tsx
@@ -165,7 +165,7 @@ export function SuperAdminPage(): JSX.Element {
   }
 
   function rebuildIndex(targets: DatabaseReindexTarget[]): void {
-    startAsyncJob(medplum, 'Reindexing Database', 'admin/super/rebuild-index', { targets });
+    startAsyncJob(medplum, 'Rebuilding indexes', 'admin/super/rebuild-index', { targets });
   }
 
   return (

--- a/packages/app/src/admin/SuperAdminPage.tsx
+++ b/packages/app/src/admin/SuperAdminPage.tsx
@@ -164,8 +164,8 @@ export function SuperAdminPage(): JSX.Element {
     startAsyncJob(medplum, 'Reconcile Schema Diff', 'admin/super/reconcile-db-schema-drift');
   }
 
-  function reindexDatabase(targets: DatabaseReindexTarget[]): void {
-    startAsyncJob(medplum, 'Reindexing Database', 'admin/super/reindex-database', { targets });
+  function rebuildIndex(targets: DatabaseReindexTarget[]): void {
+    startAsyncJob(medplum, 'Reindexing Database', 'admin/super/rebuild-index', { targets });
   }
 
   return (
@@ -350,12 +350,12 @@ export function SuperAdminPage(): JSX.Element {
       <Divider my="lg" />
       <RescopeUserWidget />
       <Divider my="lg" />
-      <Title order={2}>Reindex Database</Title>
+      <Title order={2}>Rebuild Indexes</Title>
       <p>
         Rebuild one or more PostgreSQL table or index targets concurrently. The operation runs asynchronously and may
         take a long time to complete.
       </p>
-      <DatabaseReindexForm onSubmit={reindexDatabase} />
+      <DatabaseReindexForm onSubmit={rebuildIndex} />
     </Document>
   );
 }
@@ -426,7 +426,7 @@ function DatabaseReindexForm({
             Add Target
           </Button>
           <Button type="submit" disabled={targets.some((target) => !target.name.trim())}>
-            Reindex Database
+            Rebuild Indexes
           </Button>
         </Group>
       </Stack>

--- a/packages/server/src/admin/super.ts
+++ b/packages/server/src/admin/super.ts
@@ -475,7 +475,7 @@ superAdminRouter.post(
       return;
     }
 
-    const targets = req.body.targets as ReindexTarget[];
+    const targets = req.body.targets as RebuildIndexTarget[];
     const migrationActions = {
       preDeploy: [],
       postDeploy: targets.map((target) =>
@@ -506,7 +506,7 @@ superAdminRouter.post(
   }
 );
 
-type ReindexTarget = { table: string } | { index: string };
+type RebuildIndexTarget = { table: string } | { index: string };
 
 // POST to /admin/super/setdataversion
 // to set the data version of the database.

--- a/packages/server/src/admin/super.ts
+++ b/packages/server/src/admin/super.ts
@@ -437,10 +437,10 @@ superAdminRouter.post('/reconcile-db-schema-drift', async (req: Request, res: Re
   sendOutcome(res, accepted(exec.getContentLocation(baseUrl)));
 });
 
-// POST to /admin/super/reindex-database
+// POST to /admin/super/rebuild-index
 // to rebuild one or more PostgreSQL indexes without blocking writes.
 superAdminRouter.post(
-  '/reindex-database',
+  '/rebuild-index',
   [
     body('targets').isArray({ min: 1, max: 10 }).withMessage('targets must be an array containing 1 to 10 items'),
     body('targets.*')

--- a/packages/server/src/database-migration.test.ts
+++ b/packages/server/src/database-migration.test.ts
@@ -850,13 +850,13 @@ describe('Database migrations', () => {
       });
     });
 
-    describe('Reindex database', () => {
+    describe('Rebuild index', () => {
       test('Queues one or more concurrent reindex actions', async () => {
         const targets = [{ index: 'Patient_name_idx' }, { table: 'Observation' }];
         const queueAddSpy = getQueueAddSpy();
 
         const res = await request(app)
-          .post('/admin/super/reindex-database')
+          .post('/admin/super/rebuild-index')
           .set('Authorization', 'Bearer ' + adminAccessToken)
           .set('Prefer', 'respond-async')
           .type('json')
@@ -877,7 +877,7 @@ describe('Database migrations', () => {
           },
         });
         const asyncJob = await systemRepo.readResource<AsyncJob>('AsyncJob', jobData.asyncJobId);
-        expect(asyncJob.request).toBe('/admin/super/reindex-database?index=Patient_name_idx&table=Observation');
+        expect(asyncJob.request).toBe('/admin/super/rebuild-index?index=Patient_name_idx&table=Observation');
         expect(asyncJob.meta?.project).toBeUndefined();
       });
 
@@ -898,7 +898,7 @@ describe('Database migrations', () => {
         const queueAddSpy = getQueueAddSpy();
 
         const res = await request(app)
-          .post('/admin/super/reindex-database')
+          .post('/admin/super/rebuild-index')
           .set('Authorization', 'Bearer ' + adminAccessToken)
           .set('Prefer', 'respond-async')
           .type('json')
@@ -912,7 +912,7 @@ describe('Database migrations', () => {
         const queueAddSpy = getQueueAddSpy();
 
         const res = await request(app)
-          .post('/admin/super/reindex-database')
+          .post('/admin/super/rebuild-index')
           .set('Authorization', 'Bearer ' + adminAccessToken)
           .set('Prefer', 'respond-async')
           .type('json')

--- a/packages/server/src/database-migration.test.ts
+++ b/packages/server/src/database-migration.test.ts
@@ -333,6 +333,7 @@ describe('Database migrations', () => {
         const expectedJobData = prepareCustomMigrationJobData(asyncJob);
         expect(queueAddSpy).toHaveBeenCalledTimes(1);
         expect(queueAddSpy.mock.lastCall?.[1]).toEqual(expectedJobData);
+        expect(queueAddSpy.mock.lastCall?.[2]).toEqual({ deduplication: { id: 'v1' } });
       }));
 
     test('No pending data migration', () =>
@@ -842,6 +843,7 @@ describe('Database migrations', () => {
             postDeploy: [],
           },
         });
+        expect(queueAddSpy.mock.calls[0][2]).toBeUndefined();
 
         expect(res1).toHaveStatus(202);
         expect(res1.headers['content-location']).toBeDefined();

--- a/packages/server/src/migrations/migration-utils.ts
+++ b/packages/server/src/migrations/migration-utils.ts
@@ -177,7 +177,7 @@ export async function queuePostDeployMigration(
   // picked up before the transaction was committed.
   // globalLogger.info('Adding post-deploy migration job', { version, asyncJob: getReferenceString(asyncJob) });
   const jobData = migration.prepareJobData(asyncJob);
-  const result = await addPostDeployMigrationJobData(jobData);
+  const result = await addPostDeployMigrationJobData(jobData, { deduplication: { id: `v${version}` } });
   if (!result) {
     globalLogger.error('Unable to add post-deploy migration job', {
       version,

--- a/packages/server/src/workers/post-deploy-migration.test.ts
+++ b/packages/server/src/workers/post-deploy-migration.test.ts
@@ -90,7 +90,7 @@ describe('Post-Deploy Migration Worker', () => {
     return queue;
   }
 
-  test('prepareCustomMigrationJobData and addPostDeployMigrationJobData', async () => {
+  test('prepareCustomMigrationJobData and addPostDeployMigrationJobData without deduplication', async () => {
     await initWorkers(config);
 
     const queue = getQueueFromRegistryOrThrow();
@@ -127,9 +127,7 @@ describe('Post-Deploy Migration Worker', () => {
           data: data1,
         })
       );
-      expect(addSpy).toHaveBeenCalledWith('PostDeployMigrationJobData', data1, {
-        deduplication: { id: expect.any(String) },
-      });
+      expect(addSpy).toHaveBeenCalledWith('PostDeployMigrationJobData', data1, undefined);
     });
 
     // outside of withTestContext, requestId and traceId are undefined
@@ -147,9 +145,7 @@ describe('Post-Deploy Migration Worker', () => {
         data: data2,
       })
     );
-    expect(addSpy).toHaveBeenCalledWith('PostDeployMigrationJobData', data2, {
-      deduplication: { id: expect.any(String) },
-    });
+    expect(addSpy).toHaveBeenCalledWith('PostDeployMigrationJobData', data2, undefined);
   });
 
   test.each<[string, Partial<AsyncJob>, boolean]>([

--- a/packages/server/src/workers/post-deploy-migration.ts
+++ b/packages/server/src/workers/post-deploy-migration.ts
@@ -295,19 +295,12 @@ export async function addPostDeployMigrationJobData<T extends PostDeployJobData>
   jobData: T,
   options?: JobsOptions
 ): Promise<Job<T> | undefined> {
-  const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID); // shardId will be in jobData in the future
-  const asyncJob = await systemRepo.readResource<AsyncJob>('AsyncJob', jobData.asyncJobId);
-  const deduplicationId = `v${asyncJob.dataVersion}`;
-
   const queue = queueRegistry.get<PostDeployJobData>(PostDeployMigrationQueueName);
   if (!queue) {
     throw new Error(`Job queue ${PostDeployMigrationQueueName} not available`);
   }
 
-  const job = await queue.add('PostDeployMigrationJobData', jobData, {
-    ...options,
-    deduplication: { id: deduplicationId },
-  });
+  const job = await queue.add('PostDeployMigrationJobData', jobData, options);
 
   globalLogger.debug('Added post-deploy migration job', {
     jobId: job.id,


### PR DESCRIPTION
Was resulting in non-post deploy migration jobs like those stemming from `/admin/super/reindex-database` to be ignored if one was already in flight.