### PR TITLE
feat: add identifier search for AccessPolicy

### DIFF
--- a/packages/definitions/src/fhir/r4/fhir.schema.json
+++ b/packages/definitions/src/fhir/r4/fhir.schema.json
@@ -62673,6 +62673,13 @@
           },
           "type": "array"
         },
+        "identifier": {
+          "description": "An identifier for this access policy.",
+          "items": {
+            "$ref": "#/definitions/Identifier"
+          },
+          "type": "array"
+        },
         "name": {
           "description": "A name associated with the AccessPolicy.",
           "$ref": "#/definitions/string"

--- a/packages/definitions/src/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/src/fhir/r4/profiles-medplum.json
@@ -3993,6 +3993,22 @@
             }]
           },
           {
+            "id" : "AccessPolicy.identifier",
+            "path" : "AccessPolicy.identifier",
+            "short" : "An identifier for this access policy",
+            "definition" : "An identifier for this access policy.",
+            "min" : 0,
+            "max" : "*",
+            "type" : [{
+              "code" : "Identifier"
+            }],
+            "base" : {
+              "path" : "AccessPolicy.identifier",
+              "min" : 0,
+              "max" : "*"
+            }
+          },
+          {
             "id" : "AccessPolicy.name",
             "path" : "AccessPolicy.name",
             "definition" : "A name associated with the AccessPolicy.",

--- a/packages/definitions/src/fhir/r4/search-parameters-medplum.json
+++ b/packages/definitions/src/fhir/r4/search-parameters-medplum.json
@@ -556,6 +556,23 @@
       }
     },
     {
+      "fullUrl": "https://medplum.com/fhir/SearchParameter/AccessPolicy-identifier",
+      "resource": {
+        "resourceType": "SearchParameter",
+        "id": "AccessPolicy-identifier",
+        "url": "https://medplum.com/fhir/SearchParameter/AccessPolicy-identifier",
+        "version": "4.0.1",
+        "name": "identifier",
+        "status": "draft",
+        "publisher": "Medplum",
+        "description": "The identifier of the access policy",
+        "code": "identifier",
+        "base": ["AccessPolicy"],
+        "type": "token",
+        "expression": "AccessPolicy.identifier"
+      }
+    },
+    {
       "fullUrl": "https://medplum.com/fhir/SearchParameter/AccessPolicy-name",
       "resource": {
         "resourceType": "SearchParameter",

--- a/packages/fhirtypes/dist/AccessPolicy.d.ts
+++ b/packages/fhirtypes/dist/AccessPolicy.d.ts
@@ -7,6 +7,7 @@
 
 import type { Expression } from './Expression.d.ts';
 import type { Extension } from './Extension.d.ts';
+import type { Identifier } from './Identifier.d.ts';
 import type { Meta } from './Meta.d.ts';
 import type { Narrative } from './Narrative.d.ts';
 import type { Reference } from './Reference.d.ts';
@@ -93,6 +94,11 @@ export interface AccessPolicy {
    * modifierExtension itself).
    */
   modifierExtension?: Extension[];
+
+  /**
+   * An identifier for this access policy.
+   */
+  identifier?: Identifier[];
 
   /**
    * A name associated with the AccessPolicy.

--- a/packages/server/src/fhir/tokens.test.ts
+++ b/packages/server/src/fhir/tokens.test.ts
@@ -3,6 +3,7 @@
 import type { WithId } from '@medplum/core';
 import { createReference, getReferenceString, getSearchParameter, Operator, SNOMED } from '@medplum/core';
 import type {
+  AccessPolicy,
   Bundle,
   Condition,
   Identifier,
@@ -90,6 +91,30 @@ test('Identifier', () =>
       ],
     });
     expect(badTextResult.entry?.length).toStrictEqual(0);
+  }));
+
+test('AccessPolicy identifier', () =>
+  withTestContext(async () => {
+    const system = 'https://example.com/access-policies';
+    const value = randomUUID();
+    const policy = await systemRepo.createResource<AccessPolicy>({
+      resourceType: 'AccessPolicy',
+      identifier: [{ system, value }],
+      resource: [{ resourceType: '*' }],
+    });
+
+    const searchResult = await systemRepo.search<AccessPolicy>({
+      resourceType: 'AccessPolicy',
+      filters: [
+        {
+          code: 'identifier',
+          operator: Operator.EQUALS,
+          value: `${system}|${value}`,
+        },
+      ],
+    });
+    expect(searchResult.entry?.length).toStrictEqual(1);
+    expect(searchResult.entry?.[0]?.resource?.id).toStrictEqual(policy.id);
   }));
 
 test.each(TokenQueryOperators)('%s with empty value does not throw errors', async (operator) => {


### PR DESCRIPTION
## Summary

- Add optional `identifier` support to the Medplum `AccessPolicy` StructureDefinition.
- Add the `AccessPolicy-identifier` token SearchParameter.
- Regenerate the FHIR TypeScript definitions and JSON Schema.
- Add a server regression test for exact `system|value` identifier search.

Fixes #9618

## Validation

- `npm run build --workspace @medplum/definitions`
- `npm run fhirtypes --workspace @medplum/generator`
- `npm run jsonschema --workspace @medplum/generator`
- `npm run build --workspace @medplum/core`
- `npm run build --workspace @medplum/fhir-router`
- `npm run build --workspace @medplum/ccda`
- `npm run build --workspace @medplum/server`
- `npm run test --workspace @medplum/server -- src/fhir/searchparameter.test.ts` (32 passed)
- `npm run test --workspace @medplum/definitions` (2 passed)
- DB-free token smoke check passed.

The full `tokens.test.ts` suite could not start locally because the test PostgreSQL role `medplum` and Redis service are unavailable.