### PR TITLE
feat: disambiguate invite membership upserts

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -625,6 +625,10 @@ export interface InviteRequest {
   password?: string;
   sendEmail?: boolean;
   membership?: Partial<ProjectMembership>;
+  /**
+   * Additional FHIR search parameters used to identify an existing ProjectMembership during an upsert.
+   */
+  membershipSearchCriteria?: Record<string, string | string[]>;
   upsert?: boolean;
   forceNewMembership?: boolean;
   mfaRequired?: boolean;

--- a/packages/server/src/admin/invite.test.ts
+++ b/packages/server/src/admin/invite.test.ts
@@ -815,6 +815,75 @@ describe('Admin Invite', () => {
     expect(res6.body.id).not.toStrictEqual(res2.body.id);
   });
 
+  test('Invite user with membership search criteria', () =>
+    withTestContext(async () => {
+      const { project } = await createTestProject();
+      const email = `bob${randomUUID()}@example.com`;
+      const identifierSystem = 'https://example.com/memberships';
+
+      const firstInvite = await inviteUser({
+        project,
+        resourceType: 'Practitioner',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        email,
+        forceNewMembership: true,
+        membership: {
+          identifier: [{ system: identifierSystem, value: 'admin' }],
+        },
+        sendEmail: false,
+      });
+
+      const secondInvite = await inviteUser({
+        project,
+        resourceType: 'Practitioner',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        email,
+        forceNewMembership: true,
+        membership: {
+          identifier: [{ system: identifierSystem, value: 'practitioner' }],
+        },
+        sendEmail: false,
+      });
+
+      const targetedInvite = await inviteUser({
+        project,
+        resourceType: 'Practitioner',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        email,
+        upsert: true,
+        membershipSearchCriteria: {
+          identifier: `${identifierSystem}|admin`,
+        },
+        membership: { admin: true },
+        sendEmail: false,
+      });
+
+      expect(targetedInvite.membership.id).toBe(firstInvite.membership.id);
+      expect(targetedInvite.membership.admin).toBe(true);
+
+      const systemRepo = await getProjectSystemRepo(project);
+      const secondMembership = await systemRepo.readResource<ProjectMembership>(
+        'ProjectMembership',
+        secondInvite.membership.id
+      );
+      expect(secondMembership.admin).not.toBe(true);
+
+      await expect(
+        inviteUser({
+          project,
+          resourceType: 'Practitioner',
+          firstName: 'Bob',
+          lastName: 'Jones',
+          email,
+          upsert: true,
+          sendEmail: false,
+        })
+      ).rejects.toThrow('Multiple resources found matching condition');
+    }));
+
   test('Inviting a project-scoped user when there is already a server-scoped user who is a member with the same email address', async () => {
     const { project, accessToken } = await withTestContext(() =>
       registerNew({

--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -13,6 +13,7 @@ import {
   normalizeErrorString,
   OperationOutcomeError,
   Operator,
+  parseSearchRequest,
   resolveId,
 } from '@medplum/core';
 import type {
@@ -477,7 +478,12 @@ async function upsertProjectMembership(
   // Upsert ProjectMembership resource to connect User to profile resource in the given Project
   const membership = await systemRepo.withTransaction(
     async (txRepo) => {
-      const existingMembership = await searchForExistingMembership(txRepo, user, project);
+      const existingMembership = await searchForExistingMembership(
+        txRepo,
+        user,
+        project,
+        request.membershipSearchCriteria
+      );
       if (existingMembership) {
         if (existingMembership.profile?.reference !== getReferenceString(profile)) {
           throw new OperationOutcomeError(
@@ -513,9 +519,11 @@ async function upsertProjectMembership(
 async function searchForExistingMembership(
   systemRepo: SystemRepository,
   user: WithId<User>,
-  project: WithId<Project>
+  project: WithId<Project>,
+  membershipSearchCriteria?: Record<string, string | string[]>
 ): Promise<ProjectMembership | undefined> {
-  return systemRepo.searchOne<ProjectMembership>({
+  const searchRequest = parseSearchRequest<ProjectMembership>('ProjectMembership', membershipSearchCriteria);
+  const memberships = await systemRepo.searchResources<ProjectMembership>({
     resourceType: 'ProjectMembership',
     filters: [
       {
@@ -528,8 +536,16 @@ async function searchForExistingMembership(
         operator: Operator.EQUALS,
         value: getReferenceString(project),
       },
+      ...(searchRequest.filters ?? []),
     ],
+    count: 2,
   });
+
+  if (memberships.length > 1) {
+    throw new OperationOutcomeError(multipleMatches);
+  }
+
+  return memberships[0];
 }
 
 async function sendInviteEmail(


### PR DESCRIPTION
## Summary\n\n- Add optional  to .\n- Merge parsed FHIR criteria into the existing user/project membership lookup.\n- Detect multiple matching memberships instead of selecting one nondeterministically.\n- Add regression coverage for targeted updates and ambiguous upserts.\n\nFixes #8600\n\n## Validation\n\n- 
> @medplum/definitions@5.1.36 build
> npm run clean && tsc && node build.mjs && npm run api-extractor


> @medplum/definitions@5.1.36 clean
> rimraf dist


> @medplum/definitions@5.1.36 api-extractor
> api-extractor run --local && shx cp dist/types.d.ts dist/cjs/index.d.ts && shx cp dist/types.d.ts dist/esm/index.d.ts


[1mapi-extractor 7.58.12 [36m - https://api-extractor.com/[39m
[22m
Using configuration from ./api-extractor.json
Analysis will use the bundled TypeScript version 6.0.3

API Extractor completed successfully\n- 
> @medplum/core@5.1.36 build
> npm run clean && tsc && node esbuild.mjs && npm run api-extractor && npm run api-documenter


> @medplum/core@5.1.36 clean
> rimraf dist


> @medplum/core@5.1.36 api-extractor
> api-extractor run --local && shx cp dist/types.d.ts dist/cjs/index.d.ts && shx cp dist/types.d.ts dist/esm/index.d.ts


[1mapi-extractor 7.58.12 [36m - https://api-extractor.com/[39m
[22m
Using configuration from ./api-extractor.json
Analysis will use the bundled TypeScript version 6.0.3

API Extractor completed successfully

> @medplum/core@5.1.36 api-documenter
> api-documenter markdown --input-folder ./dist/api/ --output-folder ./dist/docs/


[1mapi-documenter 7.30.11 [36m - https://api-extractor.com/[39m
[22m
Reading core.api.json

Deleting old output from ./dist/docs/
Writing @medplum/core package\n- 
> @medplum/fhir-router@5.1.36 build
> npm run clean && tsc && node esbuild.mjs && npm run api-extractor


> @medplum/fhir-router@5.1.36 clean
> rimraf dist


> @medplum/fhir-router@5.1.36 api-extractor
> api-extractor run --local && shx cp dist/types.d.ts dist/cjs/index.d.ts && shx cp dist/types.d.ts dist/esm/index.d.ts


[1mapi-extractor 7.58.12 [36m - https://api-extractor.com/[39m
[22m
Using configuration from ./api-extractor.json
Analysis will use the bundled TypeScript version 6.0.3

API Extractor completed successfully\n- 
> @medplum/ccda@5.1.36 build
> npm run clean && tsc && node esbuild.mjs && npm run api-extractor


> @medplum/ccda@5.1.36 clean
> rimraf dist


> @medplum/ccda@5.1.36 api-extractor
> api-extractor run --local && shx cp dist/types.d.ts dist/cjs/index.d.ts && shx cp dist/types.d.ts dist/esm/index.d.ts


[1mapi-extractor 7.58.12 [36m - https://api-extractor.com/[39m
[22m
Using configuration from ./api-extractor.json
Analysis will use the bundled TypeScript version 6.0.3

API Extractor completed successfully\n- 
> @medplum/server@5.1.36 build
> npm run clean && tsc && node build.mjs


> @medplum/server@5.1.36 clean
> rimraf dist\n- 
> @medplum/core@5.1.36 test
> vitest run src/search/search.test.ts src/search/parse.test.ts


 RUN  v4.1.10 /private/tmp/medplum-invite-criteria.SsjYhV/packages/core


 Test Files  2 passed (2)
      Tests  124 passed (124)
   Start at  17:09:38
   Duration  624ms (transform 176ms, setup 197ms, import 26ms, tests 438ms, environment 479ms) (124 passed)\n- Prettier, ESLint, and  passed.\n- Invite integration suite could not start locally because PostgreSQL role  and Redis are unavailable.