### PR TITLE
feat: disambiguate invite membership upserts

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -625,6 +625,10 @@ export interface InviteRequest {
   password?: string;
   sendEmail?: boolean;
   membership?: Partial<ProjectMembership>;
+  /**
+   * Additional FHIR search parameters used to identify an existing ProjectMembership during an upsert.
+   */
+  membershipSearchCriteria?: Record<string, string | string[]>;
   upsert?: boolean;
   forceNewMembership?: boolean;
   mfaRequired?: boolean;

--- a/packages/server/src/admin/invite.test.ts
+++ b/packages/server/src/admin/invite.test.ts
@@ -815,6 +815,75 @@ describe('Admin Invite', () => {
     expect(res6.body.id).not.toStrictEqual(res2.body.id);
   });
 
+  test('Invite user with membership search criteria', () =>
+    withTestContext(async () => {
+      const { project } = await createTestProject();
+      const email = `bob${randomUUID()}@example.com`;
+      const identifierSystem = 'https://example.com/memberships';
+
+      const firstInvite = await inviteUser({
+        project,
+        resourceType: 'Practitioner',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        email,
+        forceNewMembership: true,
+        membership: {
+          identifier: [{ system: identifierSystem, value: 'admin' }],
+        },
+        sendEmail: false,
+      });
+
+      const secondInvite = await inviteUser({
+        project,
+        resourceType: 'Practitioner',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        email,
+        forceNewMembership: true,
+        membership: {
+          identifier: [{ system: identifierSystem, value: 'practitioner' }],
+        },
+        sendEmail: false,
+      });
+
+      const targetedInvite = await inviteUser({
+        project,
+        resourceType: 'Practitioner',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        email,
+        upsert: true,
+        membershipSearchCriteria: {
+          identifier: `${identifierSystem}|admin`,
+        },
+        membership: { admin: true },
+        sendEmail: false,
+      });
+
+      expect(targetedInvite.membership.id).toBe(firstInvite.membership.id);
+      expect(targetedInvite.membership.admin).toBe(true);
+
+      const systemRepo = await getProjectSystemRepo(project);
+      const secondMembership = await systemRepo.readResource<ProjectMembership>(
+        'ProjectMembership',
+        secondInvite.membership.id
+      );
+      expect(secondMembership.admin).not.toBe(true);
+
+      await expect(
+        inviteUser({
+          project,
+          resourceType: 'Practitioner',
+          firstName: 'Bob',
+          lastName: 'Jones',
+          email,
+          upsert: true,
+          sendEmail: false,
+        })
+      ).rejects.toThrow('Multiple resources found matching condition');
+    }));
+
   test('Inviting a project-scoped user when there is already a server-scoped user who is a member with the same email address', async () => {
     const { project, accessToken } = await withTestContext(() =>
       registerNew({

--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -13,6 +13,7 @@ import {
   normalizeErrorString,
   OperationOutcomeError,
   Operator,
+  parseSearchRequest,
   resolveId,
 } from '@medplum/core';
 import type {
@@ -477,7 +478,12 @@ async function upsertProjectMembership(
   // Upsert ProjectMembership resource to connect User to profile resource in the given Project
   const membership = await systemRepo.withTransaction(
     async (txRepo) => {
-      const existingMembership = await searchForExistingMembership(txRepo, user, project);
+      const existingMembership = await searchForExistingMembership(
+        txRepo,
+        user,
+        project,
+        request.membershipSearchCriteria
+      );
       if (existingMembership) {
         if (existingMembership.profile?.reference !== getReferenceString(profile)) {
           throw new OperationOutcomeError(
@@ -513,9 +519,11 @@ async function upsertProjectMembership(
 async function searchForExistingMembership(
   systemRepo: SystemRepository,
   user: WithId<User>,
-  project: WithId<Project>
+  project: WithId<Project>,
+  membershipSearchCriteria?: Record<string, string | string[]>
 ): Promise<ProjectMembership | undefined> {
-  return systemRepo.searchOne<ProjectMembership>({
+  const searchRequest = parseSearchRequest<ProjectMembership>('ProjectMembership', membershipSearchCriteria);
+  const memberships = await systemRepo.searchResources<ProjectMembership>({
     resourceType: 'ProjectMembership',
     filters: [
       {
@@ -528,8 +536,16 @@ async function searchForExistingMembership(
         operator: Operator.EQUALS,
         value: getReferenceString(project),
       },
+      ...(searchRequest.filters ?? []),
     ],
+    count: 2,
   });
+
+  if (memberships.length > 1) {
+    throw new OperationOutcomeError(multipleMatches);
+  }
+
+  return memberships[0];
 }
 
 async function sendInviteEmail(


### PR DESCRIPTION
## Summary

- Add optional `membershipSearchCriteria` to `InviteRequest`.
- Merge parsed FHIR criteria into the existing user/project membership lookup.
- Detect multiple matching memberships instead of selecting one nondeterministically.
- Add regression coverage for targeted updates and ambiguous upserts.

Fixes #8600

## Validation

- `npm run build --workspace @medplum/definitions`
- `npm run build --workspace @medplum/core`
- `npm run build --workspace @medplum/fhir-router`
- `npm run build --workspace @medplum/ccda`
- `npm run build --workspace @medplum/server`
- `npm run test --workspace @medplum/core -- src/search/search.test.ts src/search/parse.test.ts` (124 passed)
- Prettier, ESLint, and `git diff --check` passed.
- Invite integration suite could not start locally because PostgreSQL role `medplum` and Redis are unavailable.
