### PR TITLE
Fixed MEDPLUM_REQUIRE_VERIFIED_EMAIL_FOR_PROJECT_CREATION env var setting

### DIFF
--- a/packages/server/src/cloud/aws/config.test.ts
+++ b/packages/server/src/cloud/aws/config.test.ts
@@ -30,6 +30,7 @@ describe('Config', () => {
         { Name: 'botCustomFunctionsEnabled', Value: 'true' },
         { Name: 'logAuditEvents', Value: 'true' },
         { Name: 'registerEnabled', Value: 'false' },
+        { Name: 'requireVerifiedEmailForProjectCreation', Value: 'false' },
         {
           Name: 'defaultProjectSystemSetting',
           Value: '[{"name":"someSetting","valueString":"someValue"},{"name":"secondSetting","valueInteger":5}]',
@@ -51,6 +52,7 @@ describe('Config', () => {
     expect(config.botCustomFunctionsEnabled).toStrictEqual(true);
     expect(config.logAuditEvents).toStrictEqual(true);
     expect(config.registerEnabled).toStrictEqual(false);
+    expect(config.requireVerifiedEmailForProjectCreation).toStrictEqual(false);
     expect(config.defaultProjectSystemSetting).toStrictEqual([
       { name: 'someSetting', valueString: 'someValue' },
       { name: 'secondSetting', valueInteger: 5 },

--- a/packages/server/src/config/loader.test.ts
+++ b/packages/server/src/config/loader.test.ts
@@ -134,12 +134,14 @@ describe('Config', () => {
     setEnv('MEDPLUM_LOG_REQUESTS', 'false');
     setEnv('MEDPLUM_BOT_CUSTOM_FUNCTIONS_ENABLED', 'true');
     setEnv('MEDPLUM_RATE_LIMITS_ENABLED', 'false');
+    setEnv('MEDPLUM_REQUIRE_VERIFIED_EMAIL_FOR_PROJECT_CREATION', 'false');
 
     const config = await loadConfig('env');
     expect(config.registerEnabled).toBe(true);
     expect(config.logRequests).toBe(false);
     expect(config.botCustomFunctionsEnabled).toBe(true);
     expect(config.rateLimitsEnabled).toBe(false);
+    expect(config.requireVerifiedEmailForProjectCreation).toBe(false);
   });
 
   test('Env config externalAuthProviders as JSON array', async () => {

--- a/packages/server/src/config/utils.test.ts
+++ b/packages/server/src/config/utils.test.ts
@@ -11,6 +11,7 @@ describe('utils', () => {
     expect(isBooleanConfig('baseUrl')).toBe(false);
     expect(isBooleanConfig('logRequests')).toBe(true);
     expect(isBooleanConfig('rateLimitsEnabled')).toBe(true);
+    expect(isBooleanConfig('requireVerifiedEmailForProjectCreation')).toBe(true);
   });
 
   test('isIntegerConfig', () => {
@@ -66,6 +67,12 @@ describe('utils', () => {
     const config = {};
     setValue(config, 'rateLimitsEnabled', 'false');
     expect(config).toEqual({ rateLimitsEnabled: false });
+  });
+
+  test('setValue parses requireVerifiedEmailForProjectCreation as boolean', () => {
+    const config = {};
+    setValue(config, 'requireVerifiedEmailForProjectCreation', 'false');
+    expect(config).toEqual({ requireVerifiedEmailForProjectCreation: false });
   });
 
   test('addDefaults preserves dataWarehouse.startDate as ISO-8601 string', () => {

--- a/packages/server/src/config/utils.ts
+++ b/packages/server/src/config/utils.ts
@@ -198,6 +198,7 @@ const booleanKeys = new Set([
   'logAuditEvents',
   'mcpEnabled',
   'registerEnabled',
+  'requireVerifiedEmailForProjectCreation',
   'serverScopedSubscriptionsEnabled',
   'require',
   'rejectUnauthorized',


### PR DESCRIPTION
`requireVerifiedEmailForProjectCreation` worked in JSON and AWS Parameter Store, but not from env vars.