### PR TITLE
Fix crash in ResourceDiffTable on previously-empty array diffs

### DIFF
--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.test.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.test.tsx
@@ -215,6 +215,31 @@ describe('ResourceDiffTable', () => {
     expect(operations).toHaveLength(1);
   });
 
+  test('Combine patch operations on array add from empty array', async () => {
+    const original: Patient = {
+      resourceType: 'Patient',
+      id: '123',
+      meta: { versionId: '456' },
+      name: [{ family: 'Smith', given: ['John'] }],
+      identifier: [],
+    };
+
+    const revised: Patient = {
+      ...original,
+      meta: { versionId: '457' },
+      identifier: [
+        { system: 'http://example.com/foo', value: '123' },
+        { system: 'http://example.com/bar', value: '456' },
+      ],
+    };
+
+    await act(async () => {
+      setup({ original, revised });
+    });
+
+    expect(await screen.findByText('Replace identifier')).toBeInTheDocument();
+  });
+
   test('Change attachment URL', async () => {
     const original: Patient = {
       resourceType: 'Patient',

--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
@@ -166,8 +166,8 @@ function touchUpValue(
   property: InternalSchemaElement | undefined,
   input: TypedValue[] | TypedValue | undefined
 ): TypedValue | undefined {
-  if (!input) {
-    return input;
+  if (!input || (Array.isArray(input) && input.length === 0)) {
+    return undefined;
   }
   return {
     type: Array.isArray(input) ? input[0].type : input.type,


### PR DESCRIPTION
## Summary

<img width="1938" height="376" alt="image (35)" src="https://github.com/user-attachments/assets/0ee7f698-bb7a-4fa0-806f-8a7bd5969d84" />

- Fixes a crash in the resource history/timeline "diff" view: `TypeError: Cannot read properties of undefined (reading 'type')`.
- Root cause: `evalFhirPathTyped()` returns an empty array (not `undefined`) when a FHIRPath doesn't resolve on one side of a diff — e.g. a merged "replace" patch op on an array field that started out empty (`identifier: []` → items added). `touchUpValue()` in `ResourceDiffTable.tsx` only guarded against falsy input, so it went on to read `input[0].type` on the empty array and threw.
- Fix: also treat an empty array as "nothing to show" and return `undefined`, matching the existing behavior for `undefined`/`null` input.