### PR TITLE
feat: allow standard FHIR subscription payloads

### DIFF
--- a/packages/docs/docs/subscriptions/subscription-extensions.md
+++ b/packages/docs/docs/subscriptions/subscription-extensions.md
@@ -243,6 +243,31 @@ def handle_webhook():
     return {"ok":True}
 ```
 
+## Omitting Medplum metadata from webhook payloads
+
+By default, rest-hook payloads can include Medplum's extended `meta` fields. To send standard FHIR metadata only, add the `subscription-omit-extended-meta` extension with `valueBoolean` set to `true`:
+
+```json
+{
+  "resourceType": "Subscription",
+  "reason": "test",
+  "status": "active",
+  "criteria": "Patient",
+  "channel": {
+    "type": "rest-hook",
+    "endpoint": "https://example.com/webhook"
+  },
+  "extension": [
+    {
+      "url": "https://medplum.com/fhir/StructureDefinition/subscription-omit-extended-meta",
+      "valueBoolean": true
+    }
+  ]
+}
+```
+
+When enabled, the webhook resource omits the Medplum-specific `meta.author`, `meta.project`, `meta.account`, `meta.accounts`, `meta.compartment`, and `meta.deleted` fields. The default payload is unchanged, and the option applies to rest-hook payloads only.
+
 ## Retry Policy
 
 If your subscription failed or threw an error, you can configure it to attempt to execute the operation multiple times.

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -5,6 +5,7 @@ import type { SearchRequest, WithId } from '@medplum/core';
 import {
   ContentType,
   createReference,
+  deepClone,
   generateId,
   getReferenceString,
   LogLevel,
@@ -190,6 +191,58 @@ describe('Subscription Worker', () => {
       await repo.deleteResource('Patient', patient.id);
 
       await findAndExecSubscriptionJob(patient, 'delete');
+    }));
+
+  test('Omit extended metadata from rest-hook payloads', () =>
+    withTestContext(async () => {
+      const url = 'https://example.com/subscription';
+      await repo.createResource<Subscription>({
+        resourceType: 'Subscription',
+        reason: 'test',
+        status: 'active',
+        criteria: 'Patient',
+        channel: {
+          type: 'rest-hook',
+          endpoint: url,
+        },
+        extension: [
+          {
+            url: 'https://medplum.com/fhir/StructureDefinition/subscription-omit-extended-meta',
+            valueBoolean: true,
+          },
+        ],
+      });
+
+      const patient = await repo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ given: ['Alice'], family: 'Smith' }],
+      });
+      expect(patient.meta?.project).toBe(repo.currentProject()?.id);
+      expect(patient.meta?.author).toBeDefined();
+      const patientBeforeDelivery = deepClone(patient);
+
+      fetchMock.mockImplementation(() => mockFetchStatus(200));
+      await findAndExecSubscriptionJob(patient, 'create');
+
+      const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+      const payload = JSON.parse(request.body as string) as Patient;
+      expect(payload).toMatchObject({
+        resourceType: 'Patient',
+        id: patient.id,
+        meta: {
+          versionId: patient.meta?.versionId,
+          lastUpdated: patient.meta?.lastUpdated,
+        },
+      });
+      expect(payload.meta).toBeDefined();
+      expect(payload.meta).not.toHaveProperty('author');
+      expect(payload.meta).not.toHaveProperty('project');
+      expect(payload.meta).not.toHaveProperty('account');
+      expect(payload.meta).not.toHaveProperty('accounts');
+      expect(payload.meta).not.toHaveProperty('compartment');
+      expect(payload.meta).not.toHaveProperty('deleted');
+      expect(patient).toStrictEqual(patientBeforeDelivery);
+      expect(request.body).toBe(stringify(payload));
     }));
 
   test('Does not send subscriptions when disabled', () =>

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -7,6 +7,7 @@ import {
   EMPTY,
   Operator,
   createReference,
+  deepClone,
   getExtension,
   getExtensionValue,
   getReferenceString,
@@ -91,6 +92,9 @@ const MAX_JOB_ATTEMPTS = 19;
  * This can be overridden by the subscription-max-attempts extension.
  */
 const DEFAULT_ATTEMPTS = 4;
+
+/** Subscription extension that removes Medplum-specific metadata from rest-hook payloads. */
+const SUBSCRIPTION_OMIT_EXTENDED_META = 'https://medplum.com/fhir/StructureDefinition/subscription-omit-extended-meta';
 
 /**
  * The maximum number of attempts to get through the preamble (loading subscription and resource).
@@ -743,18 +747,23 @@ async function sendRestHook(
     return;
   }
 
-  const body = interaction === 'delete' ? '{}' : stringify(resource);
-  const headers = buildRestHookHeaders(job, subscription, resource, interaction, body);
-  let error: Error | undefined = undefined;
-
-  const fetchStartTime = Date.now();
-  let fetchEndTime: number;
   let systemRepo: SystemRepository;
   if (subscription.meta?.project) {
     systemRepo = await getProjectSystemRepo(subscription.meta.project);
   } else {
     systemRepo = getGlobalSystemRepo(); // SHARDING is global correct if no project?
   }
+
+  const webhookResource =
+    getExtensionValue(subscription, SUBSCRIPTION_OMIT_EXTENDED_META) === true
+      ? systemRepo.withOverrideConfig({ extendedMode: false }).removeHiddenFields(deepClone(resource))
+      : resource;
+  const body = interaction === 'delete' ? '{}' : stringify(webhookResource);
+  const headers = buildRestHookHeaders(job, subscription, resource, interaction, body);
+  let error: Error | undefined = undefined;
+
+  const fetchStartTime = Date.now();
+  let fetchEndTime: number;
   try {
     log.info('Sending rest hook', {
       url,


### PR DESCRIPTION
## Summary

Fixes #6574

Adds an opt-in subscription extension for rest-hook payloads:

- `subscription-omit-extended-meta` with `valueBoolean: true`
- strips Medplum-specific `meta.author`, `meta.project`, `meta.account`, `meta.accounts`, `meta.compartment`, and `meta.deleted` fields before serialization
- preserves the default payload and signs the exact serialized body sent to the webhook
- adds regression coverage and subscription extension documentation

## Validation

- `npm run build --workspace @medplum/core`
- `npm run build --workspace @medplum/fhir-router`
- `npm run build --workspace @medplum/ccda`
- `npm run build --workspace @medplum/server`
- `npx prettier --check` on changed files
- `npx eslint` on changed TypeScript files
- `git diff --check`
- DB-free `removeHiddenFields` smoke test

The full subscription worker test could not start locally because PostgreSQL does not have the `medplum` role and Redis is unavailable.
