### PR TITLE
fix(email): return 400 for invalid project SMTP config

### DIFF
--- a/packages/server/src/email/routes.test.ts
+++ b/packages/server/src/email/routes.test.ts
@@ -190,6 +190,39 @@ describe('Email API Routes', () => {
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(0);
   });
 
+  test('Misconfigured project SMTP returns bad request', async () => {
+    mockCreateTransport.mockClear();
+    mockSendMail.mockClear();
+
+    const accessToken = await initTestAuth({
+      membership: { admin: true },
+      project: {
+        secret: [
+          { name: 'smtpHost', valueString: 'smtp.project.example.com' },
+          { name: 'smtpUsername', valueString: 'projectuser' },
+          { name: 'smtpPassword', valueString: 'projectpass' },
+          { name: 'smtpFromAddress', valueString: 'support@project.example.com' },
+        ],
+      },
+    });
+    const res = await request(app)
+      .post(`/email/v1/send`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({
+        to: 'alice@example.com',
+        subject: 'Subject',
+        text: 'Body',
+      });
+
+    expect(res).toHaveStatus(400);
+    expect(res.body.issue[0].details.text).toBe('Project SMTP configuration is incomplete or invalid');
+    expect(mockCreateTransport).not.toHaveBeenCalled();
+    expect(mockSendMail).not.toHaveBeenCalled();
+    expect(mockSESv2Client.send.callCount).toBe(0);
+    expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(0);
+  });
+
   test('Handle SES error', async () => {
     mockSESv2Client.on(SendEmailCommand).rejects(new Error('BadRequestException: Illegal address'));
 

--- a/packages/server/src/email/utils.ts
+++ b/packages/server/src/email/utils.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import { OperationOutcomeError, serverError } from '@medplum/core';
+import { OperationOutcomeError, badRequest } from '@medplum/core';
 import type { Project } from '@medplum/fhirtypes';
 import MailComposer from 'nodemailer/lib/mail-composer/index.js';
 import type Mail from 'nodemailer/lib/mailer';
@@ -49,7 +49,7 @@ export function getProjectSmtpConfig(project: WithId<Project>): ProjectSmtpConfi
         .filter(Boolean)
         .join(', '),
     });
-    throw new OperationOutcomeError(serverError(new Error('Project SMTP configuration is incomplete or invalid')));
+    throw new OperationOutcomeError(badRequest('Project SMTP configuration is incomplete or invalid'));
   }
 
   return {


### PR DESCRIPTION
## Summary

- classify incomplete project SMTP settings as a bad request so POST /email/v1/send returns HTTP 400 instead of 500
- add route coverage for a missing SMTP port
- verify that neither SMTP nor SES transport is attempted for invalid configuration

## Testing

- npx turbo run build --filter=@medplum/server
- npx eslint packages/server/src/email/utils.ts packages/server/src/email/routes.test.ts
- direct status-mapping smoke check confirms HTTP 400

The targeted integration suites could not run locally because PostgreSQL and Redis were unavailable and the Docker daemon was not running.