### PR TITLE
fix(server): parse autoDownloadEnabled as a boolean config key

### DIFF
--- a/packages/server/src/config/loader.test.ts
+++ b/packages/server/src/config/loader.test.ts
@@ -71,6 +71,7 @@ describe('Config', () => {
     expect(config.redis.tls).toStrictEqual({});
     expect(config.database.ssl).toStrictEqual({ require: true });
     expect(config.smtp?.host).toStrictEqual('smtp.example.com');
+    expect(config.autoDownloadEnabled).toBe(true);
     expect(getConfig()).toBe(config);
   });
 
@@ -134,6 +135,7 @@ describe('Config', () => {
     setEnv('MEDPLUM_LOG_REQUESTS', 'false');
     setEnv('MEDPLUM_BOT_CUSTOM_FUNCTIONS_ENABLED', 'true');
     setEnv('MEDPLUM_RATE_LIMITS_ENABLED', 'false');
+    setEnv('MEDPLUM_AUTO_DOWNLOAD_ENABLED', 'false');
     setEnv('MEDPLUM_REQUIRE_VERIFIED_EMAIL_FOR_PROJECT_CREATION', 'false');
 
     const config = await loadConfig('env');
@@ -141,6 +143,7 @@ describe('Config', () => {
     expect(config.logRequests).toBe(false);
     expect(config.botCustomFunctionsEnabled).toBe(true);
     expect(config.rateLimitsEnabled).toBe(false);
+    expect(config.autoDownloadEnabled).toBe(false);
     expect(config.requireVerifiedEmailForProjectCreation).toBe(false);
   });
 

--- a/packages/server/src/config/utils.ts
+++ b/packages/server/src/config/utils.ts
@@ -184,6 +184,7 @@ export function isFloatConfig(_key: string): boolean {
 
 const booleanKeys = new Set([
   'allowUnsafeOutbound',
+  'autoDownloadEnabled',
   'botCustomFunctionsEnabled',
   'database.ssl.rejectUnauthorized',
   'database.ssl.require',


### PR DESCRIPTION
**Why:** `MEDPLUM_AUTO_DOWNLOAD_ENABLED=false` is parsed as the string `"false"`, which is truthy, so `autoDownloadEnabled` cannot actually be disabled via env var — the download worker's early exit never fires.

**What:** Add `autoDownloadEnabled` to `booleanKeys` so the config loader parses it as a boolean.

Also adds a test asserting `MEDPLUM_AUTO_DOWNLOAD_ENABLED=false` parses to boolean `false`, and that the default remains `true` when unset.