### PR TITLE
fix(storybook): Bind fake Date to global at install time

### DIFF
--- a/packages/react-scheduling/src/stories/MockDateWrapper.tsx
+++ b/packages/react-scheduling/src/stories/MockDateWrapper.tsx
@@ -16,7 +16,17 @@ let mountCount = 0;
 // transition to/from zero mounted wrappers, rather than once per wrapper.
 function acquireSharedClock(): void {
   if (!sharedClock) {
-    sharedClock = createFakeClock({ now: MOCKED_DATE, shouldAdvanceTime: false, toFake: ['Date'] });
+    sharedClock = createFakeClock({
+      now: MOCKED_DATE,
+      shouldAdvanceTime: false,
+      toFake: ['Date'],
+      // Storybook bundles a separate copy of sinon per package, and it loads the next story's
+      // module before tearing down the current one. Without `global`, fake-timers captures the
+      // "native" Date at module load, which may be another copy's fake Date. Faking on top of
+      // a fake Date throws "Cannot redefine property: constructor". Passing `global` makes it
+      // capture Date at install time instead. sinon honors this option but its typings omit it.
+      global: globalThis,
+    } as Parameters<typeof createFakeClock>[0]);
   }
   mountCount++;
 }

--- a/packages/react/src/stories/MockDateWrapper.utils.ts
+++ b/packages/react/src/stories/MockDateWrapper.utils.ts
@@ -19,5 +19,11 @@ export function createGlobalTimer(): SinonFakeTimers {
     now: DEFAULT_MOCKED_DATE,
     shouldAdvanceTime: false,
     toFake: ['Date'],
-  });
+    // Storybook bundles a separate copy of sinon per package, and it loads the next story's
+    // module before tearing down the current one. Without `global`, fake-timers captures the
+    // "native" Date at module load, which may be another copy's fake Date. Faking on top of
+    // a fake Date throws "Cannot redefine property: constructor". Passing `global` makes it
+    // capture Date at install time instead. sinon honors this option but its typings omit it.
+    global: globalThis,
+  } as Parameters<typeof useFakeTimers>[0]);
 }


### PR DESCRIPTION
repro steps:

- go into https://storybook.medplum.com/?path=/story/medplum-calendar--basic
- then search for scheduler, open it
- it will crash with "Cannot redefine property: constructor"
- a refresh solves it

<img width="1485" height="908" alt="Screenshot 2026-09-02 at 10 59 21 AM" src="https://github.com/user-attachments/assets/cc8295d9-3170-4e36-815c-e5061ef23666" />
