### PR TITLE
feat: add Task not-before search parameter

### DIFF
--- a/packages/core/src/search/match.test.ts
+++ b/packages/core/src/search/match.test.ts
@@ -904,6 +904,50 @@ describe('Search matching', () => {
         expect(matchesSearchRequest(task, search)).toBe(false);
       });
     });
+
+    describe('not-before', () => {
+      test('matches restriction.period.start only', () => {
+        const task: Task = {
+          resourceType: 'Task',
+          status: 'accepted',
+          intent: 'order',
+          restriction: {
+            period: {
+              start: '2025-05-15T12:00:00.000Z',
+              end: '2025-06-15T12:00:00.000Z',
+            },
+          },
+        };
+
+        expect(
+          matchesSearchRequest(task, {
+            resourceType: 'Task',
+            filters: [{ code: 'not-before', operator: Operator.LESS_THAN_OR_EQUALS, value: '2025-05-01' }],
+          })
+        ).toBe(false);
+        expect(
+          matchesSearchRequest(task, {
+            resourceType: 'Task',
+            filters: [{ code: 'not-before', operator: Operator.LESS_THAN_OR_EQUALS, value: '2025-06-01' }],
+          })
+        ).toBe(true);
+      });
+
+      test('does not match a period with only an end', () => {
+        const task: Task = {
+          resourceType: 'Task',
+          status: 'accepted',
+          intent: 'order',
+          restriction: { period: { end: '2025-06-15T12:00:00.000Z' } },
+        };
+        expect(
+          matchesSearchRequest(task, {
+            resourceType: 'Task',
+            filters: [{ code: 'not-before', operator: Operator.LESS_THAN_OR_EQUALS, value: '2025-06-01' }],
+          })
+        ).toBe(false);
+      });
+    });
   });
 
   test('Compartments', () => {

--- a/packages/definitions/src/fhir/r4/search-parameters-medplum.json
+++ b/packages/definitions/src/fhir/r4/search-parameters-medplum.json
@@ -799,6 +799,24 @@
       }
     },
     {
+      "fullUrl": "https://medplum.com/fhir/SearchParameter/Task-not-before",
+      "resource": {
+        "resourceType": "SearchParameter",
+        "id": "Task-not-before",
+        "url": "https://medplum.com/fhir/SearchParameter/Task-not-before",
+        "version": "4.0.1",
+        "name": "not-before",
+        "status": "draft",
+        "publisher": "Medplum",
+        "description": "Search by the date before which a Task cannot be started",
+        "code": "not-before",
+        "base": ["Task"],
+        "type": "date",
+        "expression": "Task.restriction.period.start",
+        "comparator": ["eq", "ne", "gt", "ge", "lt", "le", "sa", "eb", "ap"]
+      }
+    },
+    {
       "fullUrl": "https://medplum.com/fhir/SearchParameter/Agent-identifier",
       "resource": {
         "resourceType": "SearchParameter",

--- a/packages/docs/docs/api/fhir/resources/task.mdx
+++ b/packages/docs/docs/api/fhir/resources/task.mdx
@@ -13,6 +13,8 @@ import { ResourcePropertiesTable, SearchParamsTable } from '@site/src/components
 
 A task to be performed.
 
+Use the `not-before` search parameter to filter Tasks by `restriction.period.start` independently of the existing `due-date` period search.
+
 <Tabs queryString="section">
   <TabItem value="schema" label="Schema" default>
 

--- a/packages/docs/static/data/resourceDefinitions/task.json
+++ b/packages/docs/static/data/resourceDefinitions/task.json
@@ -1571,6 +1571,12 @@
       "expression": "Task.restriction.period"
     },
     {
+      "name": "not-before",
+      "type": "date",
+      "description": "Search by the date before which a Task cannot be started",
+      "expression": "Task.restriction.period.start"
+    },
+    {
       "name": "priority-order",
       "type": "number",
       "description": "Numeric priority order for resource types using http://hl7.org/fhir/ValueSet/request-priority",

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -337,8 +337,9 @@ export class Repository extends FhirRepository implements Disposable {
    *                Project.link (https://github.com/medplum/medplum/pull/9159)
    * 16. 06/30/26 - Added search param: Provenance-activity (https://github.com/medplum/medplum/pull/9709)
    * 17. 08/27/26 - Added search param: PractitionerRole-davinci-pdex-network
+   * 18. 09/03/26 - Added search param: Task-not-before (https://github.com/medplum/medplum/issues/8345)
    */
-  static readonly VERSION: number = 17;
+  static readonly VERSION: number = 18;
 
   /**
    * Constructs a new Repository instance.

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -4224,6 +4224,45 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
       }));
   });
 
+  test('Filter Task by not-before without considering restriction.period.end', () =>
+    withTestContext(async () => {
+      const code = randomUUID();
+      const futureTask = await repo.createResource<Task>({
+        resourceType: 'Task',
+        status: 'requested',
+        intent: 'order',
+        code: { coding: [{ code }] },
+        restriction: { period: { start: '2026-04-01T00:00:00.000Z', end: '2026-04-15T00:00:00.000Z' } },
+      });
+      const taskWithoutStart = await repo.createResource<Task>({
+        resourceType: 'Task',
+        status: 'requested',
+        intent: 'order',
+        code: { coding: [{ code }] },
+        restriction: { period: { end: '2026-04-15T00:00:00.000Z' } },
+      });
+      const currentTask = await repo.createResource<Task>({
+        resourceType: 'Task',
+        status: 'requested',
+        intent: 'order',
+        code: { coding: [{ code }] },
+        restriction: { period: { start: '2026-03-01T00:00:00.000Z', end: '2026-05-01T00:00:00.000Z' } },
+      });
+
+      const bundle = await repo.search<Task>({
+        resourceType: 'Task',
+        filters: [
+          { code: 'code', operator: Operator.EQUALS, value: code },
+          { code: 'not-before', operator: Operator.LESS_THAN_OR_EQUALS, value: '2026-03-06' },
+        ],
+      });
+
+      expect(bundle.entry).toHaveLength(1);
+      expect(bundleContains(bundle, currentTask)).toBeTruthy();
+      expect(bundleContains(bundle, futureTask)).not.toBeTruthy();
+      expect(bundleContains(bundle, taskWithoutStart)).not.toBeTruthy();
+    }));
+
   test('Get estimated count with filter on human name', async () =>
     withTestContext(async () => {
       const result = await repo.search({

--- a/packages/server/src/fhir/searchparameter.test.ts
+++ b/packages/server/src/fhir/searchparameter.test.ts
@@ -68,6 +68,15 @@ describe('SearchParameterImplementation', () => {
     expect(impl.columnName).toStrictEqual('authored');
   });
 
+  test('Task-not-before date param', () => {
+    const notBeforeParam = indexedSearchParams.find((e) => e.id === 'Task-not-before') as SearchParameter;
+    const impl = getSearchParameterImplementation('Task', notBeforeParam);
+    assertRangeColumnImplementation(impl);
+    expect(impl.columnName).toStrictEqual('notBefore');
+    expect(impl.rangeColumnName).toStrictEqual('__notBefore');
+    expect(impl.sortColumnName).toStrictEqual('__notBeforeSort');
+  });
+
   test('Get nested impl', () => {
     // expression: 'Patient.link.other'
     const missingExpressionParam = indexedSearchParams.find((e) => e.id === 'Patient-link') as SearchParameter;

--- a/packages/server/src/migrations/data/data-version-manifest.json
+++ b/packages/server/src/migrations/data/data-version-manifest.json
@@ -162,5 +162,8 @@
   },
   "v44": {
     "serverVersion": "5.1.33"
+  },
+  "v45": {
+    "serverVersion": "5.1.37"
   }
 }

--- a/packages/server/src/migrations/data/index.ts
+++ b/packages/server/src/migrations/data/index.ts
@@ -53,3 +53,4 @@ export * as v41 from './v41';
 export * as v42 from './v42';
 export * as v43 from './v43';
 export * as v44 from './v44';
+export * as v45 from './v45';

--- a/packages/server/src/migrations/data/v45.ts
+++ b/packages/server/src/migrations/data/v45.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * This is a generated file
+ * Do not edit manually.
+ */
+
+import type { PoolClient } from 'pg';
+import { prepareCustomMigrationJobData, runCustomMigration } from '../../workers/post-deploy-migration';
+import * as fns from '../migrate-functions';
+import type { MigrationActionResult } from '../types';
+import type { CustomPostDeployMigration } from './types';
+
+export const migration: CustomPostDeployMigration = {
+  type: 'custom',
+  prepareJobData: (asyncJob) => prepareCustomMigrationJobData(asyncJob),
+  run: async (repo, job, jobData) => runCustomMigration(repo, job, jobData, callback),
+};
+
+// prettier-ignore
+async function callback(client: PoolClient, results: MigrationActionResult[]): Promise<void> {
+  await fns.idempotentCreateIndex(client, results, 'Task_notBefore_idx', `CREATE INDEX CONCURRENTLY IF NOT EXISTS "Task_notBefore_idx" ON "Task" ("notBefore")`);
+  await fns.idempotentCreateIndex(client, results, 'Task___notBefore_sorted_idx', `CREATE INDEX CONCURRENTLY IF NOT EXISTS "Task___notBefore_sorted_idx" ON "Task" USING gist ("__notBefore", "__notBeforeSort")`);
+}

--- a/packages/server/src/migrations/schema/index.ts
+++ b/packages/server/src/migrations/schema/index.ts
@@ -129,3 +129,4 @@ export * as v115 from './v115';
 export * as v116 from './v116';
 export * as v117 from './v117';
 export * as v118 from './v118';
+export * as v119 from './v119';

--- a/packages/server/src/migrations/schema/v119.ts
+++ b/packages/server/src/migrations/schema/v119.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * This is a generated file
+ * Do not edit manually.
+ */
+
+import type { PoolClient } from 'pg';
+import * as fns from '../migrate-functions';
+
+// prettier-ignore
+export async function run(client: PoolClient): Promise<void> {
+  const results: { name: string; durationMs: number }[] = []
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "Task" ADD COLUMN IF NOT EXISTS "__notBefore" TSTZRANGE`);
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "Task" ADD COLUMN IF NOT EXISTS "__notBeforeSort" TIMESTAMPTZ`);
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "Task" ADD COLUMN IF NOT EXISTS "notBefore" TIMESTAMPTZ`);
+}


### PR DESCRIPTION
Fixes #8345

## Summary

- Add the `Task-not-before` date search parameter backed by `Task.restriction.period.start`.
- Keep the existing `due-date` behavior unchanged while allowing actionable start dates and due dates to be queried independently.
- Add schema/index migrations and document the new parameter.
- Cover MemoryRepository matching, server search parameter implementation, and PostgreSQL search behavior for Tasks with start-only, end-only, and start/end periods.

## Validation

- `npm run build --workspace=@medplum/definitions`
- `npm run build --workspace=@medplum/core`
- `npm run build --workspace=@medplum/fhir-router`
- `npm run build --workspace=@medplum/ccda`
- `npm run build --workspace=@medplum/server`
- Core matching tests: 56 passed
- Search parameter implementation tests: 33 passed
- Migration consistency tests: 10 passed
- Scoped ESLint and Prettier checks passed
- The PostgreSQL-backed search test was attempted but local PostgreSQL role `medplum` and Redis are unavailable in this environment.
