### PR TITLE
feat: add AccessPolicy identifier field

### DIFF
--- a/packages/core/src/search/match.test.ts
+++ b/packages/core/src/search/match.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { SEARCH_PARAMETER_BUNDLE_FILES, readJson } from '@medplum/definitions';
 import type {
+  AccessPolicy,
   ActivityDefinition,
   Bundle,
   DiagnosticReport,
@@ -503,6 +504,35 @@ describe('Search matching', () => {
         matchesSearchRequest(resource, {
           resourceType: 'Patient',
           filters: [{ code: 'identifier', operator: Operator.EQUALS, value: 'bar' }],
+        })
+      ).toBe(false);
+    });
+
+    test('AccessPolicy identifier filter value', () => {
+      const resource: AccessPolicy = {
+        resourceType: 'AccessPolicy',
+        identifier: [{ system: 'https://example.com/policies', value: 'policy-123' }],
+      };
+
+      expect(
+        matchesSearchRequest(resource, {
+          resourceType: 'AccessPolicy',
+          filters: [
+            {
+              code: 'identifier',
+              operator: Operator.EQUALS,
+              value: 'https://example.com/policies|policy-123',
+            },
+          ],
+        })
+      ).toBe(true);
+
+      expect(
+        matchesSearchRequest(resource, {
+          resourceType: 'AccessPolicy',
+          filters: [
+            { code: 'identifier', operator: Operator.EQUALS, value: 'https://other.example/policies|policy-123' },
+          ],
         })
       ).toBe(false);
     });

--- a/packages/definitions/src/fhir/r4/fhir.schema.json
+++ b/packages/definitions/src/fhir/r4/fhir.schema.json
@@ -62687,6 +62687,13 @@
           },
           "type": "array"
         },
+        "identifier": {
+          "description": "An identifier for this AccessPolicy.",
+          "items": {
+            "$ref": "#/definitions/Identifier"
+          },
+          "type": "array"
+        },
         "name": {
           "description": "A name associated with the AccessPolicy.",
           "$ref": "#/definitions/string"

--- a/packages/definitions/src/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/src/fhir/r4/profiles-medplum.json
@@ -4279,6 +4279,22 @@
             }]
           },
           {
+            "id" : "AccessPolicy.identifier",
+            "path" : "AccessPolicy.identifier",
+            "short" : "An identifier for this AccessPolicy",
+            "definition" : "An identifier for this AccessPolicy.",
+            "min" : 0,
+            "max" : "*",
+            "type" : [{
+              "code" : "Identifier"
+            }],
+            "base" : {
+              "path" : "AccessPolicy.identifier",
+              "min" : 0,
+              "max" : "*"
+            }
+          },
+          {
             "id" : "AccessPolicy.name",
             "path" : "AccessPolicy.name",
             "definition" : "A name associated with the AccessPolicy.",

--- a/packages/definitions/src/fhir/r4/search-parameters-medplum.json
+++ b/packages/definitions/src/fhir/r4/search-parameters-medplum.json
@@ -694,6 +694,23 @@
       }
     },
     {
+      "fullUrl": "https://medplum.com/fhir/SearchParameter/AccessPolicy-identifier",
+      "resource": {
+        "resourceType": "SearchParameter",
+        "id": "AccessPolicy-identifier",
+        "url": "https://medplum.com/fhir/SearchParameter/AccessPolicy-identifier",
+        "version": "4.0.1",
+        "name": "identifier",
+        "status": "draft",
+        "publisher": "Medplum",
+        "description": "An identifier for the access policy",
+        "code": "identifier",
+        "base": ["AccessPolicy"],
+        "type": "token",
+        "expression": "AccessPolicy.identifier"
+      }
+    },
+    {
       "fullUrl": "https://medplum.com/fhir/SearchParameter/BulkDataExport-status",
       "resource": {
         "resourceType": "SearchParameter",

--- a/packages/docs/static/data/medplumDefinitions/accesspolicy.json
+++ b/packages/docs/static/data/medplumDefinitions/accesspolicy.json
@@ -160,6 +160,23 @@
       "base": "DomainResource"
     },
     {
+      "name": "identifier",
+      "depth": 1,
+      "types": [
+        {
+          "datatype": "Identifier",
+          "documentLocation": "datatype"
+        }
+      ],
+      "path": "AccessPolicy.identifier",
+      "min": 0,
+      "max": "*",
+      "short": "An identifier for this AccessPolicy",
+      "definition": "An identifier for this AccessPolicy.",
+      "comment": "",
+      "inherited": false
+    },
+    {
       "name": "name",
       "depth": 1,
       "types": [
@@ -434,6 +451,12 @@
       "type": "string",
       "description": "The name of the access policy",
       "expression": "AccessPolicy.name"
+    },
+    {
+      "name": "identifier",
+      "type": "token",
+      "description": "An identifier for the access policy",
+      "expression": "AccessPolicy.identifier"
     }
   ]
 }

--- a/packages/fhirtypes/dist/AccessPolicy.d.ts
+++ b/packages/fhirtypes/dist/AccessPolicy.d.ts
@@ -7,6 +7,7 @@
 
 import type { Expression } from './Expression.d.ts';
 import type { Extension } from './Extension.d.ts';
+import type { Identifier } from './Identifier.d.ts';
 import type { Meta } from './Meta.d.ts';
 import type { Narrative } from './Narrative.d.ts';
 import type { Reference } from './Reference.d.ts';
@@ -93,6 +94,11 @@ export interface AccessPolicy {
    * modifierExtension itself).
    */
   modifierExtension?: Extension[];
+
+  /**
+   * An identifier for this AccessPolicy.
+   */
+  identifier?: Identifier[];
 
   /**
    * A name associated with the AccessPolicy.

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -337,8 +337,9 @@ export class Repository extends FhirRepository implements Disposable {
    *                Project.link (https://github.com/medplum/medplum/pull/9159)
    * 16. 06/30/26 - Added search param: Provenance-activity (https://github.com/medplum/medplum/pull/9709)
    * 17. 08/27/26 - Added search param: PractitionerRole-davinci-pdex-network
+   * 18. 09/03/26 - Added AccessPolicy.identifier and search param: AccessPolicy-identifier
    */
-  static readonly VERSION: number = 17;
+  static readonly VERSION: number = 18;
 
   /**
    * Constructs a new Repository instance.

--- a/packages/server/src/fhir/searchparameter.test.ts
+++ b/packages/server/src/fhir/searchparameter.test.ts
@@ -257,6 +257,16 @@ describe('SearchParameterImplementation', () => {
     }
   );
 
+  test('AccessPolicy-identifier uses dedicated token columns', () => {
+    const searchParam = indexedSearchParams.find((e) => e.id === 'AccessPolicy-identifier') as SearchParameter;
+    const impl = getSearchParameterImplementation('AccessPolicy', searchParam);
+    expectTokenColumnImplementation(impl);
+    expect(impl.hasDedicatedColumns).toBe(true);
+    expect(impl.tokenColumnName).toStrictEqual('__identifier');
+    expect(impl.textSearchColumnName).toStrictEqual('__identifierText');
+    expect(impl.sortColumnName).toStrictEqual('__identifierSort');
+  });
+
   test('MedicationRequest-code legacy behavior', () => {
     const searchParam = indexedSearchParams.find((e) => e.id === 'clinical-code') as SearchParameter;
     const impl = getSearchParameterImplementation('MedicationRequest', searchParam);

--- a/packages/server/src/fhir/tokens.test.ts
+++ b/packages/server/src/fhir/tokens.test.ts
@@ -3,6 +3,7 @@
 import type { WithId } from '@medplum/core';
 import { createReference, getReferenceString, getSearchParameter, Operator, SNOMED } from '@medplum/core';
 import type {
+  AccessPolicy,
   Bundle,
   Condition,
   Identifier,
@@ -516,6 +517,31 @@ test('Search on system', () =>
     expect(searchResult2.entry?.length).toStrictEqual(1);
     expect(bundleContains(searchResult2, patient1)).toBeUndefined();
     expect(bundleContains(searchResult2, patient2)).toBeDefined();
+  }));
+
+test('AccessPolicy identifier exact search', () =>
+  withTestContext(async () => {
+    const system1 = 'https://foo.example.com/policies';
+    const system2 = 'https://bar.example.com/policies';
+    const identifier = randomUUID();
+
+    const accessPolicy1 = await systemRepo.createResource<AccessPolicy>({
+      resourceType: 'AccessPolicy',
+      identifier: [{ system: system1, value: identifier }],
+    });
+
+    const accessPolicy2 = await systemRepo.createResource<AccessPolicy>({
+      resourceType: 'AccessPolicy',
+      identifier: [{ system: system2, value: identifier }],
+    });
+
+    const searchResult = await systemRepo.search({
+      resourceType: 'AccessPolicy',
+      filters: [{ code: 'identifier', operator: Operator.EXACT, value: `${system1}|${identifier}` }],
+    });
+    expect(searchResult.entry?.length).toStrictEqual(1);
+    expect(bundleContains(searchResult, accessPolicy1)).toBeDefined();
+    expect(bundleContains(searchResult, accessPolicy2)).toBeUndefined();
   }));
 
 test('Non-array identifier', () =>

--- a/packages/server/src/migrations/data/data-version-manifest.json
+++ b/packages/server/src/migrations/data/data-version-manifest.json
@@ -162,5 +162,8 @@
   },
   "v44": {
     "serverVersion": "5.1.33"
+  },
+  "v45": {
+    "serverVersion": "5.1.37"
   }
 }

--- a/packages/server/src/migrations/data/index.ts
+++ b/packages/server/src/migrations/data/index.ts
@@ -53,3 +53,4 @@ export * as v41 from './v41';
 export * as v42 from './v42';
 export * as v43 from './v43';
 export * as v44 from './v44';
+export * as v45 from './v45';

--- a/packages/server/src/migrations/data/v45.ts
+++ b/packages/server/src/migrations/data/v45.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * This is a generated file
+ * Do not edit manually.
+ */
+
+import type { PoolClient } from 'pg';
+import { prepareCustomMigrationJobData, runCustomMigration } from '../../workers/post-deploy-migration';
+import * as fns from '../migrate-functions';
+import type { MigrationActionResult } from '../types';
+import type { CustomPostDeployMigration } from './types';
+
+export const migration: CustomPostDeployMigration = {
+  type: 'custom',
+  prepareJobData: (asyncJob) => prepareCustomMigrationJobData(asyncJob),
+  run: async (repo, job, jobData) => runCustomMigration(repo, job, jobData, callback),
+};
+
+// prettier-ignore
+async function callback(client: PoolClient, results: MigrationActionResult[]): Promise<void> {
+  await fns.idempotentCreateIndex(client, results, 'AccessPolicy___idnt_idx', `CREATE INDEX CONCURRENTLY IF NOT EXISTS "AccessPolicy___idnt_idx" ON "AccessPolicy" USING gin ("__identifier")`);
+  await fns.idempotentCreateIndex(client, results, 'AccessPolicy___idntTextTrgm_idx', `CREATE INDEX CONCURRENTLY IF NOT EXISTS "AccessPolicy___idntTextTrgm_idx" ON "AccessPolicy" USING gin (token_array_to_text("__identifierText") gin_trgm_ops)`);
+}

--- a/packages/server/src/migrations/schema/index.ts
+++ b/packages/server/src/migrations/schema/index.ts
@@ -129,3 +129,4 @@ export * as v115 from './v115';
 export * as v116 from './v116';
 export * as v117 from './v117';
 export * as v118 from './v118';
+export * as v119 from './v119';

--- a/packages/server/src/migrations/schema/v119.ts
+++ b/packages/server/src/migrations/schema/v119.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * This is a generated file
+ * Do not edit manually.
+ */
+
+import type { PoolClient } from 'pg';
+import * as fns from '../migrate-functions';
+
+// prettier-ignore
+export async function run(client: PoolClient): Promise<void> {
+  const results: { name: string; durationMs: number }[] = [];
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "AccessPolicy" ADD COLUMN IF NOT EXISTS "__identifier" UUID[]`);
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "AccessPolicy" ADD COLUMN IF NOT EXISTS "__identifierText" TEXT[]`);
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "AccessPolicy" ADD COLUMN IF NOT EXISTS "__identifierSort" TEXT`);
+}


### PR DESCRIPTION
Fixes #9618

## Summary

- Add `identifier` to the Medplum `AccessPolicy` StructureDefinition and generated FHIR artifacts.
- Add the `AccessPolicy-identifier` token SearchParameter and generated documentation data.
- Add dedicated token columns, indexes, and migrations for AccessPolicy identifier search.
- Add exact `system|value` search regression coverage in core and server tests.

## Validation

- `npm test --workspace=@medplum/definitions`
- `npm test --workspace=@medplum/core -- src/search/match.test.ts`
- `npm test --workspace=@medplum/server -- src/fhir/searchparameter.test.ts`
- `npm test --workspace=@medplum/server -- src/migrations/migrate-main.test.ts src/migrations/data/data-version-manifest.test.ts`
- `npm run build --workspace=@medplum/definitions`
- `npm run build --workspace=@medplum/core`
- `npm run build --workspace=@medplum/fhir-router`
- `npm run build --workspace=@medplum/ccda`
- `npm run build --workspace=@medplum/server`
- `npx eslint` on changed TypeScript files
- `npx prettier --check` on changed files

The DB-backed token integration test is included but could not run locally because the configured PostgreSQL role `medplum` and Redis service were unavailable.
