### PR TITLE
fix: make undeployed bot errors actionable

### DIFF
--- a/packages/server/src/bots/utils.ts
+++ b/packages/server/src/bots/utils.ts
@@ -41,6 +41,8 @@ import { getBinaryStorage } from '../storage/loader';
 import { findProjectMembership } from '../workers/utils';
 import type { BotExecutionRequest, BotExecutionResult } from './types';
 
+export const BOT_NOT_DEPLOYED_MESSAGE = 'Bot likely needs to be deployed: Bot/$deploy first';
+
 /**
  * Returns the bot's project membership.
  * If the bot is configured to run as the user, then use the current user's membership.

--- a/packages/server/src/bots/vmcontext.ts
+++ b/packages/server/src/bots/vmcontext.ts
@@ -18,6 +18,7 @@ import { getBinaryStorage } from '../storage/loader';
 import { MockConsole } from '../util/console';
 import { readStreamToString } from '../util/streams';
 import type { BotExecutionContext, BotExecutionResult } from './types';
+import { BOT_NOT_DEPLOYED_MESSAGE } from './utils';
 
 /*
  * SECURITY NOTE: VMContext Bots execute administrator-provided JavaScript inside
@@ -61,7 +62,7 @@ export async function runInVmContext(request: BotExecutionContext): Promise<BotE
 
   const codeUrl = bot.executableCode?.url;
   if (!codeUrl) {
-    return { success: false, logResult: 'No executable code' };
+    return { success: false, logResult: `No executable code. ${BOT_NOT_DEPLOYED_MESSAGE}` };
   }
   if (!codeUrl.startsWith('Binary/')) {
     return { success: false, logResult: 'Executable code is not a Binary' };

--- a/packages/server/src/cloud/aws/execute.test.ts
+++ b/packages/server/src/cloud/aws/execute.test.ts
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { InvokeCommand, LambdaClient, ListLayerVersionsCommand } from '@aws-sdk/client-lambda';
+import {
+  InvokeCommand,
+  LambdaClient,
+  ListLayerVersionsCommand,
+  ResourceNotFoundException,
+} from '@aws-sdk/client-lambda';
 import { badRequest, ContentType } from '@medplum/core';
 import type { Bot } from '@medplum/fhirtypes';
 import type { AwsClientStub } from 'aws-sdk-client-mock';
@@ -164,6 +169,22 @@ describe('Execute', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .send({});
     expect(res2).toHaveStatus(400);
+  });
+
+  test('Execute before Lambda deployment returns an actionable error', async () => {
+    mockLambdaClient
+      .on(InvokeCommand)
+      .rejects(new ResourceNotFoundException({ $metadata: {}, message: 'Function not found' }));
+
+    const res = await request(app)
+      .post(`/fhir/R4/Bot/${bot.id}/$execute`)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({});
+    expect(res).toHaveStatus(400);
+    expect(res.body.issue[0].details.text).toStrictEqual(
+      'Function not found. Bot likely needs to be deployed: Bot/$deploy first'
+    );
   });
 
   test('Unsupported runtime version', async () => {

--- a/packages/server/src/cloud/aws/execute.ts
+++ b/packages/server/src/cloud/aws/execute.ts
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { InvokeCommand, LambdaClient } from '@aws-sdk/client-lambda';
+import { InvokeCommand, LambdaClient, ResourceNotFoundException } from '@aws-sdk/client-lambda';
 import { Hl7Message, createReference, getIdentifier, normalizeErrorString } from '@medplum/core';
 import type { Bot } from '@medplum/fhirtypes';
 import { TextDecoder, TextEncoder } from 'node:util';
 import type { BotExecutionContext, BotExecutionResult } from '../../bots/types';
+import { BOT_NOT_DEPLOYED_MESSAGE } from '../../bots/utils';
 import { getConfig } from '../../config/loader';
 
 let client: LambdaClient;
@@ -77,9 +78,23 @@ export async function runInLambda(request: BotExecutionContext): Promise<BotExec
   } catch (err) {
     return {
       success: false,
-      logResult: normalizeErrorString(err),
+      logResult: isLambdaFunctionNotFoundError(err)
+        ? `Function not found. ${BOT_NOT_DEPLOYED_MESSAGE}`
+        : normalizeErrorString(err),
     };
   }
+}
+
+/**
+ * Returns true when AWS could not find the Lambda function for a Bot.
+ * @param err - The error returned by AWS.
+ * @returns True if the error indicates a missing Lambda function.
+ */
+export function isLambdaFunctionNotFoundError(err: unknown): boolean {
+  return (
+    err instanceof ResourceNotFoundException ||
+    (typeof err === 'object' && err !== null && (err as { name?: unknown }).name === 'ResourceNotFoundException')
+  );
 }
 
 /**

--- a/packages/server/src/cloud/aws/executestreaming.test.ts
+++ b/packages/server/src/cloud/aws/executestreaming.test.ts
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { InvokeWithResponseStreamCommand, LambdaClient, ListLayerVersionsCommand } from '@aws-sdk/client-lambda';
+import {
+  InvokeWithResponseStreamCommand,
+  LambdaClient,
+  ListLayerVersionsCommand,
+  ResourceNotFoundException,
+} from '@aws-sdk/client-lambda';
 import { badRequest, ContentType, getStatus } from '@medplum/core';
 import type { Bot } from '@medplum/fhirtypes';
 import type { AwsClientStub } from 'aws-sdk-client-mock';
@@ -192,6 +197,23 @@ describe('Execute', () => {
         .send('input');
       expect(res).toHaveStatus(400);
       expect(res.body.issue[0].details.text).toContain('Lambda error: Unhandled');
+    });
+
+    test('Streaming execution before Lambda deployment returns an actionable error', async () => {
+      mockLambdaClient
+        .on(InvokeWithResponseStreamCommand)
+        .rejects(new ResourceNotFoundException({ $metadata: {}, message: 'Function not found' }));
+
+      const res = await request(app)
+        .post(`/fhir/R4/Bot/${streamingBot.id}/$execute`)
+        .set('Content-Type', ContentType.TEXT)
+        .set('Accept', 'text/event-stream')
+        .set('Authorization', 'Bearer ' + accessToken)
+        .send('input');
+      expect(res).toHaveStatus(400);
+      expect(res.body.issue[0].details.text).toStrictEqual(
+        'Function not found. Bot likely needs to be deployed: Bot/$deploy first'
+      );
     });
 
     test('Streaming execution with headers split across chunks', async () => {

--- a/packages/server/src/cloud/aws/executestreaming.ts
+++ b/packages/server/src/cloud/aws/executestreaming.ts
@@ -4,11 +4,13 @@ import { InvokeWithResponseStreamCommand } from '@aws-sdk/client-lambda';
 import { normalizeErrorString } from '@medplum/core';
 import { TextDecoder, TextEncoder } from 'node:util';
 import type { BotExecutionContext, BotExecutionResult } from '../../bots/types';
+import { BOT_NOT_DEPLOYED_MESSAGE } from '../../bots/utils';
 import { getLogger } from '../../logger';
 import {
   buildLambdaPayload,
   getExecuteLambdaClient,
   getLambdaFunctionName,
+  isLambdaFunctionNotFoundError,
   parseLambdaLog,
   sanitizeLogResult,
 } from './execute';
@@ -41,7 +43,12 @@ export async function runInLambdaStreaming(request: BotExecutionContext): Promis
 
     return await processEventStream(response.EventStream, responseStream);
   } catch (err) {
-    return { success: false, logResult: normalizeErrorString(err) };
+    return {
+      success: false,
+      logResult: isLambdaFunctionNotFoundError(err)
+        ? `Function not found. ${BOT_NOT_DEPLOYED_MESSAGE}`
+        : normalizeErrorString(err),
+    };
   }
 }
 

--- a/packages/server/src/fhir/operations/execute.test.ts
+++ b/packages/server/src/fhir/operations/execute.test.ts
@@ -419,7 +419,9 @@ describe('Execute', () => {
       .set('Authorization', 'Bearer ' + accessToken1)
       .send({});
     expect(res2).toHaveStatus(400);
-    expect(res2.body.issue[0].details.text).toStrictEqual('No executable code');
+    expect(res2.body.issue[0].details.text).toStrictEqual(
+      'No executable code. Bot likely needs to be deployed: Bot/$deploy first'
+    );
 
     // Update the bot with an invalid code URL
     const res3 = await request(app)


### PR DESCRIPTION
## Summary

- add a shared actionable deployment hint for bots that have not been deployed
- preserve the underlying No executable code and Function not found causes across VM, Lambda, and streaming Lambda execution
- add regression coverage for all affected execution paths

## Testing

- npm run build --workspace=@medplum/definitions
- npm run build --workspace=@medplum/core
- npm run build --workspace=@medplum/fhir-router
- npm run build --workspace=@medplum/ccda
- npm run build --workspace=@medplum/server
- targeted Prettier and ESLint checks
- direct VM and Lambda missing-deployment checks
- targeted Vitest suites could not initialize because the local PostgreSQL medplum role and Redis service are unavailable

Fixes #6551