### PR TITLE
Allow dropping invalid indexes in any schema

### DIFF
--- a/packages/server/src/admin/super.ts
+++ b/packages/server/src/admin/super.ts
@@ -518,8 +518,14 @@ superAdminRouter.post(
       .isObject({ strict: true })
       .withMessage('Each target must be an object')
       .bail()
-      .custom((target) => Object.keys(target).length === 1 && 'index' in target)
-      .withMessage('Each target must contain exactly index'),
+      .custom((target) => Object.keys(target).length === 2 && 'schema' in target && 'index' in target)
+      .withMessage('Each target must contain exactly schema and index'),
+    body('targets.*.schema')
+      .isString()
+      .withMessage('Schema name must be a string')
+      .bail()
+      .custom(isValidPostgresIdentifier)
+      .withMessage('Invalid schema name'),
     body('targets.*.index')
       .isString()
       .withMessage('Index name must be a string')
@@ -543,13 +549,14 @@ superAdminRouter.post(
       preDeploy: [],
       postDeploy: targets.map((target) => ({
         type: 'DROP_INVALID_INDEX' as const,
+        schemaName: target.schema,
         indexName: target.index,
       })),
     };
 
     const requestParams = new URLSearchParams();
     for (const target of targets) {
-      requestParams.append('index', target.index);
+      requestParams.append('index', `${target.schema}.${target.index}`);
     }
 
     const exec = new AsyncJobExecutor(ctx.systemRepo);
@@ -564,7 +571,7 @@ superAdminRouter.post(
   }
 );
 
-type DropInvalidIndexTarget = { index: string };
+type DropInvalidIndexTarget = { schema: string; index: string };
 
 // POST to /admin/super/setdataversion
 // to set the data version of the database.

--- a/packages/server/src/database-migration.test.ts
+++ b/packages/server/src/database-migration.test.ts
@@ -926,8 +926,8 @@ describe('Database migrations', () => {
     describe('Drop invalid indexes', () => {
       test('Queues explicitly selected invalid index cleanup actions', async () => {
         const targets = [
-          { index: 'AuditEvent_References_pkey_ccnew' },
-          { index: 'AuditEvent_References_targetId_code_idx_ccnew' },
+          { schema: 'public', index: 'AuditEvent_References_pkey_ccnew' },
+          { schema: 'pg_toast', index: 'pg_toast_2539493_index_ccnew' },
         ];
         const queueAddSpy = getQueueAddSpy();
 
@@ -949,18 +949,20 @@ describe('Database migrations', () => {
             postDeploy: [
               {
                 type: 'DROP_INVALID_INDEX',
+                schemaName: 'public',
                 indexName: 'AuditEvent_References_pkey_ccnew',
               },
               {
                 type: 'DROP_INVALID_INDEX',
-                indexName: 'AuditEvent_References_targetId_code_idx_ccnew',
+                schemaName: 'pg_toast',
+                indexName: 'pg_toast_2539493_index_ccnew',
               },
             ],
           },
         });
         const asyncJob = await systemRepo.readResource<AsyncJob>('AsyncJob', jobData.asyncJobId);
         expect(asyncJob.request).toBe(
-          '/admin/super/drop-invalid-indexes?index=AuditEvent_References_pkey_ccnew&index=AuditEvent_References_targetId_code_idx_ccnew'
+          '/admin/super/drop-invalid-indexes?index=public.AuditEvent_References_pkey_ccnew&index=pg_toast.pg_toast_2539493_index_ccnew'
         );
         expect(asyncJob.meta?.project).toBeUndefined();
       });
@@ -968,15 +970,17 @@ describe('Database migrations', () => {
       test.each([
         {},
         { targets: [] },
-        { targets: Array.from({ length: 11 }, (_, index) => ({ index: `Index${index}` })) },
+        { targets: Array.from({ length: 11 }, (_, index) => ({ schema: 'public', index: `Index${index}` })) },
         { targets: 'AuditEvent_References_pkey_ccnew' },
         { targets: [123] },
         { targets: [{}] },
         { targets: [{ schema: 'public' }] },
-        { targets: [{ schema: 'public', index: 'AuditEvent_References_pkey_ccnew' }] },
+        { targets: [{ index: 'AuditEvent_References_pkey_ccnew' }] },
         { targets: [{ schema: 'public', index: 'AuditEvent_References_pkey_ccnew', extra: true }] },
-        { targets: [{ index: 123 }] },
-        { targets: [{ index: 'index; DROP TABLE Patient' }] },
+        { targets: [{ schema: 123, index: 'AuditEvent_References_pkey_ccnew' }] },
+        { targets: [{ schema: 'schema; DROP SCHEMA public', index: 'AuditEvent_References_pkey_ccnew' }] },
+        { targets: [{ schema: 'public', index: 123 }] },
+        { targets: [{ schema: 'public', index: 'index; DROP TABLE Patient' }] },
       ])('Rejects invalid input: %j', async (body) => {
         const queueAddSpy = getQueueAddSpy();
 

--- a/packages/server/src/migrations/migrate-functions.test.ts
+++ b/packages/server/src/migrations/migrate-functions.test.ts
@@ -25,7 +25,7 @@ interface IndexInfo {
   is_live: boolean;
   index_definition: string;
 }
-async function getTableIndexes(client: PgQueryable, tableName: string): Promise<IndexInfo[]> {
+async function getTableIndexes(client: PgQueryable, tableName: string, schemaName = 'public'): Promise<IndexInfo[]> {
   return client
     .query<IndexInfo>(
       `SELECT
@@ -44,8 +44,8 @@ async function getTableIndexes(client: PgQueryable, tableName: string): Promise<
         JOIN pg_class t ON t.oid = idx.indrelid
         JOIN pg_am am ON am.oid = i.relam
         JOIN pg_namespace n ON n.oid = t.relnamespace
-        WHERE t.relname = $1 AND n.nspname = 'public'`,
-      [tableName]
+        WHERE t.relname = $1 AND n.nspname = $2`,
+      [tableName, schemaName]
     )
     .then((results) => results.rows);
 }
@@ -135,7 +135,7 @@ describe('migrate-functions', () => {
       );
       const results: MigrationActionResult[] = [];
 
-      await dropInvalidIndexConcurrently(client, results, indexName);
+      await dropInvalidIndexConcurrently(client, results, 'public', indexName);
 
       expect(results).toEqual([
         {
@@ -146,10 +146,44 @@ describe('migrate-functions', () => {
       expect(await getTableIndexes(client, tableName)).toHaveLength(0);
     });
 
+    test('drops an invalid index outside the public schema', async () => {
+      const schemaName = 'test_index_cleanup';
+      const schemaIndexName = 'Test_Table_schema_idx_ccnew';
+      const qualifiedTableName = `${escapeIdentifier(schemaName)}.${escapedTableName}`;
+      await client.query(`CREATE SCHEMA IF NOT EXISTS ${escapeIdentifier(schemaName)}`);
+      try {
+        await client.query(`DROP TABLE IF EXISTS ${qualifiedTableName}`);
+        await client.query(`CREATE TABLE ${qualifiedTableName} (id INTEGER NOT NULL)`);
+        await client.query(`CREATE INDEX ${escapeIdentifier(schemaIndexName)} ON ${qualifiedTableName} (id)`);
+        await client.query(
+          `UPDATE pg_index SET indisvalid = false
+          FROM pg_class, pg_namespace
+          WHERE pg_class.oid = pg_index.indexrelid
+            AND pg_namespace.oid = pg_class.relnamespace
+            AND pg_namespace.nspname = $1
+            AND pg_class.relname = $2`,
+          [schemaName, schemaIndexName]
+        );
+        const results: MigrationActionResult[] = [];
+
+        await dropInvalidIndexConcurrently(client, results, schemaName, schemaIndexName);
+
+        expect(results).toEqual([
+          {
+            name: `DROP INDEX CONCURRENTLY IF EXISTS ${escapeIdentifier(schemaName)}.${escapeIdentifier(schemaIndexName)}`,
+            durationMs: expect.any(Number),
+          },
+        ]);
+        expect(await getTableIndexes(client, tableName, schemaName)).toHaveLength(0);
+      } finally {
+        await client.query(`DROP SCHEMA ${escapeIdentifier(schemaName)} CASCADE`);
+      }
+    });
+
     test('is a no-op if the index no longer exists', async () => {
       const results: MigrationActionResult[] = [];
 
-      await dropInvalidIndexConcurrently(client, results, indexName);
+      await dropInvalidIndexConcurrently(client, results, 'public', indexName);
 
       expect(results).toEqual([
         {
@@ -163,7 +197,7 @@ describe('migrate-functions', () => {
     test('refuses to drop a valid index', async () => {
       await client.query(`CREATE INDEX ${escapeIdentifier(indexName)} ON ${escapedTableName} (id)`);
 
-      await expect(dropInvalidIndexConcurrently(client, [], indexName)).rejects.toThrow(
+      await expect(dropInvalidIndexConcurrently(client, [], 'public', indexName)).rejects.toThrow(
         `Cannot drop valid index "public".${escapeIdentifier(indexName)}`
       );
       expect(await getTableIndexes(client, tableName)).toHaveLength(1);
@@ -178,14 +212,17 @@ describe('migrate-functions', () => {
         [primaryIndexName]
       );
 
-      await expect(dropInvalidIndexConcurrently(client, [], primaryIndexName)).rejects.toThrow(
+      await expect(dropInvalidIndexConcurrently(client, [], 'public', primaryIndexName)).rejects.toThrow(
         `Cannot drop primary index "public".${escapeIdentifier(primaryIndexName)}`
       );
       expect(await getTableIndexes(client, tableName)).toHaveLength(1);
     });
 
     test('rejects invalid identifiers', async () => {
-      await expect(dropInvalidIndexConcurrently(client, [], 'index; DROP TABLE Patient')).rejects.toThrow(
+      await expect(dropInvalidIndexConcurrently(client, [], 'schema; DROP SCHEMA public', indexName)).rejects.toThrow(
+        'Invalid PostgreSQL schema name'
+      );
+      await expect(dropInvalidIndexConcurrently(client, [], 'public', 'index; DROP TABLE Patient')).rejects.toThrow(
         'Invalid PostgreSQL index name'
       );
     });

--- a/packages/server/src/migrations/migrate-functions.ts
+++ b/packages/server/src/migrations/migrate-functions.ts
@@ -3,7 +3,7 @@
 import type { PoolClient, QueryResult, QueryResultRow } from 'pg';
 import { escapeIdentifier } from 'pg';
 import type { UpdateQuery } from '../fhir/sql';
-import { isValidPostgresIdentifier, PUBLIC_SCHEMA, SqlBuilder } from '../fhir/sql';
+import { isValidPostgresIdentifier, SqlBuilder } from '../fhir/sql';
 import { globalLogger } from '../logger';
 import { getCheckConstraints } from './migrate';
 import { getColumns } from './migrate-utils';
@@ -54,13 +54,17 @@ export async function reindexConcurrently(
 export async function dropInvalidIndexConcurrently(
   client: PoolClient,
   results: MigrationActionResult[],
+  schemaName: string,
   indexName: string
 ): Promise<void> {
+  if (!isValidPostgresIdentifier(schemaName)) {
+    throw new Error(`Invalid PostgreSQL schema name: ${schemaName}`);
+  }
   if (!isValidPostgresIdentifier(indexName)) {
     throw new Error(`Invalid PostgreSQL index name: ${indexName}`);
   }
 
-  const qualifiedIndexName = `${escapeIdentifier(PUBLIC_SCHEMA)}.${escapeIdentifier(indexName)}`;
+  const qualifiedIndexName = `${escapeIdentifier(schemaName)}.${escapeIdentifier(indexName)}`;
   const indexResult = await client.query<{
     is_valid: boolean;
     is_primary: boolean;
@@ -84,7 +88,7 @@ export async function dropInvalidIndexConcurrently(
     JOIN pg_class index_class ON index_class.oid = i.indexrelid
     JOIN pg_namespace index_namespace ON index_namespace.oid = index_class.relnamespace
     WHERE index_namespace.nspname = $1 AND index_class.relname = $2`,
-    [PUBLIC_SCHEMA, indexName]
+    [schemaName, indexName]
   );
 
   if (indexResult.rows.length === 0) {

--- a/packages/server/src/migrations/migrate.test.ts
+++ b/packages/server/src/migrations/migrate.test.ts
@@ -441,6 +441,33 @@ describe('Generator', () => {
   });
 
   describe('generateIndexesActions', () => {
+    test('allows a primary key to satisfy a structurally identical unique index declaration', () => {
+      const startTable: TableDefinition = {
+        name: 'Coding',
+        columns: [{ name: 'id', type: 'BIGSERIAL', primaryKey: true }],
+        indexes: [
+          {
+            columns: ['id'],
+            indexType: 'btree',
+            unique: true,
+            indexdef: 'CREATE UNIQUE INDEX "Coding_pkey" ON public."Coding" USING btree (id)',
+          },
+        ],
+      };
+      const targetTable: TableDefinition = {
+        name: 'Coding',
+        columns: [{ name: 'id', type: 'BIGSERIAL', primaryKey: true }],
+        indexes: [{ columns: ['id'], indexType: 'btree', unique: true }],
+      };
+
+      const result = generateIndexesActions(startTable, targetTable, {
+        dbClient: getDatabasePool(DatabaseMode.WRITER),
+        dropUnmatchedIndexes: true,
+      });
+
+      expect(result).toEqual({ preDeploy: [], postDeploy: [] });
+    });
+
     test('drops concurrent rebuild indexes instead of valid indexes with the same definition', () => {
       const primaryKeyDefinition = {
         columns: ['resourceId', 'targetId', 'code'],
@@ -714,13 +741,15 @@ const migrationActionTestCases: MigrationActionTestCase[] = [
   },
   {
     name: 'DROP_INVALID_INDEX',
-    action: {
-      type: 'DROP_INVALID_INDEX',
-      indexName: 'Patient_name_idx_ccnew',
-    },
-    builderExpected: 'await fns.dropInvalidIndexConcurrently(client, results, "Patient_name_idx_ccnew");',
+    action: { type: 'DROP_INVALID_INDEX', schemaName: 'public', indexName: 'Patient_name_idx_ccnew' },
+    builderExpected: "await fns.dropInvalidIndexConcurrently(client, results, 'public', 'Patient_name_idx_ccnew');",
     executionCheck: ({ mockDropInvalidIndexConcurrently, mockClient, results }) => {
-      expect(mockDropInvalidIndexConcurrently).toHaveBeenCalledWith(mockClient, results, 'Patient_name_idx_ccnew');
+      expect(mockDropInvalidIndexConcurrently).toHaveBeenCalledWith(
+        mockClient,
+        results,
+        'public',
+        'Patient_name_idx_ccnew'
+      );
     },
   },
   {

--- a/packages/server/src/migrations/migrate.ts
+++ b/packages/server/src/migrations/migrate.ts
@@ -643,11 +643,7 @@ function buildCodingTable(result: SchemaDefinition): void {
   result.tables.push({
     name: 'Coding',
     columns: [
-      {
-        name: 'id',
-        type: 'BIGSERIAL',
-        primaryKey: true,
-      },
+      { name: 'id', type: 'BIGSERIAL', primaryKey: true },
       { name: 'system', type: 'UUID', notNull: true },
       { name: 'code', type: 'TEXT', notNull: true },
       { name: 'display', type: 'TEXT' },
@@ -656,7 +652,6 @@ function buildCodingTable(result: SchemaDefinition): void {
       { name: 'language', type: 'TEXT' },
     ],
     indexes: [
-      { columns: ['id'], indexType: 'btree', unique: true },
       {
         columns: ['system', 'code'],
         indexType: 'btree',
@@ -727,11 +722,7 @@ function buildCodeSystemPropertyTable(result: SchemaDefinition): void {
   result.tables.push({
     name: 'CodeSystem_Property',
     columns: [
-      {
-        name: 'id',
-        type: 'BIGSERIAL',
-        primaryKey: true,
-      },
+      { name: 'id', type: 'BIGSERIAL', primaryKey: true },
       { name: 'system', type: 'UUID', notNull: true },
       { name: 'code', type: 'TEXT', notNull: true },
       { name: 'type', type: 'TEXT', notNull: true },
@@ -880,7 +871,7 @@ export async function executeMigrationActions(
         break;
       }
       case 'DROP_INVALID_INDEX': {
-        await fns.dropInvalidIndexConcurrently(client, results, action.indexName);
+        await fns.dropInvalidIndexConcurrently(client, results, action.schemaName, action.indexName);
         break;
       }
       case 'REINDEX_CONCURRENTLY': {
@@ -1051,7 +1042,9 @@ export function writeActionsToBuilder(b: FileBuilder, actions: MigrationAction[]
         break;
       }
       case 'DROP_INVALID_INDEX': {
-        b.appendNoWrap(`await fns.dropInvalidIndexConcurrently(client, results, ${JSON.stringify(action.indexName)});`);
+        b.appendNoWrap(
+          `await fns.dropInvalidIndexConcurrently(client, results, '${action.schemaName}', '${action.indexName}');`
+        );
         break;
       }
       case 'REINDEX_CONCURRENTLY': {
@@ -1271,9 +1264,9 @@ export function generateIndexesActions(
     assert(!seenIndexNames.has(indexName), new Error('Duplicate index name: ' + indexName, { cause: targetIndex }));
     seenIndexNames.add(indexName);
 
-    const matchingStartIndexes = startTable.indexes.filter(
-      (i) => !matchedIndexes.has(i) && indexDefinitionsEqual(i, targetIndex)
-    );
+    // A physical index can satisfy multiple structurally identical target declarations, such as a unique index
+    // declaration that duplicates a primary key. Preserve that compatibility while preferring the expected name.
+    const matchingStartIndexes = startTable.indexes.filter((i) => indexDefinitionsEqual(i, targetIndex));
     // REINDEX CONCURRENTLY can leave a duplicate _ccnew/_ccold index behind after a failure. Prefer the expected
     // name, then any established legacy name, so the temporary copy is the index classified as unmatched.
     const startIndex =

--- a/packages/server/src/migrations/types.ts
+++ b/packages/server/src/migrations/types.ts
@@ -72,7 +72,7 @@ export type MigrationAction =
   | { type: 'ALTER_COLUMN_TYPE'; tableName: string; columnName: string; columnType: string }
   | { type: 'CREATE_INDEX'; indexName: string; createIndexSql: string }
   | { type: 'DROP_INDEX'; indexName: string }
-  | { type: 'DROP_INVALID_INDEX'; indexName: string }
+  | { type: 'DROP_INVALID_INDEX'; schemaName: string; indexName: string }
   | { type: 'REINDEX_CONCURRENTLY'; target: 'INDEX' | 'TABLE'; name: string }
   | { type: 'ADD_CONSTRAINT'; tableName: string; constraintName: string; constraintExpression: string }
   | { type: 'ANALYZE_TABLE'; tableName: string };


### PR DESCRIPTION
Motivated by an invalid index on a TOAST table in the `pg_toast` schema