### PR TITLE
[Scheduling] $cancel takes an optional `cancelationReason`

### DIFF
--- a/packages/docs/docs/scheduling/appointment-cancel.md
+++ b/packages/docs/docs/scheduling/appointment-cancel.md
@@ -6,7 +6,7 @@ The `$cancel` operation is currently in [beta](/docs/compliance/alpha-beta).
 
 :::
 
-The `$cancel` operation cancels an [`Appointment`](/docs/api/fhir/resources/appointment) by atomically setting its status to `cancelled` and deleting all [`Slot`](/docs/api/fhir/resources/slot) resources it references in a single FHIR transaction.
+The `$cancel` operation cancels an [`Appointment`](/docs/api/fhir/resources/appointment) by atomically setting its status to `cancelled` and deleting all [`Slot`](/docs/api/fhir/resources/slot) resources it references in a single FHIR transaction. An optional `cancelationReason` records why the Appointment was canceled.
 
 ## Use Cases
 
@@ -28,12 +28,34 @@ import TabItem from '@theme/TabItem';
 
 ```typescript
 import { MedplumClient } from '@medplum/core';
-import type { Appointment } from '@medplum/fhirtypes';
+import type { Appointment, Parameters } from '@medplum/fhirtypes';
 
 const medplum = new MedplumClient();
 
 const appointment = await medplum.post<Appointment>(
   medplum.fhirUrl('Appointment', 'my-appointment-id', '$cancel')
+);
+
+// Optionally, record why the Appointment was canceled
+const appointmentWithReason = await medplum.post<Appointment>(
+  medplum.fhirUrl('Appointment', 'my-appointment-id', '$cancel'),
+  {
+    resourceType: 'Parameters',
+    parameter: [
+      {
+        name: 'cancelationReason',
+        valueCodeableConcept: {
+          coding: [
+            {
+              system: 'http://terminology.hl7.org/CodeSystem/appointment-cancellation-reason',
+              code: 'pat-cpp',
+              display: 'Patient: Canceled via Patient Portal',
+            },
+          ],
+        },
+      },
+    ],
+  } satisfies Parameters
 );
 ```
 
@@ -45,12 +67,73 @@ curl -X POST 'https://api.medplum.com/fhir/R4/Appointment/my-appointment-id/$can
   -H "Authorization: Bearer MY_ACCESS_TOKEN"
 ```
 
+Optionally, record why the Appointment was canceled:
+
+```bash
+curl -X POST 'https://api.medplum.com/fhir/R4/Appointment/my-appointment-id/$cancel' \
+  -H "Authorization: Bearer MY_ACCESS_TOKEN" \
+  -H "Content-Type: application/fhir+json" \
+  -d '{
+    "resourceType": "Parameters",
+    "parameter": [
+      {
+        "name": "cancelationReason",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/appointment-cancellation-reason",
+              "code": "pat-cpp",
+              "display": "Patient: Canceled via Patient Portal"
+            }
+          ]
+        }
+      }
+    ]
+  }'
+```
+
 </TabItem>
 </Tabs>
 
 ## Parameters
 
-This operation takes no input parameters. The appointment to cancel is identified by the `id` in the URL.
+The appointment to cancel is identified by the `id` in the URL.
+
+| Name                | Type              | Description                                                                               | Required |
+| ------------------- | ----------------- | ----------------------------------------------------------------------------------------- | -------- |
+| `cancelationReason` | `CodeableConcept` | The coded reason the Appointment was canceled. Stored on `Appointment.cancelationReason`. | No       |
+
+### Cancelation Reason
+
+When `cancelationReason` is provided, it is written to [`Appointment.cancelationReason`](/docs/api/fhir/resources/appointment) on the canceled Appointment. When it is omitted, the field is left untouched.
+
+:::note
+
+FHIR R4 spells this element `cancelationReason`, with a single `l`. The operation parameter uses the same spelling as the resource element.
+
+:::
+
+FHIR recommends coding this with the [appointment-cancellation-reason](http://terminology.hl7.org/CodeSystem/appointment-cancellation-reason) CodeSystem, but any `CodeableConcept` is accepted.
+
+```json
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "cancelationReason",
+      "valueCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/appointment-cancellation-reason",
+            "code": "pat-cpp",
+            "display": "Patient: Canceled via Patient Portal"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
 
 ### Constraints
 
@@ -61,7 +144,7 @@ This operation takes no input parameters. The appointment to cancel is identifie
 
 Returns `200 OK` with the updated [`Appointment`](/docs/api/fhir/resources/appointment) resource directly:
 
-- One [`Appointment`](/docs/api/fhir/resources/appointment) with `status: cancelled`
+- One [`Appointment`](/docs/api/fhir/resources/appointment) with `status: cancelled`, and `cancelationReason` set if it was provided
 
 All `Slot` resources that were referenced by the Appointment are deleted and do not appear in the response.
 
@@ -72,6 +155,15 @@ All `Slot` resources that were referenced by the Appointment are deleted and do 
   "resourceType": "Appointment",
   "id": "my-appointment-id",
   "status": "cancelled",
+  "cancelationReason": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/appointment-cancellation-reason",
+        "code": "pat-cpp",
+        "display": "Patient: Canceled via Patient Portal"
+      }
+    ]
+  },
   "start": "2026-03-10T09:00:00.000Z",
   "end": "2026-03-10T10:00:00.000Z",
   "participant": [
@@ -88,7 +180,7 @@ All `Slot` resources that were referenced by the Appointment are deleted and do 
 1. Reads the Appointment identified by the URL `id`
 2. Loads all `Slot` resources listed in `Appointment.slot`
 3. Validates that the Appointment's `status` is `booked` or `pending`
-4. Sets the Appointment's `status` to `cancelled` and saves it
+4. Sets the Appointment's `status` to `cancelled`, along with `cancelationReason` if one was provided, and saves it
 5. Deletes all referenced Slots
 6. Returns the updated Appointment
 

--- a/packages/server/src/fhir/operations/cancel.test.ts
+++ b/packages/server/src/fhir/operations/cancel.test.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import { createReference, parseSearchRequest } from '@medplum/core';
-import type { Appointment, Practitioner, Schedule, Slot } from '@medplum/fhirtypes';
+import { HTTP_TERMINOLOGY_HL7_ORG, createReference, parseSearchRequest } from '@medplum/core';
+import type { Appointment, Parameters, Practitioner, Schedule, Slot } from '@medplum/fhirtypes';
 import express from 'express';
 import supertest from 'supertest';
 import { initApp, shutdownApp } from '../../app';
@@ -10,6 +10,8 @@ import { loadTestConfig } from '../../config/loader';
 import { getGlobalSystemRepo } from '../../fhir/repo';
 import type { TestProjectResult } from '../../test.setup';
 import { createTestProject } from '../../test.setup';
+
+const CANCELATION_REASON_SYSTEM = `${HTTP_TERMINOLOGY_HL7_ORG}/CodeSystem/appointment-cancellation-reason`;
 
 const systemRepo = getGlobalSystemRepo();
 const app = express();
@@ -105,6 +107,64 @@ describe('Appointment/$cancel', () => {
 
     const updated = response.body as Appointment;
     expect(updated).toMatchObject({ resourceType: 'Appointment', id: appointment.id, status: 'cancelled' });
+  });
+
+  test('Sets cancelation reason from a plain JSON body', async () => {
+    const appointment = await makeAppointment('booked');
+
+    const response = await request
+      .post(`/fhir/R4/Appointment/${appointment.id}/$cancel`)
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({ cancelationReason: { coding: [{ system: CANCELATION_REASON_SYSTEM, code: 'pat' }], text: 'Patient' } });
+
+    expect(response).toHaveStatus(200);
+    expect(response.body).toMatchObject({
+      resourceType: 'Appointment',
+      status: 'cancelled',
+      cancelationReason: { coding: [{ system: CANCELATION_REASON_SYSTEM, code: 'pat' }], text: 'Patient' },
+    });
+  });
+
+  test('Sets cancelation reason from a Parameters body', async () => {
+    const appointment = await makeAppointment('booked');
+
+    const response = await request
+      .post(`/fhir/R4/Appointment/${appointment.id}/$cancel`)
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'cancelationReason',
+            valueCodeableConcept: {
+              coding: [{ system: CANCELATION_REASON_SYSTEM, code: 'pat-cpp' }],
+              text: 'Patient: Canceled via Patient Portal',
+            },
+          },
+        ],
+      } satisfies Parameters);
+
+    expect(response).toHaveStatus(200);
+    expect(response.body).toMatchObject({
+      resourceType: 'Appointment',
+      status: 'cancelled',
+      cancelationReason: {
+        coding: [{ system: CANCELATION_REASON_SYSTEM, code: 'pat-cpp' }],
+        text: 'Patient: Canceled via Patient Portal',
+      },
+    });
+  });
+
+  test('Leaves cancelation reason unset when omitted', async () => {
+    const appointment = await makeAppointment('booked');
+
+    const response = await request
+      .post(`/fhir/R4/Appointment/${appointment.id}/$cancel`)
+      .set('Authorization', `Bearer ${project.accessToken}`);
+
+    expect(response).toHaveStatus(200);
+    expect(response.body).toMatchObject({ resourceType: 'Appointment', status: 'cancelled' });
+    expect(response.body.cancelationReason).toBeUndefined();
   });
 
   test('Deletes the referenced slot', async () => {

--- a/packages/server/src/fhir/operations/cancel.ts
+++ b/packages/server/src/fhir/operations/cancel.ts
@@ -3,7 +3,7 @@
 
 import { allOk, badRequest, OperationOutcomeError } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { Appointment } from '@medplum/fhirtypes';
+import type { Appointment, CodeableConcept } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
 import { withPaths } from '../../util/withpath';
 import { makeOperationDefinition } from './definitions';
@@ -15,11 +15,16 @@ const cancelOperation = makeOperationDefinition(
   {
     name: 'cancel',
     code: 'cancel',
-    parameter: [{ use: 'out', name: 'return', type: 'Appointment', min: 1, max: '1' }],
+    parameter: [
+      { use: 'in', name: 'cancelationReason', type: 'CodeableConcept', min: 0, max: '1' },
+      { use: 'out', name: 'return', type: 'Appointment', min: 1, max: '1' },
+    ],
   }
 );
 
-type CancelParameters = {};
+type CancelParameters = {
+  cancelationReason?: CodeableConcept;
+};
 
 /**
  * Handles HTTP requests for the Appointment $cancel operation.
@@ -33,7 +38,7 @@ type CancelParameters = {};
  */
 export async function appointmentCancelHandler(req: FhirRequest): Promise<FhirResponse> {
   const ctx = getAuthenticatedContext();
-  parseInputParameters<CancelParameters>(cancelOperation, req);
+  const params = parseInputParameters<CancelParameters>(cancelOperation, req);
   const appointmentId = req.params.id;
 
   const updatedAppointment = await ctx.repo.withTransaction(
@@ -49,6 +54,9 @@ export async function appointmentCancelHandler(req: FhirRequest): Promise<FhirRe
       }
 
       appointment.status = 'cancelled';
+      if (params.cancelationReason) {
+        appointment.cancelationReason = params.cancelationReason;
+      }
 
       const updatedAppointment = await txRepo.updateResource(appointment);
       await Promise.all(slots.map((slot) => txRepo.deleteResource('Slot', slot.id)));


### PR DESCRIPTION
In some workflows, we want to collect structured data about why an appointment was cancelled. The Appointment resource type has a field explicitly for this, `cancelationReason`.

Note that the spelling of this follows the R4 convention of a single 'l' in "cancelation", while future FHIR versions update this to double 'l' ("cancellation"). I've opted to stay consistent with the R4 spelling, which makes it easy to connect the dots between the parameter and the field.

This is in support of #10140.