### PR TITLE
Global-only repo shard routing semantics

### DIFF
--- a/packages/server/src/auth/scope.test.ts
+++ b/packages/server/src/auth/scope.test.ts
@@ -8,13 +8,14 @@ import { authenticator } from 'otplib';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
-import { getGlobalSystemRepo } from '../fhir/repo';
+import type { SystemRepository } from '../fhir/repo';
+import { getProjectSystemRepo } from '../fhir/repo';
 import { withTestContext } from '../test.setup';
 import { registerNew } from './register';
 
 describe('Scope', () => {
   const app = express();
-  const systemRepo = getGlobalSystemRepo();
+  let systemRepo: SystemRepository;
   const email = `multi${randomUUID()}@example.com`;
   const password = randomUUID();
   // Patient scopes require a Patient context, which is provided to the login by this launch
@@ -32,6 +33,7 @@ describe('Scope', () => {
         email,
         password,
       });
+      systemRepo = await getProjectSystemRepo(project);
 
       const patient = await systemRepo.createResource<Patient>({
         resourceType: 'Patient',

--- a/packages/server/src/auth/setpassword.ts
+++ b/packages/server/src/auth/setpassword.ts
@@ -8,7 +8,7 @@ import { body } from 'express-validator';
 import { pwnedPassword } from 'hibp';
 import { MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH } from '../constants';
 import { sendOutcome } from '../fhir/outcomes';
-import type { SystemRepository } from '../fhir/repo';
+import type { SuperAdminRepository } from '../fhir/repo';
 import { getGlobalSystemRepo } from '../fhir/repo';
 import { timingSafeEqualStr } from '../oauth/utils';
 import { makeValidationMiddleware } from '../util/validator';
@@ -64,13 +64,13 @@ export async function setPasswordHandler(req: Request, res: Response): Promise<v
  * It is consumed after the password has been validated and hashed, so a password that fails
  * validation does not burn the user's link, but before the password is applied, so the request
  * cannot be redeemed twice.
- * @param systemRepo - The system repository to use.
+ * @param repo - The system repository to use.
  * @param user - The user whose password is being set.
  * @param password - The new plaintext password.
  * @param securityRequest - Optional security request authorizing the change, consumed on success.
  */
 export async function setPassword(
-  systemRepo: SystemRepository,
+  repo: SuperAdminRepository,
   user: WithId<User>,
   password: string,
   securityRequest?: WithId<UserSecurityRequest>
@@ -82,24 +82,24 @@ export async function setPassword(
 
   const passwordHash = await bcryptHashPassword(password);
 
-  await systemRepo.withTransaction(
+  await repo.withTransaction(
     async (txRepo) => {
       // Consume the request first, so that concurrent requests carrying the same token
       // cannot both get through
       if (securityRequest) {
-        await consumeSecurityRequest(txRepo, securityRequest);
+        await consumeSecurityRequest(txRepo.getSystemRepo(), securityRequest);
       }
       await txRepo.updateResource<User>({ ...user, passwordHash });
     },
     { resourceTypes: ['User', 'UserSecurityRequest'], source: 'setPassword' }
   );
 
-  const activeSessions = await systemRepo.search<Login>({
+  const activeSessions = await repo.search<Login>({
     resourceType: 'Login',
     filters: [{ code: 'user', operator: Operator.EQUALS, value: getReferenceString(user) }],
   });
   for (const entry of activeSessions.entry ?? EMPTY) {
     const login = entry.resource as Login;
-    await systemRepo.updateResource({ ...login, revoked: true });
+    await repo.updateResource({ ...login, revoked: true });
   }
 }

--- a/packages/server/src/context.ts
+++ b/packages/server/src/context.ts
@@ -59,6 +59,7 @@ export type AuthenticatedContextOptions = {
 
 export class AuthenticatedRequestContext extends RequestContext {
   readonly authState: Readonly<AuthState>;
+  readonly project: WithId<Project>;
   readonly repo: Repository;
   readonly isAsync: boolean;
   readonly fhirRateLimiter?: FhirRateLimiter;
@@ -88,11 +89,12 @@ export class AuthenticatedRequestContext extends RequestContext {
 
     this.authState = authState;
     this.repo = repo;
+    const project = repo.currentProject();
+    if (!project) {
+      throw new Error('Authenticated repository must have a current project');
+    }
+    this.project = project;
     this.isAsync = options?.async ?? false;
-  }
-
-  get project(): WithId<Project> {
-    return this.authState.project;
   }
 
   get membership(): WithId<ProjectMembership> {
@@ -105,10 +107,6 @@ export class AuthenticatedRequestContext extends RequestContext {
 
   get profile(): Reference<ProfileResource | Bot | ClientApplication> {
     return this.membership.profile;
-  }
-
-  get authentication(): Readonly<AuthState> {
-    return this.authState;
   }
 
   /**

--- a/packages/server/src/context.ts
+++ b/packages/server/src/context.ts
@@ -16,7 +16,7 @@ import { randomUUID } from 'node:crypto';
 import { getConfig } from './config/loader';
 import { getRepoForLogin } from './fhir/accesspolicy';
 import { FhirRateLimiter, getFhirQuotaConfig } from './fhir/fhirquota';
-import type { Repository, SystemRepository } from './fhir/repo';
+import type { Repository, SuperAdminRepository, SystemRepository } from './fhir/repo';
 import { ResourceCap } from './fhir/resource-cap';
 import { getLogger, globalLogger, writeLineToStdout } from './logger';
 import type { AuthState } from './oauth/middleware';
@@ -263,9 +263,17 @@ function getResourceCap(authState: AuthState, logger?: Logger): ResourceCap | un
     : undefined;
 }
 
-export function requireSuperAdmin(): AuthenticatedRequestContext {
+type SuperAdminRequestContext = AuthenticatedRequestContext & {
+  readonly repo: SuperAdminRepository;
+};
+
+function isSuperAdminContext(ctx: AuthenticatedRequestContext): ctx is SuperAdminRequestContext {
+  return ctx.repo.isSuperAdmin();
+}
+
+export function requireSuperAdmin(): SuperAdminRequestContext {
   const ctx = getAuthenticatedContext();
-  if (!ctx.project.superAdmin) {
+  if (!isSuperAdminContext(ctx)) {
     throw new OperationOutcomeError(forbidden);
   }
   return ctx;

--- a/packages/server/src/database-migration.test.ts
+++ b/packages/server/src/database-migration.test.ts
@@ -13,7 +13,8 @@ import { initApp, initAppServices, shutdownApp } from './app';
 import { getConfig, loadTestConfig } from './config/loader';
 import { DatabaseMode, getDatabasePool } from './database';
 import type { SystemRepository } from './fhir/repo';
-import { getGlobalSystemRepo } from './fhir/repo';
+import { getShardSystemRepo } from './fhir/repo';
+import { PLACEHOLDER_SHARD_ID } from './fhir/sharding';
 import type { PgQueryable } from './fhir/sql';
 import { globalLogger } from './logger';
 import * as migrationSql from './migration-sql';
@@ -175,7 +176,7 @@ describe('Database migrations', () => {
       restoreWorkerQueueMocks();
     });
 
-    systemRepo = getGlobalSystemRepo();
+    systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID);
     await loadTestConfig();
     // We want a clean history of post-deploy migration AsyncJob. init and shutdown the app
     // to facilitate expunging all relevant AsyncJob

--- a/packages/server/src/email/email.test.ts
+++ b/packages/server/src/email/email.test.ts
@@ -12,7 +12,7 @@ import { Readable } from 'stream';
 import { vi } from 'vitest';
 import { initAppServices, shutdownApp } from '../app';
 import { getConfig, loadTestConfig } from '../config/loader';
-import { getGlobalSystemRepo } from '../fhir/repo';
+import { getTestProjectSystemRepo } from '../fhir/repository/test-utils';
 import { globalLogger } from '../logger';
 import { getBinaryStorage } from '../storage/loader';
 import { withTestContext } from '../test.setup';
@@ -30,7 +30,7 @@ vi.mock('nodemailer', () => ({
 }));
 
 describe('Email', () => {
-  const systemRepo = getGlobalSystemRepo();
+  const systemRepo = getTestProjectSystemRepo();
   let mockSESv2Client: AwsClientStub<SESv2Client>;
 
   beforeAll(async () => {

--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -47,6 +47,16 @@ import { tryLogin } from '../oauth/utils';
 import { addTestUser, createTestProject, withTestContext } from '../test.setup';
 import { buildAccessPolicy, getRepoForLogin, reconcileDefaultAccessPolicy } from './accesspolicy';
 import { getGlobalSystemRepo, getProjectSystemRepo, Repository } from './repo';
+import type { RepositoryContext } from './repository/repository-context';
+import { PLACEHOLDER_SHARD_ID } from './sharding';
+
+function getRepository(repoContext: Partial<RepositoryContext>): Repository {
+  return new Repository({
+    ...repoContext,
+    author: repoContext.author ?? { reference: 'Practitioner/123' },
+    routing: repoContext.routing ?? { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
+  });
+}
 
 describe('AccessPolicy', () => {
   let testProject: WithId<Project>;
@@ -80,10 +90,7 @@ describe('AccessPolicy', () => {
         resourceType: 'AccessPolicy',
       };
 
-      const repo2 = new Repository({
-        author: {
-          reference: 'Practitioner/123',
-        },
+      const repo2 = getRepository({
         accessPolicy,
       });
 
@@ -97,10 +104,7 @@ describe('AccessPolicy', () => {
         resourceType: 'AccessPolicy',
       };
 
-      const repo2 = new Repository({
-        author: {
-          reference: 'Practitioner/123',
-        },
+      const repo2 = getRepository({
         accessPolicy,
       });
 
@@ -126,10 +130,7 @@ describe('AccessPolicy', () => {
         ],
       };
 
-      const repo2 = new Repository({
-        author: {
-          reference: 'Practitioner/123',
-        },
+      const repo2 = getRepository({
         accessPolicy,
       });
 
@@ -163,10 +164,7 @@ describe('AccessPolicy', () => {
         ],
       };
 
-      const repo2 = new Repository({
-        author: {
-          reference: 'Practitioner/123',
-        },
+      const repo2 = getRepository({
         accessPolicy,
       });
 
@@ -200,10 +198,7 @@ describe('AccessPolicy', () => {
         ],
       };
 
-      const repo2 = new Repository({
-        author: {
-          reference: 'Practitioner/123',
-        },
+      const repo2 = getRepository({
         accessPolicy,
       });
 
@@ -230,10 +225,7 @@ describe('AccessPolicy', () => {
         ],
       };
 
-      const repo2 = new Repository({
-        author: {
-          reference: 'Practitioner/123',
-        },
+      const repo2 = getRepository({
         accessPolicy,
       });
 
@@ -260,11 +252,8 @@ describe('AccessPolicy', () => {
         ],
       };
 
-      const repo = new Repository({
+      const repo = getRepository({
         extendedMode: true,
-        author: {
-          reference: 'Practitioner/123',
-        },
         accessPolicy,
       });
 
@@ -305,11 +294,8 @@ describe('AccessPolicy', () => {
         ],
       };
 
-      const repo = new Repository({
+      const repo = getRepository({
         extendedMode: true,
-        author: {
-          reference: 'Practitioner/123',
-        },
         accessPolicy,
       });
 
@@ -356,12 +342,9 @@ describe('AccessPolicy', () => {
           binaryResource.criteria = 'Binary?_compartment=' + orgRef;
         }
 
-        const repo = new Repository({
+        const repo = getRepository({
           extendedMode: true,
           accessPolicy,
-          author: {
-            reference: 'Practitioner/1',
-          },
         });
 
         const binary = await repo.createResource<Binary>({
@@ -404,12 +387,9 @@ describe('AccessPolicy', () => {
         ],
       };
 
-      const repo = new Repository({
+      const repo = getRepository({
         extendedMode: true,
         accessPolicy,
-        author: {
-          reference: 'Practitioner/1',
-        },
       });
 
       const observation = await repo.createResource<Observation>({
@@ -427,12 +407,9 @@ describe('AccessPolicy', () => {
       expect(readObservation.meta?.accounts).toContainExactly([{ reference: 'Organization/' + overrideId }]);
       expect(readObservation.meta?.compartment).toContainExactly([{ reference: 'Organization/' + overrideId }]);
 
-      const adminRepo = new Repository({
+      const adminRepo = getRepository({
         extendedMode: true,
         projectAdmin: true,
-        author: {
-          reference: 'Practitioner/0',
-        },
       });
       const orgReference = { reference: 'Organization/' + randomUUID() };
       const patient = await adminRepo.createResource<Patient>({
@@ -500,19 +477,13 @@ describe('AccessPolicy', () => {
         ],
       };
 
-      const repo1 = new Repository({
+      const repo1 = getRepository({
         extendedMode: true,
-        author: {
-          reference: 'Practitioner/123',
-        },
         accessPolicy: accessPolicy1,
       });
 
-      const repo2 = new Repository({
+      const repo2 = getRepository({
         extendedMode: true,
-        author: {
-          reference: 'Practitioner/123',
-        },
         accessPolicy: accessPolicy2,
       });
 
@@ -577,19 +548,13 @@ describe('AccessPolicy', () => {
         ],
       };
 
-      const repo1 = new Repository({
+      const repo1 = getRepository({
         extendedMode: true,
-        author: {
-          reference: 'Practitioner/123',
-        },
         accessPolicy: accessPolicy1,
       });
 
-      const repo2 = new Repository({
+      const repo2 = getRepository({
         extendedMode: true,
-        author: {
-          reference: 'Practitioner/456',
-        },
         accessPolicy: accessPolicy2,
       });
 
@@ -637,19 +602,13 @@ describe('AccessPolicy', () => {
         ],
       };
 
-      const repo1 = new Repository({
+      const repo1 = getRepository({
         extendedMode: true,
-        author: {
-          reference: 'Practitioner/123',
-        },
         accessPolicy: accessPolicy1,
       });
 
-      const repo2 = new Repository({
+      const repo2 = getRepository({
         extendedMode: true,
-        author: {
-          reference: 'Practitioner/123',
-        },
         accessPolicy: accessPolicy2,
       });
 
@@ -992,10 +951,7 @@ describe('AccessPolicy', () => {
         ],
       };
 
-      const repo2 = new Repository({
-        author: {
-          reference: 'Practitioner/123',
-        },
+      const repo2 = getRepository({
         accessPolicy,
       });
 
@@ -1037,10 +993,7 @@ describe('AccessPolicy', () => {
         ],
       };
 
-      const repo2 = new Repository({
-        author: {
-          reference: 'Practitioner/123',
-        },
+      const repo2 = getRepository({
         accessPolicy,
       });
 
@@ -1080,10 +1033,7 @@ describe('AccessPolicy', () => {
         ],
       };
 
-      const repo = new Repository({
-        author: {
-          reference: 'Practitioner/123',
-        },
+      const repo = getRepository({
         accessPolicy,
       });
 
@@ -1108,10 +1058,7 @@ describe('AccessPolicy', () => {
         ],
       };
 
-      const repo = new Repository({
-        author: {
-          reference: 'Practitioner/123',
-        },
+      const repo = getRepository({
         accessPolicy,
       });
 
@@ -1148,10 +1095,7 @@ describe('AccessPolicy', () => {
         ],
       };
 
-      const repo = new Repository({
-        author: {
-          reference: 'Practitioner/123',
-        },
+      const repo = getRepository({
         accessPolicy,
       });
 
@@ -1214,10 +1158,7 @@ describe('AccessPolicy', () => {
         ],
       };
 
-      const repo = new Repository({
-        author: {
-          reference: 'Practitioner/123',
-        },
+      const repo = getRepository({
         accessPolicy,
       });
 
@@ -1267,8 +1208,7 @@ describe('AccessPolicy', () => {
         ],
       };
 
-      const repo = new Repository({
-        author: { reference: 'Practitioner/123' },
+      const repo = getRepository({
         accessPolicy,
       });
 
@@ -1401,8 +1341,7 @@ describe('AccessPolicy', () => {
         resource: [{ resourceType: 'Patient', hiddenFields: ['name.family'] }],
       };
 
-      const repo2 = new Repository({
-        author: { reference: 'Practitioner/123' },
+      const repo2 = getRepository({
         accessPolicy,
       });
 
@@ -1449,7 +1388,7 @@ describe('AccessPolicy', () => {
         ],
       };
 
-      const repo2 = new Repository({ author: { reference: 'Practitioner/123' }, accessPolicy });
+      const repo2 = getRepository({ accessPolicy });
 
       const readResource1 = await repo2.readResource<Observation>('Observation', obs1.id);
       expect(readResource1).toMatchObject({
@@ -1567,7 +1506,7 @@ describe('AccessPolicy', () => {
         ],
       };
 
-      const repo2 = new Repository({ author: { reference: 'Practitioner/123' }, accessPolicy });
+      const repo2 = getRepository({ accessPolicy });
 
       const readResource1 = await repo2.readResource<Observation>('Observation', obsQuantity.id);
       expect(readResource1).toMatchObject({
@@ -1686,10 +1625,7 @@ describe('AccessPolicy', () => {
         ],
       };
 
-      const repo = new Repository({
-        author: {
-          reference: 'Practitioner/123',
-        },
+      const repo = getRepository({
         accessPolicy,
       });
 
@@ -1736,10 +1672,7 @@ describe('AccessPolicy', () => {
         ],
       };
 
-      const repo2 = new Repository({
-        author: {
-          reference: 'Practitioner/123',
-        },
+      const repo2 = getRepository({
         accessPolicy,
       });
 
@@ -1767,8 +1700,7 @@ describe('AccessPolicy', () => {
 
   test('Compound parameterized access policy', () =>
     withTestContext(async () => {
-      const adminRepo = new Repository({
-        author: { reference: 'Practitioner/' + randomUUID() },
+      const adminRepo = getRepository({
         projects: [testProject],
         strictMode: true,
         extendedMode: true,
@@ -1822,8 +1754,7 @@ describe('AccessPolicy', () => {
 
   test('String parameters', () =>
     withTestContext(async () => {
-      const adminRepo = new Repository({
-        author: { reference: 'Practitioner/' + randomUUID() },
+      const adminRepo = getRepository({
         projects: [testProject],
         strictMode: true,
         extendedMode: true,
@@ -1871,8 +1802,7 @@ describe('AccessPolicy', () => {
     withTestContext(async () => {
       const project = await systemRepo.createResource<Project>({ resourceType: 'Project', name: 'Test Project' });
 
-      const adminRepo = new Repository({
-        author: { reference: 'Practitioner/' + randomUUID() },
+      const adminRepo = getRepository({
         projects: [project],
         strictMode: true,
         extendedMode: true,
@@ -2375,8 +2305,7 @@ describe('AccessPolicy', () => {
     withTestContext(async () => {
       const { project, membership } = await createTestProject({ superAdmin: true, withClient: true });
 
-      const adminRepo = new Repository({
-        author: { reference: 'Practitioner/' + randomUUID() },
+      const adminRepo = getRepository({
         projects: [project],
         strictMode: true,
         extendedMode: true,
@@ -2476,8 +2405,7 @@ describe('AccessPolicy', () => {
           },
         ],
       });
-      const repo = new Repository({
-        author: { reference: 'Practitioner/' + randomUUID() },
+      const repo = getRepository({
         projects: [project],
         projectAdmin: true,
         strictMode: true,
@@ -2542,8 +2470,7 @@ describe('AccessPolicy', () => {
   test('Project admin check references', () =>
     withTestContext(async () => {
       const project1 = await systemRepo.createResource<Project>({ resourceType: 'Project', name: 'Test1' });
-      const repo1 = new Repository({
-        author: { reference: 'Practitioner/' + randomUUID() },
+      const repo1 = getRepository({
         projects: [project1],
         projectAdmin: true,
         strictMode: true,
@@ -2552,8 +2479,7 @@ describe('AccessPolicy', () => {
       });
 
       const project2 = await systemRepo.createResource<Project>({ resourceType: 'Project', name: 'Test2' });
-      const repo2 = new Repository({
-        author: { reference: 'Practitioner/' + randomUUID() },
+      const repo2 = getRepository({
         projects: [project2],
         projectAdmin: true,
         strictMode: true,
@@ -2614,8 +2540,7 @@ describe('AccessPolicy', () => {
 
   test('Shared project read only', () =>
     withTestContext(async () => {
-      const repo = new Repository({
-        author: { reference: 'Practitioner/' + randomUUID() },
+      const repo = getRepository({
         projects: [testProject],
         projectAdmin: true,
         strictMode: true,
@@ -2639,8 +2564,7 @@ describe('AccessPolicy', () => {
       };
 
       const project1 = await systemRepo.createResource<Project>({ resourceType: 'Project', name: 'Test1' });
-      const repo1 = new Repository({
-        author: { reference: 'Practitioner/' + randomUUID() },
+      const repo1 = getRepository({
         projects: [project1],
         projectAdmin: true,
         strictMode: true,
@@ -2649,8 +2573,7 @@ describe('AccessPolicy', () => {
       });
 
       const project2 = await systemRepo.createResource<Project>({ resourceType: 'Project', name: 'Test2' });
-      const repo2 = new Repository({
-        author: { reference: 'Practitioner/' + randomUUID() },
+      const repo2 = getRepository({
         projects: [project2, project1],
         projectAdmin: true,
         strictMode: true,
@@ -2736,7 +2659,7 @@ describe('AccessPolicy', () => {
 
       // Repos for the test user
 
-      const repoWithoutAccessPolicy = new Repository({
+      const repoWithoutAccessPolicy = getRepository({
         author: createReference(profile),
         projects: [project],
         projectAdmin: false,
@@ -2744,7 +2667,7 @@ describe('AccessPolicy', () => {
         extendedMode: true,
       });
 
-      const repoWithAccessPolicy = new Repository({
+      const repoWithAccessPolicy = getRepository({
         author: createReference(profile),
         projects: [project],
         projectAdmin: false,
@@ -3038,8 +2961,7 @@ describe('AccessPolicy', () => {
 
   test('Combined access policies with overlapping entries', () =>
     withTestContext(async () => {
-      const adminRepo = new Repository({
-        author: { reference: 'Practitioner/' + randomUUID() },
+      const adminRepo = getRepository({
         projects: [testProject],
         strictMode: true,
         extendedMode: true,

--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -46,6 +46,7 @@ import { globalLogger } from '../logger';
 import { tryLogin } from '../oauth/utils';
 import { addTestUser, createTestProject, withTestContext } from '../test.setup';
 import { buildAccessPolicy, getRepoForLogin, reconcileDefaultAccessPolicy } from './accesspolicy';
+import type { SystemRepository } from './repo';
 import { getGlobalSystemRepo, getProjectSystemRepo, Repository } from './repo';
 import type { RepositoryContext } from './repository/repository-context';
 import { PLACEHOLDER_SHARD_ID } from './sharding';
@@ -60,7 +61,7 @@ function getRepository(repoContext: Partial<RepositoryContext>): Repository {
 
 describe('AccessPolicy', () => {
   let testProject: WithId<Project>;
-  let systemRepo: Repository;
+  let systemRepo: SystemRepository;
 
   beforeAll(async () => {
     const config = await loadTestConfig();

--- a/packages/server/src/fhir/accesspolicy.ts
+++ b/packages/server/src/fhir/accesspolicy.ts
@@ -28,6 +28,7 @@ import { getLogger } from '../logger';
 import type { AuthState } from '../oauth/middleware';
 import type { SystemRepository } from './repo';
 import { getGlobalSystemRepo, getProjectSystemRepo, Repository } from './repo';
+import { PLACEHOLDER_SHARD_ID } from './sharding';
 import { applySmartScopes } from './smart';
 
 export type PopulatedAccessPolicy = AccessPolicy & { resource: AccessPolicyResource[] };
@@ -72,6 +73,7 @@ export async function getRepoForLogin(
   const allowedProjects = await getAllowedProjects(project);
 
   return new Repository({
+    routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
     projects: allowedProjects,
     author: profile ? createReference(profile) : realMembership.profile,
     remoteAddress: remoteAddress ?? login.remoteAddress,

--- a/packages/server/src/fhir/accesspolicy.ts
+++ b/packages/server/src/fhir/accesspolicy.ts
@@ -49,15 +49,18 @@ export async function getRepoForLogin(
   extendedMode?: boolean,
   remoteAddress?: string
 ): Promise<Repository> {
-  const { login, membership: realMembership, onBehalfOfMembership } = authState;
+  const { login, membership: realMembership, onBehalfOfMembership, project: realProject } = authState;
   const membership = onBehalfOfMembership ?? realMembership;
   const accessPolicy = await getAccessPolicyForLogin(authState);
 
-  const globalSystemRepo = getGlobalSystemRepo();
   let profile: WithId<ProfileResource | Bot | ClientApplication> | undefined = authState.profile;
   if (!profile) {
     try {
-      profile = await globalSystemRepo.readReference<ProfileResource | Bot | ClientApplication>(realMembership.profile);
+      // project system repo since not all ProfileResource types are global
+      const realProjectSystemRepo = await getProjectSystemRepo(realProject);
+      profile = await realProjectSystemRepo.readReference<ProfileResource | Bot | ClientApplication>(
+        realMembership.profile
+      );
     } catch (err: unknown) {
       if (!(err instanceof OperationOutcomeError && isNotFound(err.outcome))) {
         throw err;
@@ -65,12 +68,14 @@ export async function getRepoForLogin(
     }
   }
 
-  let project = authState.project;
+  let project = realProject;
+  let globalSystemRepo: SystemRepository | undefined;
   if (membership.project.reference !== realMembership.project.reference) {
+    globalSystemRepo = getGlobalSystemRepo();
     project = await globalSystemRepo.readReference<Project>(membership.project);
   }
 
-  const allowedProjects = await getAllowedProjects(project);
+  const allowedProjects = await getAllowedProjects(project, globalSystemRepo);
 
   return new Repository({
     routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
@@ -92,9 +97,13 @@ export async function getRepoForLogin(
 /**
  * Resolves a project and the projects it links to, which its members may read from.
  * @param project - The project whose links to resolve.
+ * @param systemRepo - Optional system repository used to read projects
  * @returns The project followed by each linked project that could be read.
  */
-export async function getAllowedProjects(project: WithId<Project>): Promise<WithId<Project>[]> {
+export async function getAllowedProjects(
+  project: WithId<Project>,
+  systemRepo?: SystemRepository
+): Promise<WithId<Project>[]> {
   const allowedProjects: WithId<Project>[] = [project];
   if (project.link) {
     const linkedProjectRefs: Reference<Project>[] = [];
@@ -104,8 +113,9 @@ export async function getAllowedProjects(project: WithId<Project>): Promise<With
       }
     }
 
-    const systemRepo = await getProjectSystemRepo(project);
-    const linkedProjectsOrError = await systemRepo.readReferences<Project>(linkedProjectRefs);
+    const linkedProjectsOrError = await (systemRepo ?? getGlobalSystemRepo()).readReferences<Project>(
+      linkedProjectRefs
+    );
     for (let i = 0; i < linkedProjectsOrError.length; i++) {
       const linkedProjectOrError = linkedProjectsOrError[i];
       if (isResource(linkedProjectOrError)) {

--- a/packages/server/src/fhir/job.test.ts
+++ b/packages/server/src/fhir/job.test.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ContentType } from '@medplum/core';
 import type { AsyncJob } from '@medplum/fhirtypes';
-import { randomUUID } from 'crypto';
 import express from 'express';
 import request from 'supertest';
 import { vi } from 'vitest';
@@ -10,7 +9,6 @@ import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import { createTestProject, waitForAsyncJob, withTestContext } from '../test.setup';
 import { AsyncJobExecutor } from './operations/utils/asyncjobexecutor';
-import { Repository } from './repo';
 
 const app = express();
 
@@ -28,14 +26,9 @@ describe('Job status', () => {
   });
 
   beforeEach(async () => {
-    const testProject = await createTestProject({ withAccessToken: true });
+    const testProject = await createTestProject({ withAccessToken: true, withRepo: true });
     accessToken = testProject.accessToken;
-    asyncJobManager = new AsyncJobExecutor(
-      new Repository({
-        projects: [testProject.project],
-        author: { reference: 'User/' + randomUUID() },
-      })
-    );
+    asyncJobManager = new AsyncJobExecutor(testProject.repo);
   });
 
   test('in progress', () =>

--- a/packages/server/src/fhir/lookups/address.test.ts
+++ b/packages/server/src/fhir/lookups/address.test.ts
@@ -9,13 +9,13 @@ import { initAppServices, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
 import { getLogger } from '../../logger';
 import { withTestContext } from '../../test.setup';
-import { getGlobalSystemRepo } from '../repo';
+import { getTestProjectSystemRepo } from '../repository/test-utils';
 import type { PgQueryable } from '../sql';
 import type { AddressTableRow } from './address';
 import { AddressTable } from './address';
 
 describe('Address Lookup Table', () => {
-  const systemRepo = getGlobalSystemRepo();
+  const systemRepo = getTestProjectSystemRepo();
 
   beforeAll(async () => {
     const config = await loadTestConfig();

--- a/packages/server/src/fhir/lookups/coding.test.ts
+++ b/packages/server/src/fhir/lookups/coding.test.ts
@@ -5,10 +5,10 @@ import { initAppServices, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
 import { DatabaseMode, getDatabasePool } from '../../database';
 import { withTestContext } from '../../test.setup';
-import { getGlobalSystemRepo } from '../repo';
+import { getTestProjectSystemRepo } from '../repository/test-utils';
 
 describe('Coding lookup table', () => {
-  const systemRepo = getGlobalSystemRepo();
+  const systemRepo = getTestProjectSystemRepo();
 
   beforeAll(async () => {
     const config = await loadTestConfig();

--- a/packages/server/src/fhir/lookups/conceptmapping.test.ts
+++ b/packages/server/src/fhir/lookups/conceptmapping.test.ts
@@ -6,10 +6,10 @@ import { initAppServices, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
 import { DatabaseMode, getDatabasePool } from '../../database';
 import { withTestContext } from '../../test.setup';
-import { getGlobalSystemRepo } from '../repo';
+import { getTestProjectSystemRepo } from '../repository/test-utils';
 
 describe('ConceptMapping lookup table', () => {
-  const systemRepo = getGlobalSystemRepo();
+  const systemRepo = getTestProjectSystemRepo();
 
   const conceptMap: ConceptMap = {
     resourceType: 'ConceptMap',

--- a/packages/server/src/fhir/lookups/humanname.test.ts
+++ b/packages/server/src/fhir/lookups/humanname.test.ts
@@ -8,13 +8,13 @@ import { vi } from 'vitest';
 import { initAppServices, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
 import { bundleContains, withTestContext } from '../../test.setup';
-import { getGlobalSystemRepo } from '../repo';
+import { getTestProjectSystemRepo } from '../repository/test-utils';
 import type { PgQueryable } from '../sql';
 import type { HumanNameTableRow } from './humanname';
 import { getHumanNameSortValue, HumanNameTable } from './humanname';
 
 describe('HumanName Lookup Table', () => {
-  const systemRepo = getGlobalSystemRepo();
+  const systemRepo = getTestProjectSystemRepo();
 
   beforeAll(async () => {
     const config = await loadTestConfig();

--- a/packages/server/src/fhir/lookups/reference.test.ts
+++ b/packages/server/src/fhir/lookups/reference.test.ts
@@ -6,14 +6,15 @@ import { randomUUID } from 'node:crypto';
 import { vi } from 'vitest';
 import { initAppServices, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
-import { getGlobalSystemRepo } from '../repo';
+import { globalLogger } from '../../logger';
 import { repoAccess } from '../repository/access-tracker';
+import { getTestProjectSystemRepo } from '../repository/test-utils';
 import { lookupTables } from '../searchparameter';
 import type { PgQueryable } from '../sql';
 import { ReferenceTable } from './reference';
 
 describe('ReferenceTable', () => {
-  const systemRepo = getGlobalSystemRepo();
+  const systemRepo = getTestProjectSystemRepo();
   let refTable: ReferenceTable;
 
   beforeAll(async () => {
@@ -221,11 +222,17 @@ describe('ReferenceTable', () => {
         throw extractError;
       });
 
+      const logErrorSpy = vi.spyOn(globalLogger, 'error').mockImplementation(() => {});
       await expect(refTable.batchIndexResources(getReferenceTestClient(obs.resourceType), [obs], true)).rejects.toThrow(
         'Test extraction error'
       );
+      expect(logErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error extracting values'),
+        expect.objectContaining({ err: extractError })
+      );
 
       extractValuesSpy.mockRestore();
+      logErrorSpy.mockRestore();
     });
 
     test('handles resource with contained resource reference', async () => {

--- a/packages/server/src/fhir/operations/asyncjobcancel.test.ts
+++ b/packages/server/src/fhir/operations/asyncjobcancel.test.ts
@@ -7,14 +7,15 @@ import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
-import { getSuperAdminAccessToken, withTestContext } from '../../test.setup';
-import { getGlobalSystemRepo } from '../repo';
+import { getSuperAdminTestProject, withTestContext } from '../../test.setup';
+import type { Repository } from '../repo';
 import { asyncJobCancelHandler } from './asyncjobcancel';
 
 const app = express();
 
 describe('AsyncJob/$cancel', () => {
   let accessToken: string;
+  let repo: Repository;
 
   beforeAll(async () => {
     const config = await loadTestConfig();
@@ -22,8 +23,7 @@ describe('AsyncJob/$cancel', () => {
   });
 
   beforeEach(async () => {
-    accessToken = await getSuperAdminAccessToken();
-    expect(accessToken).toBeDefined();
+    ({ accessToken, repo } = await getSuperAdminTestProject());
   });
 
   afterAll(async () => {
@@ -149,7 +149,7 @@ describe('AsyncJob/$cancel', () => {
   test('Cancelled job does not get added to super admin project', () =>
     withTestContext(async () => {
       // We create the resource with system repo so that it is like how system AsyncJobs get created
-      const asyncJob = await getGlobalSystemRepo().createResource<AsyncJob>({
+      const asyncJob = await repo.getSystemRepo().createResource<AsyncJob>({
         resourceType: 'AsyncJob',
         status: 'accepted',
         requestTime: new Date().toISOString(),

--- a/packages/server/src/fhir/operations/book.test.ts
+++ b/packages/server/src/fhir/operations/book.test.ts
@@ -26,7 +26,7 @@ import express from 'express';
 import supertest from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
-import { getGlobalSystemRepo } from '../../fhir/repo';
+import type { SystemRepository } from '../../fhir/repo';
 import type { TestProjectResult } from '../../test.setup';
 import { addTestUser, createTestProject } from '../../test.setup';
 import type {
@@ -34,7 +34,6 @@ import type {
   SchedulingParametersExtensionExtension,
 } from './utils/scheduling-parameters';
 
-const systemRepo = getGlobalSystemRepo();
 const app = express();
 const request = supertest(app);
 
@@ -63,11 +62,12 @@ const threeDayAvailability: SchedulingParametersExtensionExtension = {
 };
 
 describe('Appointment/$book', () => {
-  let project: TestProjectResult<{ withAccessToken: true }>;
+  let project: TestProjectResult<{ withAccessToken: true; withRepo: true }>;
   let practitioner1: Practitioner;
   let practitioner2: Practitioner;
   let patient: Patient;
   let officeVisitService: WithId<HealthcareService>;
+  let systemRepo: SystemRepository;
 
   const officeVisit: CodeableConcept = {
     coding: [{ system: 'https://example.com/fhir', code: 'office-visit' }],
@@ -78,7 +78,8 @@ describe('Appointment/$book', () => {
     // try to be more resilient to concurrent tests touching the same tables
     config.transactionAttempts = 5;
     await initApp(app, config);
-    project = await createTestProject({ withAccessToken: true });
+    project = await createTestProject({ withAccessToken: true, withRepo: true });
+    systemRepo = project.repo.getSystemRepo();
     practitioner1 = await makePractitioner({ timezone: 'America/New_York' });
     practitioner2 = await makePractitioner({ timezone: 'America/New_York' });
     patient = await makePatient();
@@ -2059,8 +2060,9 @@ describe('Appointment/$book', () => {
 });
 
 describe('scheduling flow integration test', () => {
-  let project: TestProjectResult<{ withAccessToken: true }>;
+  let project: TestProjectResult<{ withAccessToken: true; withRepo: true }>;
   let service: WithId<HealthcareService>;
+  let systemRepo: SystemRepository;
 
   const officeVisitConcept: CodeableConcept = {
     coding: [{ system: 'https://example.com/fhir', code: 'office-visit' }],
@@ -2071,7 +2073,8 @@ describe('scheduling flow integration test', () => {
     // try to be more resilient to concurrent tests touching the same tables
     config.transactionAttempts = 5;
     await initApp(app, config);
-    project = await createTestProject({ withAccessToken: true });
+    project = await createTestProject({ withAccessToken: true, withRepo: true });
+    systemRepo = project.repo.getSystemRepo();
     service = await systemRepo.createResource<HealthcareService>({
       resourceType: 'HealthcareService',
       name: 'Office Visit',

--- a/packages/server/src/fhir/operations/cancel.test.ts
+++ b/packages/server/src/fhir/operations/cancel.test.ts
@@ -7,18 +7,18 @@ import express from 'express';
 import supertest from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
-import { getGlobalSystemRepo } from '../../fhir/repo';
+import type { SystemRepository } from '../../fhir/repo';
 import type { TestProjectResult } from '../../test.setup';
 import { createTestProject } from '../../test.setup';
 
 const CANCELATION_REASON_SYSTEM = `${HTTP_TERMINOLOGY_HL7_ORG}/CodeSystem/appointment-cancellation-reason`;
 
-const systemRepo = getGlobalSystemRepo();
 const app = express();
 const request = supertest(app);
 
 describe('Appointment/$cancel', () => {
-  let project: TestProjectResult<{ withAccessToken: true }>;
+  let project: TestProjectResult<{ withAccessToken: true; withRepo: true }>;
+  let systemRepo: SystemRepository;
   let practitioner: WithId<Practitioner>;
   let schedule: WithId<Schedule>;
 
@@ -27,7 +27,8 @@ describe('Appointment/$cancel', () => {
     // try to be more resilient to concurrent tests touching the same tables
     config.transactionAttempts = 5;
     await initApp(app, config);
-    project = await createTestProject({ withAccessToken: true });
+    project = await createTestProject({ withAccessToken: true, withRepo: true });
+    systemRepo = project.repo.getSystemRepo();
 
     practitioner = await systemRepo.createResource<Practitioner>({
       resourceType: 'Practitioner',

--- a/packages/server/src/fhir/operations/confirm.test.ts
+++ b/packages/server/src/fhir/operations/confirm.test.ts
@@ -7,16 +7,16 @@ import express from 'express';
 import supertest from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
-import { getGlobalSystemRepo } from '../../fhir/repo';
+import type { SystemRepository } from '../../fhir/repo';
 import type { TestProjectResult } from '../../test.setup';
 import { createTestProject } from '../../test.setup';
 
-const systemRepo = getGlobalSystemRepo();
 const app = express();
 const request = supertest(app);
 
 describe('Appointment/:id/$confirm', () => {
-  let project: TestProjectResult<{ withAccessToken: true }>;
+  let project: TestProjectResult<{ withAccessToken: true; withRepo: true }>;
+  let systemRepo: SystemRepository;
   let practitioner: WithId<Practitioner>;
   let schedule: WithId<Schedule>;
 
@@ -25,7 +25,8 @@ describe('Appointment/:id/$confirm', () => {
     // try to be more resilient to concurrent tests touching the same tables
     config.transactionAttempts = 5;
     await initApp(app, config);
-    project = await createTestProject({ withAccessToken: true });
+    project = await createTestProject({ withAccessToken: true, withRepo: true });
+    systemRepo = project.repo.getSystemRepo();
 
     practitioner = await systemRepo.createResource<Practitioner>({
       resourceType: 'Practitioner',

--- a/packages/server/src/fhir/operations/explain.ts
+++ b/packages/server/src/fhir/operations/explain.ts
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { allOk, getSearchResourceTypes, parseSearchRequest } from '@medplum/core';
+import { allOk, forbidden, getSearchResourceTypes, OperationOutcomeError, parseSearchRequest } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { RepositoryMode } from '@medplum/fhir-router';
 import type { Project, Reference } from '@medplum/fhirtypes';
-import { requireSuperAdmin } from '../../context';
+import type { AuthenticatedRequestContext } from '../../context';
+import { getAuthenticatedContext, requireSuperAdmin } from '../../context';
 import { escapeUnicode } from '../../migrations/migrate-utils';
 import { repoAccess } from '../repository/access-tracker';
 import { getCount, getSelectQueryForSearch } from '../search';
@@ -36,7 +37,7 @@ const operation = makeOperationDefinition(
 );
 
 export async function dbExplainHandler(req: FhirRequest): Promise<FhirResponse> {
-  const ctx = requireSuperAdmin();
+  const ctx = requireExplainAccess();
   const params = parseInputParameters<{
     query: string;
     project?: Reference<Project>;
@@ -108,4 +109,26 @@ function formatQueryParam(param: any): string {
     return param.toString();
   }
   return `'${typeof param === 'string' ? escapeUnicode(param) : param}'`;
+}
+
+/**
+ * Requires a super-admin caller while preserving the effective repository for delegated requests.
+ * Unlike other privileged operations, $explain intentionally uses On-Behalf-Of to show the query
+ * plan produced by the delegated user's access policy.
+ * @returns The authenticated request context.
+ */
+function requireExplainAccess(): AuthenticatedRequestContext {
+  const ctx = getAuthenticatedContext();
+
+  if (ctx.authState.onBehalfOfMembership) {
+    // if onBehalfOf, must check if the actor's project is a super admin
+    if (!ctx.authState.project.superAdmin) {
+      throw new OperationOutcomeError(forbidden);
+    }
+  } else {
+    // if no onBehalfOfMembership, just check for super admin
+    return requireSuperAdmin();
+  }
+
+  return ctx;
 }

--- a/packages/server/src/fhir/operations/export.test.ts
+++ b/packages/server/src/fhir/operations/export.test.ts
@@ -10,13 +10,13 @@ import { loadTestConfig } from '../../config/loader';
 import type { FileSystemStorage } from '../../storage/filesystem';
 import { getBinaryStorage } from '../../storage/loader';
 import { createTestProject, initTestAuth, waitForAsyncJob, withTestContext } from '../../test.setup';
-import { getGlobalSystemRepo } from '../repo';
+import { getTestProjectSystemRepo } from '../repository/test-utils';
 import { exportResourceType, exportResources } from './export';
 import { BulkExporter } from './utils/bulkexporter';
 
 describe('Export', () => {
   const app = express();
-  const systemRepo = getGlobalSystemRepo();
+  const systemRepo = getTestProjectSystemRepo();
 
   beforeAll(async () => {
     const config = await loadTestConfig();
@@ -29,7 +29,6 @@ describe('Export', () => {
 
   test('Success', async () => {
     const accessToken = await initTestAuth({ membership: { admin: true } });
-    expect(accessToken).toBeDefined();
 
     const res1 = await request(app)
       .post(`/fhir/R4/Patient`)
@@ -158,7 +157,6 @@ describe('Export', () => {
       await exporter.start('http://example.com');
 
       const { project } = await createTestProject();
-      expect(project).toBeDefined();
       await exportResourceType(exporter, 'Observation', 1, since);
       const bulkDataExport = await exporter.close(project);
       expect(bulkDataExport.status).toBe('completed');

--- a/packages/server/src/fhir/operations/expunge.test.ts
+++ b/packages/server/src/fhir/operations/expunge.test.ts
@@ -16,11 +16,9 @@ import {
   waitForAsyncJob,
   withTestContext,
 } from '../../test.setup';
-import { getGlobalSystemRepo } from '../repo';
+import { getTestProjectSystemRepo } from '../repository/test-utils';
 import { SelectQuery } from '../sql';
 import { Expunger } from './expunge';
-
-const systemRepo = getGlobalSystemRepo();
 
 describe('Expunge', () => {
   const app = express();
@@ -48,13 +46,13 @@ describe('Expunge', () => {
   });
 
   test('Expunge single resource', async () => {
+    const systemRepo = getTestProjectSystemRepo();
     const patient = await withTestContext(() =>
       systemRepo.createResource<Patient>({
         resourceType: 'Patient',
         name: [{ given: ['Alice'], family: 'Smith' }],
       })
     );
-    expect(patient).toBeDefined();
 
     // Expect the patient to be in the "Patient" and "Patient_History" tables
     expect(await existsInDatabase('Patient', patient.id)).toBe(true);
@@ -96,36 +94,33 @@ describe('Expunge', () => {
       membership: { admin: true },
     });
 
-    const { project, client, membership, accessToken } = await createTestProject({
+    const { project, client, membership, accessToken, repo } = await createTestProject({
       withClient: true,
       withAccessToken: true,
+      withRepo: true,
       membership: opts.membership,
       project: { link: [{ project: createReference(linkedProject) }] },
     });
 
     const linkedPatient = await linkedRepo.createResource<Patient>({
       resourceType: 'Patient',
-      meta: { project: linkedProject.id },
       name: [{ given: ['Linked'], family: 'Patient' }],
     });
 
-    const patient = await systemRepo.createResource<Patient>({
+    const patient = await repo.createResource<Patient>({
       resourceType: 'Patient',
-      meta: { project: project.id },
       name: [{ given: ['Alice'], family: 'Smith' }],
     });
 
     const linkedObs = await linkedRepo.createResource<Observation>({
       resourceType: 'Observation',
-      meta: { project: linkedProject.id },
       status: 'final',
       code: { coding: [{ system: LOINC, code: '12345-6' }] },
       subject: { reference: 'Patient/' + linkedPatient.id },
     });
 
-    const obs = await systemRepo.createResource<Observation>({
+    const obs = await repo.createResource<Observation>({
       resourceType: 'Observation',
-      meta: { project: project.id },
       status: 'final',
       code: { coding: [{ system: LOINC, code: '12345-6' }] },
       subject: { reference: 'Patient/' + patient.id },
@@ -168,20 +163,19 @@ describe('Expunge', () => {
   });
 
   test('Project admin can expunge patient everything within own project', async () => {
-    const { project, accessToken } = await createTestProject({
+    const { accessToken, repo } = await createTestProject({
       withAccessToken: true,
+      withRepo: true,
       membership: { admin: true },
     });
 
-    const patient = await systemRepo.createResource<Patient>({
+    const patient = await repo.createResource<Patient>({
       resourceType: 'Patient',
-      meta: { project: project.id },
       name: [{ given: ['Alice'], family: 'Smith' }],
     });
 
-    const obs = await systemRepo.createResource<Observation>({
+    const obs = await repo.createResource<Observation>({
       resourceType: 'Observation',
-      meta: { project: project.id },
       status: 'final',
       code: { coding: [{ system: LOINC, code: '12345-6' }] },
       subject: { reference: 'Patient/' + patient.id },
@@ -210,10 +204,9 @@ describe('Expunge', () => {
 
   test('Project admin cannot expunge patient everything in another project', async () => {
     // Patient belongs to an unrelated project
-    const { project: otherProject } = await createTestProject({});
-    const otherPatient = await systemRepo.createResource<Patient>({
+    const { repo: otherRepo } = await createTestProject({ withRepo: true });
+    const otherPatient = await otherRepo.createResource<Patient>({
       resourceType: 'Patient',
-      meta: { project: otherProject.id },
       name: [{ given: ['Bob'], family: 'Jones' }],
     });
 
@@ -238,38 +231,31 @@ describe('Expunge', () => {
   });
 
   test('Expunger.expunge() expunges all resource types', async () => {
-    //setup
-    const { project, client, membership } = await createTestProject({ withClient: true });
-    expect(project).toBeDefined();
-    expect(client).toBeDefined();
-    expect(membership).toBeDefined();
+    const { project, client, membership, repo } = await createTestProject({
+      withClient: true,
+      withRepo: true,
+      membership: { admin: true },
+    });
 
-    const patient = await systemRepo.createResource<Patient>({
+    const patient = await repo.createResource<Patient>({
       resourceType: 'Patient',
-      meta: { project: project.id },
       name: [{ given: ['Alice'], family: 'Smith' }],
     });
-    expect(patient).toBeDefined();
-    const patient2 = await systemRepo.createResource<Patient>({
+    const patient2 = await repo.createResource<Patient>({
       resourceType: 'Patient',
-      meta: { project: project.id },
       name: [{ given: ['Bob'], family: 'Smith' }],
     });
-    const patient3 = await systemRepo.createResource<Patient>({
+    const patient3 = await repo.createResource<Patient>({
       resourceType: 'Patient',
-      meta: { project: project.id },
       name: [{ given: ['Bob'], family: 'Smith' }],
     });
-    expect(patient3).toBeDefined();
 
-    const obs = await systemRepo.createResource<Observation>({
+    const obs = await repo.createResource<Observation>({
       resourceType: 'Observation',
-      meta: { project: project.id },
       status: 'final',
       code: { coding: [{ system: LOINC, code: '12345-6' }] },
       subject: { reference: 'Patient/' + patient.id },
     });
-    expect(obs).toBeDefined();
 
     expect(await existsInCache('Project', project.id)).toBe(true);
     expect(await existsInCache('ClientApplication', client.id)).toBe(true);
@@ -280,7 +266,7 @@ describe('Expunge', () => {
     expect(await existsInCache('Observation', obs.id)).toBe(true);
 
     //execute
-    await new Expunger(systemRepo, project.id, 2).expunge();
+    await new Expunger(repo, project.id, 2).expunge();
 
     //result
 

--- a/packages/server/src/fhir/operations/graphql.test.ts
+++ b/packages/server/src/fhir/operations/graphql.test.ts
@@ -15,6 +15,7 @@ import { getCacheRedis } from '../../redis';
 import { addTestUser, createTestProject, withTestContext } from '../../test.setup';
 import { Repository } from '../repo';
 import * as searchFile from '../search';
+import { PLACEHOLDER_SHARD_ID } from '../sharding';
 
 const app = express();
 let practitioner: Practitioner;
@@ -44,6 +45,7 @@ describe('GraphQL', () => {
       practitioner = aliceRegistration.profile as Practitioner;
 
       const aliceRepo = new Repository({
+        routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
         author: createReference(aliceRegistration.profile),
         projects: [aliceRegistration.project],
       });

--- a/packages/server/src/fhir/operations/groupexport.test.ts
+++ b/packages/server/src/fhir/operations/groupexport.test.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
 import { ContentType, getReferenceString } from '@medplum/core';
-import type { BulkDataExportOutput, Group, Organization, Patient } from '@medplum/fhirtypes';
+import type { BulkDataExportOutput, Group, Organization, Patient, Project } from '@medplum/fhirtypes';
 import express from 'express';
 import request from 'supertest';
 import { vi } from 'vitest';
@@ -9,20 +10,23 @@ import { initApp, shutdownApp } from '../../app';
 import { getConfig, loadTestConfig } from '../../config/loader';
 import type { FileSystemStorage } from '../../storage/filesystem';
 import { getBinaryStorage } from '../../storage/loader';
-import { createTestProject, initTestAuth, waitForAsyncJob, withTestContext } from '../../test.setup';
-import { getGlobalSystemRepo } from '../repo';
+import { createTestProject, waitForAsyncJob, withTestContext } from '../../test.setup';
+import type { Repository, SystemRepository } from '../repo';
 import { groupExportResources } from './groupexport';
 import { BulkExporter } from './utils/bulkexporter';
 
 describe('Group Export', () => {
   const app = express();
-  const systemRepo = getGlobalSystemRepo();
   let accessToken: string;
+  let project: WithId<Project>;
+  let repo: Repository;
+  let systemRepo: SystemRepository;
 
   beforeAll(async () => {
     const config = await loadTestConfig();
     await initApp(app, config);
-    accessToken = await initTestAuth();
+    ({ project, accessToken, repo } = await createTestProject({ withAccessToken: true, withRepo: true }));
+    systemRepo = repo.getSystemRepo();
   });
 
   afterAll(async () => {
@@ -326,8 +330,6 @@ describe('Group Export', () => {
   });
 
   test('groupExportResources without members', async () => {
-    const { project } = await createTestProject();
-    expect(project).toBeDefined();
     const exporter = new BulkExporter(systemRepo);
     const exportWriteResourceSpy = vi.spyOn(exporter, 'writeResource');
 
@@ -344,8 +346,6 @@ describe('Group Export', () => {
   });
 
   test('groupExportResources members without reference', async () => {
-    const { project } = await createTestProject();
-    expect(project).toBeDefined();
     const exporter = new BulkExporter(systemRepo);
 
     const patient: Patient = await systemRepo.createResource<Patient>({
@@ -375,12 +375,12 @@ describe('Group Export', () => {
       // and Binary resources are server-side bookkeeping and must not require the caller
       // to have write access -- e.g. a read-only `system/*.read` scope must still work.
       // BulkExporter creates these via the system repo, scoped to the caller's project.
-      const { repo, project } = await createTestProject({
-        withRepo: true,
-        accessPolicy: { resource: [{ resourceType: '*', readonly: true }] },
+
+      const readOnlyRepo = repo.clone({
+        accessPolicy: { resourceType: 'AccessPolicy', resource: [{ resourceType: '*', readonly: true }] },
       });
 
-      const exporter = new BulkExporter(repo);
+      const exporter = new BulkExporter(readOnlyRepo);
 
       // Previously threw OperationOutcomeError(Forbidden): the AsyncJob was created via
       // the caller's (read-only) repo.

--- a/packages/server/src/fhir/operations/hold.test.ts
+++ b/packages/server/src/fhir/operations/hold.test.ts
@@ -25,15 +25,14 @@ import express from 'express';
 import supertest from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
-import { getGlobalSystemRepo } from '../../fhir/repo';
 import type { TestProjectResult } from '../../test.setup';
 import { createTestProject } from '../../test.setup';
+import type { SystemRepository } from '../repo';
 import type {
   SchedulingParametersExtension,
   SchedulingParametersExtensionExtension,
 } from './utils/scheduling-parameters';
 
-const systemRepo = getGlobalSystemRepo();
 const app = express();
 const request = supertest(app);
 
@@ -62,7 +61,8 @@ const threeDayAvailability: SchedulingParametersExtensionExtension = {
 };
 
 describe('Appointment/$hold', () => {
-  let project: TestProjectResult<{ withAccessToken: true }>;
+  let project: TestProjectResult<{ withAccessToken: true; withRepo: true }>;
+  let systemRepo: SystemRepository;
   let practitioner1: WithId<Practitioner>;
   let practitioner2: WithId<Practitioner>;
   let patient: WithId<Patient>;
@@ -75,7 +75,8 @@ describe('Appointment/$hold', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
     await initApp(app, config);
-    project = await createTestProject({ withAccessToken: true });
+    project = await createTestProject({ withAccessToken: true, withRepo: true });
+    systemRepo = project.repo.getSystemRepo();
     patient = await makePatient();
     practitioner1 = await makePractitioner({ timezone: 'America/New_York' });
     practitioner2 = await makePractitioner({ timezone: 'America/New_York' });
@@ -1329,12 +1330,14 @@ describe('Appointment/$hold', () => {
 });
 
 describe('scheduling flow integration test', () => {
-  let project: TestProjectResult<{ withAccessToken: true }>;
+  let project: TestProjectResult<{ withAccessToken: true; withRepo: true }>;
+  let systemRepo: SystemRepository;
 
   beforeAll(async () => {
     const config = await loadTestConfig();
     await initApp(app, config);
-    project = await createTestProject({ withAccessToken: true });
+    project = await createTestProject({ withAccessToken: true, withRepo: true });
+    systemRepo = project.repo.getSystemRepo();
   });
 
   afterAll(async () => {

--- a/packages/server/src/fhir/operations/packageinstall.test.ts
+++ b/packages/server/src/fhir/operations/packageinstall.test.ts
@@ -13,7 +13,7 @@ import { loadTestConfig } from '../../config/loader';
 import * as storage from '../../storage/loader';
 import type { BinaryStorage } from '../../storage/types';
 import { addTestUser, createTestProject, withTestContext } from '../../test.setup';
-import { getGlobalSystemRepo } from '../repo';
+import type { Repository, SystemRepository } from '../repo';
 
 class MockBinaryStorage {
   private content: string;
@@ -37,6 +37,7 @@ class MockBinaryStorage {
 describe('PackageRelease $install', () => {
   const app = express();
   let project: WithId<Project>;
+  let systemRepo: SystemRepository;
   let adminAccessToken: string;
   let nonAdminAccessToken: string;
 
@@ -44,16 +45,15 @@ describe('PackageRelease $install', () => {
     const config = await loadTestConfig();
     await initApp(app, config);
 
-    const testProject = await createTestProject({
-      withAccessToken: true,
-      membership: { admin: true },
-    });
+    let adminRepo: Repository;
+    ({
+      project,
+      repo: adminRepo,
+      accessToken: adminAccessToken,
+    } = await createTestProject({ withAccessToken: true, withRepo: true, membership: { admin: true } }));
+    systemRepo = adminRepo.getSystemRepo();
 
-    const testUser = await addTestUser(testProject.project);
-
-    project = testProject.project;
-    adminAccessToken = testProject.accessToken;
-    nonAdminAccessToken = testUser.accessToken;
+    ({ accessToken: nonAdminAccessToken } = await addTestUser(project));
   });
 
   afterAll(async () => {
@@ -65,7 +65,6 @@ describe('PackageRelease $install', () => {
   });
 
   test('Require semver version string', async () => {
-    const systemRepo = getGlobalSystemRepo();
     await expect(async () =>
       withTestContext(() =>
         systemRepo.createResource<PackageRelease>({
@@ -83,7 +82,6 @@ describe('PackageRelease $install', () => {
   });
 
   test('Forbidden for non-admin user', async () => {
-    const systemRepo = getGlobalSystemRepo();
     const packageRelease = await withTestContext(() =>
       systemRepo.createResource<PackageRelease>({
         resourceType: 'PackageRelease',
@@ -106,8 +104,6 @@ describe('PackageRelease $install', () => {
   });
 
   test('Success for admin user', async () => {
-    const systemRepo = getGlobalSystemRepo();
-
     // Create a test bundle to install
     const bundle: Bundle = {
       resourceType: 'Bundle',
@@ -174,8 +170,6 @@ describe('PackageRelease $install', () => {
   });
 
   test('Error handling when bundle processing fails', async () => {
-    const systemRepo = getGlobalSystemRepo();
-
     // Create a malformed bundle
     const malformedBundle = {
       resourceType: 'Bundle',

--- a/packages/server/src/fhir/operations/projectinit.test.ts
+++ b/packages/server/src/fhir/operations/projectinit.test.ts
@@ -11,7 +11,13 @@ import { initApp, shutdownApp } from '../../app';
 import { createUser } from '../../auth/newuser';
 import { loadTestConfig } from '../../config/loader';
 import type { MedplumServerConfig } from '../../config/types';
-import { getSuperAdminAccessToken, initTestAuth, setupRecaptchaMock, withTestContext } from '../../test.setup';
+import {
+  getSuperAdminAccessToken,
+  getSuperAdminTestProject,
+  initTestAuth,
+  setupRecaptchaMock,
+  withTestContext,
+} from '../../test.setup';
 import { getGlobalSystemRepo } from '../repo';
 import { PRACTITIONER_READONLY_RESOURCE_TYPES } from './projectinit';
 
@@ -146,11 +152,9 @@ describe('Project $init', () => {
   });
 
   test('Requires owner to be User', async () => {
-    const superAdminClientToken = await getSuperAdminAccessToken();
-    expect(superAdminClientToken).toBeDefined();
-
+    const { repo: superAdminRepo, accessToken: superAdminClientToken } = await getSuperAdminTestProject();
     const doc = await withTestContext(() =>
-      getGlobalSystemRepo().createResource<Practitioner>({ resourceType: 'Practitioner' })
+      superAdminRepo.createResource<Practitioner>({ resourceType: 'Practitioner' })
     );
 
     const projectName = 'Test Init Project ' + randomUUID();

--- a/packages/server/src/fhir/operations/rebuild-base-definitions.ts
+++ b/packages/server/src/fhir/operations/rebuild-base-definitions.ts
@@ -24,7 +24,7 @@ import type {
 import { r4ProjectId } from '../../constants';
 import { requireSuperAdmin } from '../../context';
 import { globalLogger } from '../../logger';
-import type { Repository, SystemRepository } from '../repo';
+import type { SystemRepository } from '../repo';
 import { parseInputParameters } from './utils/parameters';
 
 const op = getDefinitionResource<OperationDefinition>(
@@ -38,15 +38,15 @@ type InputParams = {
 };
 
 export async function rebuildBaseDefinitionsOperation(req: FhirRequest): Promise<FhirResponse> {
-  const { repo } = requireSuperAdmin();
+  const { systemRepo } = requireSuperAdmin();
 
   const params = parseInputParameters<InputParams>(op, req);
-  await rebuildBaseDefinitions(repo, params.resourceType);
+  await rebuildBaseDefinitions(systemRepo, params.resourceType);
 
   return [allOk];
 }
 
-export async function rebuildBaseDefinitions(repo: Repository, types?: ResourceType[]): Promise<void> {
+export async function rebuildBaseDefinitions(repo: SystemRepository, types?: ResourceType[]): Promise<void> {
   // Search Parameters
   if (shouldProcessType(types, 'SearchParameter')) {
     await processBaseDefinitions(SEARCH_PARAMETER_BUNDLE_FILES, (entry) => processSearchParameterEntry(repo, entry));
@@ -76,7 +76,7 @@ export async function rebuildBaseDefinitions(repo: Repository, types?: ResourceT
   }
 }
 
-async function processSearchParameterEntry(repo: Repository, entry: BundleEntry): Promise<void> {
+async function processSearchParameterEntry(repo: SystemRepository, entry: BundleEntry): Promise<void> {
   if (!isResource<SearchParameter>(entry.resource, 'SearchParameter')) {
     return;
   }
@@ -87,7 +87,7 @@ async function processSearchParameterEntry(repo: Repository, entry: BundleEntry)
 }
 
 async function processStructureDefinitionEntry(
-  repo: Repository,
+  repo: SystemRepository,
   entry: BundleEntry<StructureDefinition>
 ): Promise<void> {
   const sd = entry.resource;
@@ -106,7 +106,7 @@ async function processStructureDefinitionEntry(
 }
 
 async function processOperationDefinitionEntry(
-  repo: Repository,
+  repo: SystemRepository,
   entry: BundleEntry<OperationDefinition>
 ): Promise<void> {
   const op = entry.resource as OperationDefinition;
@@ -119,7 +119,7 @@ async function processOperationDefinitionEntry(
 }
 
 async function processTerminologyDefinitionEntry(
-  repo: Repository,
+  repo: SystemRepository,
   entry: BundleEntry<CodeSystem | ValueSet>
 ): Promise<void> {
   const resource = entry.resource as CodeSystem | ValueSet;

--- a/packages/server/src/fhir/operations/refresh-reference-display.test.ts
+++ b/packages/server/src/fhir/operations/refresh-reference-display.test.ts
@@ -8,7 +8,7 @@ import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
 import { createTestProject, withTestContext } from '../../test.setup';
-import type { Repository } from '../repo';
+import type { Repository, SystemRepository } from '../repo';
 
 describe('$refresh-reference-display', () => {
   const app = express();
@@ -16,7 +16,7 @@ describe('$refresh-reference-display', () => {
   let accessToken: string;
   let client: WithId<ClientApplication>;
   let accessPolicy: WithId<AccessPolicy>;
-  let systemRepo: Repository;
+  let systemRepo: SystemRepository;
 
   beforeAll(async () => {
     const config = await loadTestConfig();

--- a/packages/server/src/fhir/operations/smarthealth.test.ts
+++ b/packages/server/src/fhir/operations/smarthealth.test.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { badRequest, ContentType } from '@medplum/core';
+import { badRequest, ContentType, generateId } from '@medplum/core';
 import type { Binary, Bundle, Parameters, Patient, SmartHealthLink } from '@medplum/fhirtypes';
 import express from 'express';
 import { base64url, CompactEncrypt, CompactSign, exportJWK, generateKeyPair } from 'jose';
@@ -10,16 +10,18 @@ import { vi } from 'vitest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
 import type { KeyLike } from '../../oauth/keys';
-import { createTestProject, initTestAuth } from '../../test.setup';
+import { createTestProject } from '../../test.setup';
+import type { Repository } from '../repo';
 
 const app = express();
 let accessToken: string;
+let repo: Repository;
 
 describe('SMART Health operations', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
     await initApp(app, config);
-    accessToken = await initTestAuth();
+    ({ repo, accessToken } = await createTestProject({ withAccessToken: true, withRepo: true }));
   });
 
   afterAll(async () => {
@@ -639,8 +641,7 @@ describe('SMART Health operations', () => {
     const directUrl = new URL(getStringParameter(generateResponse.body, 'url'));
     const smartHealthLink = await readGeneratedSmartHealthLink(directUrl.pathname);
     const binaryId = getBinaryId(smartHealthLink);
-    const { getGlobalSystemRepo } = await import('../repo');
-    await getGlobalSystemRepo().deleteResource('Binary', binaryId);
+    await repo.deleteResource('Binary', binaryId);
 
     const payloadResponse = await request(app).get(directUrl.pathname).query({ recipient: 'Test Recipient' });
     expect(payloadResponse).toHaveStatus(404);
@@ -718,21 +719,17 @@ async function createPatient(): Promise<Patient> {
 async function readGeneratedSmartHealthLink(pathname: string): Promise<SmartHealthLink> {
   const id = pathname.match(/^\/shl\/([^/]+)\//)?.[1];
   expect(id).toBeDefined();
-  const { getGlobalSystemRepo } = await import('../repo');
-  return getGlobalSystemRepo().readResource<SmartHealthLink>('SmartHealthLink', id as string);
+  return repo.readResource<SmartHealthLink>('SmartHealthLink', id as string);
 }
 
 async function updateGeneratedSmartHealthLink(smartHealthLink: SmartHealthLink): Promise<void> {
-  const { getGlobalSystemRepo } = await import('../repo');
-  await getGlobalSystemRepo().updateResource(smartHealthLink);
+  await repo.updateResource(smartHealthLink);
 }
 
 async function createBinaryInAnotherProject(): Promise<Binary> {
-  const { project } = await createTestProject();
-  const { getGlobalSystemRepo } = await import('../repo');
-  return getGlobalSystemRepo().createResource<Binary>({
+  return repo.getSystemRepo().createResource<Binary>({
     resourceType: 'Binary',
-    meta: { project: project.id },
+    meta: { project: generateId() },
     contentType: ContentType.JOSE,
   });
 }

--- a/packages/server/src/fhir/operations/utils/asyncjobexecutor.test.ts
+++ b/packages/server/src/fhir/operations/utils/asyncjobexecutor.test.ts
@@ -1,12 +1,11 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { randomUUID } from 'crypto';
 import express from 'express';
 import { vi } from 'vitest';
 import { initApp, shutdownApp } from '../../../app';
 import { loadTestConfig } from '../../../config/loader';
 import { createTestProject, waitForAsyncJob, withTestContext } from '../../../test.setup';
-import { getGlobalSystemRepo, Repository } from '../../repo';
+import { getGlobalSystemRepo } from '../../repo';
 import { AsyncJobExecutor } from './asyncjobexecutor';
 
 describe('AsyncJobExecutor', () => {
@@ -33,13 +32,8 @@ describe('AsyncJobExecutor', () => {
 
   test('start', () =>
     withTestContext(async () => {
-      const testProject = await createTestProject({ withAccessToken: true });
-      const exec = new AsyncJobExecutor(
-        new Repository({
-          projects: [testProject.project],
-          author: { reference: 'User/' + randomUUID() },
-        })
-      );
+      const testProject = await createTestProject({ withAccessToken: true, withRepo: true });
+      const exec = new AsyncJobExecutor(testProject.repo);
 
       const resource = await exec.init('http://example.com/async');
       const callback = vi.fn();

--- a/packages/server/src/fhir/operations/utils/asyncjobexecutor.test.ts
+++ b/packages/server/src/fhir/operations/utils/asyncjobexecutor.test.ts
@@ -5,12 +5,12 @@ import { vi } from 'vitest';
 import { initApp, shutdownApp } from '../../../app';
 import { loadTestConfig } from '../../../config/loader';
 import { createTestProject, waitForAsyncJob, withTestContext } from '../../../test.setup';
-import { getGlobalSystemRepo } from '../../repo';
+import { getTestProjectSystemRepo } from '../../repository/test-utils';
 import { AsyncJobExecutor } from './asyncjobexecutor';
 
 describe('AsyncJobExecutor', () => {
   const app = express();
-  const systemRepo = getGlobalSystemRepo();
+  const systemRepo = getTestProjectSystemRepo();
 
   beforeAll(async () => {
     const config = await loadTestConfig();

--- a/packages/server/src/fhir/operations/utils/terminology.test.ts
+++ b/packages/server/src/fhir/operations/utils/terminology.test.ts
@@ -8,7 +8,8 @@ import { initAppServices, shutdownApp } from '../../../app';
 import { loadTestConfig } from '../../../config/loader';
 import { r4ProjectId } from '../../../constants';
 import { createTestProject, withTestContext } from '../../../test.setup';
-import { getGlobalSystemRepo } from '../../repo';
+import type { Repository } from '../../repo';
+import { getTestProjectSystemRepo } from '../../repository/test-utils';
 import { SelectQuery, SqlBuilder } from '../../sql';
 import { addDescendants, findTerminologyResource, parentProperty } from './terminology';
 
@@ -43,8 +44,6 @@ describe('Terminology query builders', () => {
 });
 
 describe('findTerminologyResource', () => {
-  const systemRepo = getGlobalSystemRepo();
-
   beforeAll(async () => {
     const config = await loadTestConfig();
     await initAppServices(config);
@@ -54,13 +53,12 @@ describe('findTerminologyResource', () => {
     await shutdownApp();
   });
 
-  function createCodeSystem(projectId: string, codeSystem: Partial<CodeSystem>): Promise<WithId<CodeSystem>> {
-    return systemRepo.createResource<CodeSystem>({
+  function createCodeSystem(repo: Repository, codeSystem: Partial<CodeSystem>): Promise<WithId<CodeSystem>> {
+    return repo.createResource<CodeSystem>({
       resourceType: 'CodeSystem',
       status: 'active',
       content: 'complete',
       ...codeSystem,
-      meta: { project: projectId },
     });
   }
 
@@ -71,11 +69,11 @@ describe('findTerminologyResource', () => {
   test('Prefers current Project over linked Project with newer version and date', () =>
     withTestContext(async () => {
       const url = 'http://example.com/cs-' + randomUUID();
-      const { project: linked } = await createTestProject();
-      await createCodeSystem(linked.id, { url, version: '9.9.9', date: '2030-01-01' });
+      const { project: linked, repo: linkedRepo } = await createTestProject({ withRepo: true });
+      await createCodeSystem(linkedRepo, { url, version: '9.9.9', date: '2030-01-01' });
 
-      const { project, repo } = await createTestProject({ withRepo: true, project: linkTo(linked) });
-      const own = await createCodeSystem(project.id, { url, version: '1.0.0', date: '2020-01-01' });
+      const { repo } = await createTestProject({ withRepo: true, project: linkTo(linked) });
+      const own = await createCodeSystem(repo, { url, version: '1.0.0', date: '2020-01-01' });
 
       await expect(findTerminologyResource(repo, 'CodeSystem', url)).resolves.toMatchObject({ id: own.id });
     }));
@@ -83,12 +81,12 @@ describe('findTerminologyResource', () => {
   test('Prefers linked Projects in link order', () =>
     withTestContext(async () => {
       const url = 'http://example.com/cs-' + randomUUID();
-      const { project: p1 } = await createTestProject();
-      const { project: p2 } = await createTestProject();
-      const { project: p3 } = await createTestProject();
-      const cs1 = await createCodeSystem(p1.id, { url });
-      const cs2 = await createCodeSystem(p2.id, { url });
-      const cs3 = await createCodeSystem(p3.id, { url });
+      const { project: p1, repo: repo1 } = await createTestProject({ withRepo: true });
+      const { project: p2, repo: repo2 } = await createTestProject({ withRepo: true });
+      const { project: p3, repo: repo3 } = await createTestProject({ withRepo: true });
+      const cs1 = await createCodeSystem(repo1, { url });
+      const cs2 = await createCodeSystem(repo2, { url });
+      const cs3 = await createCodeSystem(repo3, { url });
 
       const { repo: firstRepo } = await createTestProject({ withRepo: true, project: linkTo(p1, p2, p3) });
       await expect(findTerminologyResource(firstRepo, 'CodeSystem', url)).resolves.toMatchObject({ id: cs1.id });
@@ -102,16 +100,16 @@ describe('findTerminologyResource', () => {
   test('Falls back to base FHIR resource when no Project-local resource exists', () =>
     withTestContext(async () => {
       const url = 'http://example.com/cs-' + randomUUID();
-      const base = await createCodeSystem(r4ProjectId, { url });
-      const { project: linked } = await createTestProject();
+      const base = await createCodeSystem(getTestProjectSystemRepo(), { meta: { project: r4ProjectId }, url });
+      const { project: linked, repo: linkedRepo } = await createTestProject({ withRepo: true });
+      const linkedCodeSystem = await createCodeSystem(linkedRepo, { url });
 
       const { repo: unlinkedRepo } = await createTestProject({ withRepo: true });
       await expect(findTerminologyResource(unlinkedRepo, 'CodeSystem', url)).resolves.toMatchObject({ id: base.id });
 
       // A linked Project's resource outranks the base FHIR one
-      const linkedCodeSystem = await createCodeSystem(linked.id, { url });
-      const { repo: linkedRepo } = await createTestProject({ withRepo: true, project: linkTo(linked) });
-      await expect(findTerminologyResource(linkedRepo, 'CodeSystem', url)).resolves.toMatchObject({
+      const { repo } = await createTestProject({ withRepo: true, project: linkTo(linked) });
+      await expect(findTerminologyResource(repo, 'CodeSystem', url)).resolves.toMatchObject({
         id: linkedCodeSystem.id,
       });
     }));
@@ -119,11 +117,11 @@ describe('findTerminologyResource', () => {
   test('ownProjectOnly selects the current Project resource ranked below a linked one', () =>
     withTestContext(async () => {
       const url = 'http://example.com/cs-' + randomUUID();
-      const { project: linked } = await createTestProject();
-      await createCodeSystem(linked.id, { url, content: 'complete' });
+      const { project: linked, repo: linkedRepo } = await createTestProject({ withRepo: true });
+      await createCodeSystem(linkedRepo, { url, content: 'complete' });
 
-      const { project, repo } = await createTestProject({ withRepo: true, project: linkTo(linked) });
-      const own = await createCodeSystem(project.id, { url, content: 'fragment' });
+      const { repo } = await createTestProject({ withRepo: true, project: linkTo(linked) });
+      const own = await createCodeSystem(repo, { url, content: 'fragment' });
 
       await expect(findTerminologyResource(repo, 'CodeSystem', url, { ownProjectOnly: true })).resolves.toMatchObject({
         id: own.id,
@@ -134,7 +132,7 @@ describe('findTerminologyResource', () => {
     withTestContext(async () => {
       const url = 'http://example.com/cs-' + randomUUID();
       const { project, repo } = await createTestProject({ withRepo: true, extendedMode: false });
-      await createCodeSystem(project.id, { url });
+      await createCodeSystem(repo, { url });
 
       const resolved = await findTerminologyResource(repo, 'CodeSystem', url);
       expect(resolved.meta?.project).toBeUndefined();
@@ -149,8 +147,8 @@ describe('findTerminologyResource', () => {
   test('Excludes retired resources', () =>
     withTestContext(async () => {
       const url = 'http://example.com/cs-' + randomUUID();
-      const { project, repo } = await createTestProject({ withRepo: true });
-      await createCodeSystem(project.id, { url, status: 'retired' });
+      const { repo } = await createTestProject({ withRepo: true });
+      await createCodeSystem(repo, { url, status: 'retired' });
 
       await expect(findTerminologyResource(repo, 'CodeSystem', url)).rejects.toThrow(`CodeSystem ${url} not found`);
     }));

--- a/packages/server/src/fhir/patient.test.ts
+++ b/packages/server/src/fhir/patient.test.ts
@@ -14,7 +14,7 @@ import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import { withTestContext } from '../test.setup';
 import { getPatientCompartmentParams, getPatientResourceTypes, getPatients } from './patient';
-import { getGlobalSystemRepo } from './repo';
+import { getTestProjectSystemRepo } from './repository/test-utils';
 
 describe('FHIR Patient utils', () => {
   beforeAll(async () => {
@@ -158,7 +158,7 @@ describe('FHIR Patient utils', () => {
       // and that resource has a reference to a patient,
       // but the patient reference is an external patient ID,
       // we should silently ignore the patient reference
-      const systemRepo = getGlobalSystemRepo();
+      const systemRepo = getTestProjectSystemRepo();
       const eob = await systemRepo.createResource<ExplanationOfBenefit>({
         resourceType: 'ExplanationOfBenefit',
         status: 'active',

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -7,6 +7,7 @@ import {
   badRequest,
   created,
   createReference,
+  forbidden,
   getReferenceString,
   isGone,
   isOk,
@@ -59,18 +60,17 @@ import {
 import { AuditEventOutcome, createAuditEvent, ReadInteraction, RestfulOperationType } from '../util/auditevent';
 import * as workersModule from '../workers';
 import { getRepoForLogin } from './accesspolicy';
-import { getGlobalSystemRepo, getProjectSystemRepo, getShardSystemRepo, Repository } from './repo';
+import type { SystemRepository } from './repo';
+import { getShardSystemRepo, Repository } from './repo';
 import { repoAccess } from './repository/access-tracker';
 import { PLACEHOLDER_SHARD_ID } from './sharding';
 import { SelectQuery } from './sql';
 import * as tokenColumnModule from './token-column';
 
 describe('FHIR Repo', () => {
-  const globalSystemRepo = getGlobalSystemRepo();
   let testProject: WithId<Project>;
-
   let testProjectRepo: Repository;
-  let systemRepo: Repository;
+  let systemRepo: SystemRepository;
   let stdoutSpy: MockInstance<typeof process.stdout.write>;
 
   beforeAll(async () => {
@@ -79,20 +79,8 @@ describe('FHIR Repo', () => {
     const config = await loadTestConfig();
     await initAppServices(config);
 
-    testProject = await globalSystemRepo.createResource({
-      resourceType: 'Project',
-      id: randomUUID(),
-    });
-    systemRepo = await getProjectSystemRepo(testProject);
-    testProjectRepo = new Repository({
-      routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
-      projects: [testProject],
-      extendedMode: true,
-      strictMode: true,
-      author: {
-        reference: 'Practitioner/' + randomUUID(),
-      },
-    });
+    ({ project: testProject, repo: testProjectRepo } = await createTestProject({ withRepo: true }));
+    systemRepo = testProjectRepo.getSystemRepo();
   });
 
   afterAll(async () => {
@@ -117,7 +105,7 @@ describe('FHIR Repo', () => {
 
   test('Enterprise access is limited to super admins', () => {
     expect(testProjectRepo.supportsInteraction(AccessPolicyInteraction.READ, 'Enterprise')).toBe(false);
-    expect(globalSystemRepo.supportsInteraction(AccessPolicyInteraction.READ, 'Enterprise')).toBe(true);
+    expect(testProjectRepo.getSystemRepo().supportsInteraction(AccessPolicyInteraction.READ, 'Enterprise')).toBe(true);
   });
 
   describe('setMode routes reads to reader until writer promotion', () => {
@@ -249,9 +237,9 @@ describe('FHIR Repo', () => {
   });
 
   test('Read Binary requires access to securityContext', async () => {
-    const patient = await withTestContext(() => globalSystemRepo.createResource<Patient>({ resourceType: 'Patient' }));
+    const patient = await withTestContext(() => testProjectRepo.createResource<Patient>({ resourceType: 'Patient' }));
     const binary = await withTestContext(() =>
-      globalSystemRepo.createResource<Binary>({
+      testProjectRepo.createResource<Binary>({
         resourceType: 'Binary',
         contentType: 'text/plain',
         securityContext: createReference(patient),
@@ -260,8 +248,7 @@ describe('FHIR Repo', () => {
     const versionId = binary.meta?.versionId as string;
 
     const repoWithoutPatientAccess = new Repository({
-      routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
-      author: { reference: 'Practitioner/' + randomUUID() },
+      ...testProjectRepo.getConfig(),
       accessPolicy: {
         resourceType: 'AccessPolicy',
         resource: [{ resourceType: 'Binary', interaction: ['read', 'vread'] }],
@@ -271,12 +258,12 @@ describe('FHIR Repo', () => {
     await expect(repoWithoutPatientAccess.readResource<Binary>('Binary', binary.id)).rejects.toThrow();
     await expect(repoWithoutPatientAccess.readReference<Binary>(createReference(binary))).rejects.toThrow();
     await expect(repoWithoutPatientAccess.readVersion<Binary>('Binary', binary.id, versionId)).rejects.toThrow();
-    const deniedReferences = await repoWithoutPatientAccess.readReferences<Binary>([createReference(binary)]);
-    expect(deniedReferences[0]).toBeInstanceOf(Error);
+    await expect(repoWithoutPatientAccess.readReferences<Binary>([createReference(binary)])).rejects.toThrow(
+      new OperationOutcomeError(forbidden)
+    );
 
     const repoWithPatientAccess = new Repository({
-      routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
-      author: { reference: 'Practitioner/' + randomUUID() },
+      ...testProjectRepo.getConfig(),
       accessPolicy: {
         resourceType: 'AccessPolicy',
         resource: [{ resourceType: 'Binary' }, { resourceType: 'Patient' }],
@@ -293,7 +280,7 @@ describe('FHIR Repo', () => {
 
   test('Write Binary rejects Binary securityContext', async () => {
     const binary = await withTestContext(() =>
-      globalSystemRepo.createResource<Binary>({
+      systemRepo.createResource<Binary>({
         resourceType: 'Binary',
         contentType: 'text/plain',
         data: Buffer.from('recursive security context').toString('base64'),
@@ -301,10 +288,7 @@ describe('FHIR Repo', () => {
     );
 
     await expect(
-      globalSystemRepo.updateResource<Binary>({
-        ...binary,
-        securityContext: createReference(binary),
-      })
+      systemRepo.updateResource<Binary>({ ...binary, securityContext: createReference(binary) })
     ).rejects.toThrow('Binary.securityContext cannot reference another Binary');
   });
 

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -85,6 +85,7 @@ describe('FHIR Repo', () => {
     });
     systemRepo = await getProjectSystemRepo(testProject);
     testProjectRepo = new Repository({
+      routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
       projects: [testProject],
       extendedMode: true,
       strictMode: true,
@@ -259,6 +260,7 @@ describe('FHIR Repo', () => {
     const versionId = binary.meta?.versionId as string;
 
     const repoWithoutPatientAccess = new Repository({
+      routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
       author: { reference: 'Practitioner/' + randomUUID() },
       accessPolicy: {
         resourceType: 'AccessPolicy',
@@ -273,6 +275,7 @@ describe('FHIR Repo', () => {
     expect(deniedReferences[0]).toBeInstanceOf(Error);
 
     const repoWithPatientAccess = new Repository({
+      routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
       author: { reference: 'Practitioner/' + randomUUID() },
       accessPolicy: {
         resourceType: 'AccessPolicy',
@@ -802,6 +805,7 @@ describe('FHIR Repo', () => {
       const author = 'Practitioner/' + randomUUID();
 
       const repo = new Repository({
+        routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
         extendedMode: true,
         author: {
           reference: author,
@@ -822,6 +826,7 @@ describe('FHIR Repo', () => {
       const fakeAuthor = 'Practitioner/' + randomUUID();
 
       const repo = new Repository({
+        routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
         extendedMode: true,
         author: {
           reference: author,
@@ -850,6 +855,7 @@ describe('FHIR Repo', () => {
       const { project } = await createTestProject();
 
       const repo = new Repository({
+        routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
         projects: [project],
         extendedMode: true,
         skipBackgroundJobs: true,
@@ -907,6 +913,7 @@ describe('FHIR Repo', () => {
       const author = 'Practitioner/' + randomUUID();
 
       const repo = new Repository({
+        routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
         extendedMode: true,
         author: {
           reference: author,
@@ -2200,21 +2207,19 @@ describe('FHIR Repo', () => {
       resourceType: 'Project',
       id: randomUUID(),
     };
-    const context = {
+    const repo = new Repository({
+      routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
       projects: [project],
       author: {
         reference: 'Practitioner/' + randomUUID(),
       },
-    };
-
-    const repo = new Repository(context);
+    });
     const clonedRepo = repo.clone();
 
     // Repository construction mutates the shared context in place, but repeated
     // construction from that context must not append duplicate synthetic projects.
-    expect(context.projects.map((p) => p.id)).toStrictEqual([project.id, r4ProjectId]);
-    expect(repo.getConfig().projects?.filter((p) => p.id === r4ProjectId)).toHaveLength(1);
-    expect(clonedRepo.getConfig().projects?.filter((p) => p.id === r4ProjectId)).toHaveLength(1);
+    expect(repo.getConfig().projects?.map((p) => p.id)).toStrictEqual([project.id, r4ProjectId]);
+    expect(clonedRepo.getConfig().projects?.map((p) => p.id)).toStrictEqual([project.id, r4ProjectId]);
   });
 });
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -144,7 +144,7 @@ import type { SearchOptions } from './search';
 import { buildSearchExpression, searchByReferenceImpl, searchImpl } from './search';
 import { lookupTables } from './searchparameter';
 import type { ShardRouting } from './sharding';
-import { GLOBAL_SHARD_ID, normalizeShardId, resolveShardId, shardRoutingError } from './sharding';
+import { GLOBAL_SHARD_ID, normalizeShardId, resolveShardId, shardRoutingError, TODO_SHARD_ID } from './sharding';
 import type { Expression, PgQueryable } from './sql';
 import { Condition, DeleteQuery, Disjunction, InsertQuery, SelectQuery } from './sql';
 
@@ -2288,7 +2288,7 @@ export class Repository extends FhirRepository implements Disposable {
     return input;
   }
 
-  isSuperAdmin(): boolean {
+  isSuperAdmin(): this is SuperAdminRepository {
     return !!this.context.superAdmin;
   }
 
@@ -2676,7 +2676,15 @@ export class Repository extends FhirRepository implements Disposable {
   }
 }
 
-export class SystemRepository extends Repository {}
+declare const superAdminRepository: unique symbol;
+export type SuperAdminRepository = Repository & {
+  readonly [superAdminRepository]: true;
+};
+
+declare const systemRepository: unique symbol;
+export type SystemRepository = SuperAdminRepository & {
+  readonly [systemRepository]: true;
+};
 
 type SystemRepositoryContextDefaults = Pick<RepositoryContext, 'skipBackgroundJobs'>;
 
@@ -2694,13 +2702,14 @@ function createSystemRepository(
   transaction?: TransactionBinding,
   contextDefaults?: SystemRepositoryContextDefaults
 ): SystemRepository {
-  return new SystemRepository(
+  const repo = new Repository(
     {
       ...contextDefaults,
       routing,
       superAdmin: true,
       strictMode: true,
       extendedMode: true,
+      accessPolicy: undefined,
       author: {
         reference: 'system',
       },
@@ -2709,6 +2718,26 @@ function createSystemRepository(
     connections,
     transaction
   );
+
+  return asSystemRepository(repo);
+}
+
+function asSystemRepository(repo: Repository): SystemRepository {
+  if (!repo.isSuperAdmin()) {
+    throw new Error('System repository is not a super admin');
+  }
+  const context = repo.getConfig();
+  if (context.author.reference !== 'system') {
+    throw new Error('Repository author is not the system');
+  }
+  if (context.accessPolicy) {
+    throw new Error('System repository cannot have access policy');
+  }
+  if (context.projects) {
+    throw new Error('System repository cannot have projects');
+  }
+
+  return repo as SystemRepository;
 }
 
 /*
@@ -2777,7 +2806,7 @@ export async function getProjectSystemRepo(
   // Eventually, this will resolve the project's shard and return
   // a SystemRepository for that shard.
   // But for now, all projects are on the global shard.
-  return getGlobalSystemRepo();
+  return getShardSystemRepo(TODO_SHARD_ID);
 }
 
 const patchOperationDefinition: OperationDefinition = {

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -2794,8 +2794,8 @@ export function getShardSystemRepo(
 /**
  * Returns a SystemRepository for the specified project's shard.
  *
- * Note: This is a passthrough to `getGlobalSystemRepo` to facilitate
- * future sharding support.
+ * Note: resolves to getShardSystemRepo(TODO_SHARD_ID) until realproject-shard
+ * routing is implemented.
  *
  * @param _projectId - The project's ID, reference, or resource.
  * @returns A SystemRepository for the project's shard.

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -51,7 +51,6 @@ import type {
   Binary,
   Bundle,
   BundleEntry,
-  ClientApplication,
   Meta,
   OperationDefinition,
   OperationDefinitionParameter,
@@ -122,6 +121,7 @@ import type {
 } from './repository/repository-connection';
 import type { ConnectionEntry } from './repository/repository-connections';
 import { RepositoryConnections } from './repository/repository-connections';
+import type { RepositoryContext } from './repository/repository-context';
 import type { CacheEntry } from './repository/resource-cache';
 import {
   deleteResourceCacheEntries,
@@ -143,112 +143,10 @@ import { rewriteAttachments, RewriteMode } from './rewrite';
 import type { SearchOptions } from './search';
 import { buildSearchExpression, searchByReferenceImpl, searchImpl } from './search';
 import { lookupTables } from './searchparameter';
+import type { ShardRouting } from './sharding';
 import { GLOBAL_SHARD_ID, normalizeShardId, resolveShardId, shardRoutingError } from './sharding';
 import type { Expression, PgQueryable } from './sql';
 import { Condition, DeleteQuery, Disjunction, InsertQuery, SelectQuery } from './sql';
-
-/**
- * The RepositoryContext interface defines standard metadata for repository actions.
- * In practice, there will be one Repository per HTTP request.
- * And the RepositoryContext represents the context of that request,
- * such as "who is the current user?" and "what is the current project?"
- */
-export interface RepositoryContext {
-  /**
-   * The shard ID for this repository, i.e. where its project-scoped resources live.
-   * Defaults to GLOBAL_SHARD_ID if not specified. See {@link normalizeShardId}.
-   */
-  shardId?: string;
-
-  /**
-   * The current author reference.
-   * This should be a FHIR reference string (i.e., "resourceType/id").
-   * Where resource type is ClientApplication, Patient, Practitioner, etc.
-   * This value will be included in every resource as meta.author.
-   */
-  author: Reference;
-
-  /**
-   * Optional individual, device, or organization for whom the change was made.
-   * This value will be included in every resource as meta.onBehalfOf.
-   */
-  onBehalfOf?: Reference;
-
-  /**
-   * The authenticating ClientApplication for the current login, when present.
-   * This is the application that obtained the access token, which may differ
-   * from the acting `author` (e.g. when using `X-Medplum-On-Behalf-Of`, or for
-   * a SMART on FHIR app acting on behalf of a user). It is recorded as an
-   * additional non-requestor `agent[]` participant on per-interaction AuditEvents
-   * so the audit trail captures which client performed an action.
-   * Absent on the pure `client_credentials` / system paths.
-   */
-  client?: Reference<ClientApplication>;
-
-  remoteAddress?: string;
-
-  /**
-   * Projects that the Repository is allowed to access.
-   * If undefined, the repository acts on behalf of the server
-   * instead of a particular user.
-   * If not undefined, must have at least one element, and the first element
-   * is considered the "current project". The repository sets meta.project to
-   * the current project in edited resources. The R4 Project is appended if not already present
-   * by the Repository constructor.
-   */
-  projects?: WithId<Project>[];
-
-  /**
-   * Optional compartment restriction.
-   * If the compartments array is provided,
-   * all queries will be restricted to those compartments.
-   */
-  accessPolicy?: AccessPolicy;
-
-  /**
-   * Optional flag for system administrators,
-   * which grants system-level access.
-   */
-  superAdmin?: boolean;
-
-  /**
-   * Optional flag for project administrators,
-   * which grants additional project-level access.
-   */
-  projectAdmin?: boolean;
-
-  /**
-   * Optional flag to validate resources in strict mode.
-   * Strict mode validates resources against StructureDefinition resources,
-   * which includes strict date validation, backbone elements, and more.
-   * Non-strict mode uses the official FHIR JSONSchema definition, which is
-   * significantly more relaxed.
-   */
-  strictMode?: boolean;
-
-  /**
-   * Optional flag to validate references on write operations.
-   * If enabled, the repository will check that all references are valid,
-   * and that the current user has access to the referenced resource.
-   */
-  checkReferencesOnWrite?: boolean;
-
-  validateTerminology?: boolean;
-
-  /**
-   * Optional flag to include Medplum extended meta fields.
-   * Medplum tracks additional metadata for each resource, such as:
-   * 1) "author" - Reference to the last user who modified the resource.
-   * 2) "project" - Reference to the project that owns the resource.
-   * 3) "compartment" - References to all compartments the resource is in.
-   */
-  extendedMode?: boolean;
-
-  /**
-   * Optional flag to skip scheduling background jobs for writes.
-   */
-  skipBackgroundJobs?: boolean;
-}
 
 export interface InteractionOptions {
   verbose?: boolean;
@@ -395,7 +293,11 @@ export class Repository extends FhirRepository implements Disposable {
     }
     addSyntheticR4ProjectIfMissing(context);
     this.context = context;
-    this._normalizedShardId = normalizeShardId(context.shardId);
+    if (context.routing.kind === 'global-only') {
+      this._normalizedShardId = normalizeShardId(GLOBAL_SHARD_ID);
+    } else {
+      this._normalizedShardId = normalizeShardId(context.routing.shardId);
+    }
     this.ownsConnections = connections === undefined;
     this.connections = connections ?? new RepositoryConnections();
     // `transaction` is not validated for liveness here: it legitimately outlives its
@@ -432,7 +334,7 @@ export class Repository extends FhirRepository implements Disposable {
    */
   private connectionFor(options: RepositoryAccessOptions): { entry: ConnectionEntry; scope: ConnectionScope } {
     const { source } = options;
-    const shardId = resolveShardId(this.shardId, normalizeResourceTypes(options.resourceTypes), source);
+    const shardId = resolveShardId(this.context.routing, normalizeResourceTypes(options.resourceTypes), source);
     this.assertShardReachable(shardId, source);
     const entry = this.connections.entryFor(shardId, source);
     return { entry, scope: this.scopeFor(entry) };
@@ -514,9 +416,9 @@ export class Repository extends FhirRepository implements Disposable {
 
     let systemRepo: SystemRepository;
     if (this.connections.hasConnection()) {
-      systemRepo = createSystemRepository(this.shardId, this.connections, this.transaction, contextDefaults);
+      systemRepo = createSystemRepository(this.context.routing, this.connections, this.transaction, contextDefaults);
     } else {
-      systemRepo = createSystemRepository(this.shardId, undefined, undefined, contextDefaults);
+      systemRepo = createSystemRepository(this.context.routing, undefined, undefined, contextDefaults);
     }
     return systemRepo;
   }
@@ -2780,14 +2682,14 @@ type SystemRepositoryContextDefaults = Pick<RepositoryContext, 'skipBackgroundJo
 
 /**
  * Creates a SystemRepository for the specified shard.
- * @param shardId - The shard ID.
+ * @param routing - Shard routing information.
  * @param connections - Optional connection set to share, for transaction support.
  * @param transaction - Optional transaction binding to inherit from the sharing repository.
  * @param contextDefaults - Optional context defaults to apply before the fixed SystemRepository context.
  * @returns A SystemRepository instance.
  */
 function createSystemRepository(
-  shardId: string,
+  routing: ShardRouting,
   connections?: RepositoryConnections,
   transaction?: TransactionBinding,
   contextDefaults?: SystemRepositoryContextDefaults
@@ -2795,7 +2697,7 @@ function createSystemRepository(
   return new SystemRepository(
     {
       ...contextDefaults,
-      shardId,
+      routing,
       superAdmin: true,
       strictMode: true,
       extendedMode: true,
@@ -2831,15 +2733,10 @@ mostly intended for system-level, super-admin triggered operations against a par
  * - Looking up Users, Logins, ClientApplications
  * - Cross-project operations by super admins
  *
- * @param connection - Optional repository connection to use in new Repository.
- * @param contextDefaults - Optional context defaults to apply before the fixed SystemRepository context.
  * @returns A SystemRepository for the global shard.
  */
-export function getGlobalSystemRepo(
-  connection?: RepositoryConnection,
-  contextDefaults?: SystemRepositoryContextDefaults
-): SystemRepository {
-  return getShardSystemRepo(GLOBAL_SHARD_ID, connection, contextDefaults);
+export function getGlobalSystemRepo(): SystemRepository {
+  return createSystemRepository({ kind: 'global-only' });
 }
 
 /**
@@ -2858,7 +2755,7 @@ export function getShardSystemRepo(
   contextDefaults?: SystemRepositoryContextDefaults
 ): SystemRepository {
   return createSystemRepository(
-    shardId,
+    { kind: 'project-shard', shardId },
     connection && new RepositoryConnections(connection),
     undefined,
     contextDefaults

--- a/packages/server/src/fhir/repository/access-tracker.test.ts
+++ b/packages/server/src/fhir/repository/access-tracker.test.ts
@@ -6,11 +6,15 @@ import type { MockInstance } from 'vitest';
 import { DatabaseMode } from '../../database';
 import { getLogger } from '../../logger';
 import { Repository } from '../repo';
+import { PLACEHOLDER_SHARD_ID } from '../sharding';
 import { SelectQuery } from '../sql';
 import { RepositoryAccessTracker } from './access-tracker';
 
 describe('Repository SQL access', () => {
-  const repo = new Repository({ author: { reference: 'system' } });
+  const repo = new Repository({
+    routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
+    author: { reference: 'system' },
+  });
 
   test('Rejects a statement that declares no resource types', () => {
     expect(() =>

--- a/packages/server/src/fhir/repository/repository-context.ts
+++ b/packages/server/src/fhir/repository/repository-context.ts
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { WithId } from '@medplum/core';
+import type { AccessPolicy, ClientApplication, Project, Reference } from '@medplum/fhirtypes';
+import type { ShardRouting } from '../sharding';
+
+/**
+ * The RepositoryContext interface defines standard metadata for repository actions.
+ * In practice, there will be one Repository per HTTP request.
+ * And the RepositoryContext represents the context of that request,
+ * such as "who is the current user?" and "what is the current project?"
+ */
+export interface RepositoryContext {
+  routing: ShardRouting;
+
+  /**
+   * The current author reference.
+   * This should be a FHIR reference string (i.e., "resourceType/id").
+   * Where resource type is ClientApplication, Patient, Practitioner, etc.
+   * This value will be included in every resource as meta.author.
+   */
+  author: Reference;
+
+  /**
+   * Optional individual, device, or organization for whom the change was made.
+   * This value will be included in every resource as meta.onBehalfOf.
+   */
+  onBehalfOf?: Reference;
+
+  /**
+   * The authenticating ClientApplication for the current login, when present.
+   * This is the application that obtained the access token, which may differ
+   * from the acting `author` (e.g. when using `X-Medplum-On-Behalf-Of`, or for
+   * a SMART on FHIR app acting on behalf of a user). It is recorded as an
+   * additional non-requestor `agent[]` participant on per-interaction AuditEvents
+   * so the audit trail captures which client performed an action.
+   * Absent on the pure `client_credentials` / system paths.
+   */
+  client?: Reference<ClientApplication>;
+
+  remoteAddress?: string;
+
+  /**
+   * Projects that the Repository is allowed to access.
+   * If undefined, the repository acts on behalf of the server
+   * instead of a particular user.
+   * If not undefined, must have at least one element, and the first element
+   * is considered the "current project". The repository sets meta.project to
+   * the current project in edited resources. The R4 Project is appended if not already present
+   * by the Repository constructor.
+   */
+  projects?: WithId<Project>[];
+
+  /**
+   * Optional compartment restriction.
+   * If the compartments array is provided,
+   * all queries will be restricted to those compartments.
+   */
+  accessPolicy?: AccessPolicy;
+
+  /**
+   * Optional flag for system administrators,
+   * which grants system-level access.
+   */
+  superAdmin?: boolean;
+
+  /**
+   * Optional flag for project administrators,
+   * which grants additional project-level access.
+   */
+  projectAdmin?: boolean;
+
+  /**
+   * Optional flag to validate resources in strict mode.
+   * Strict mode validates resources against StructureDefinition resources,
+   * which includes strict date validation, backbone elements, and more.
+   * Non-strict mode uses the official FHIR JSONSchema definition, which is
+   * significantly more relaxed.
+   */
+  strictMode?: boolean;
+
+  /**
+   * Optional flag to validate references on write operations.
+   * If enabled, the repository will check that all references are valid,
+   * and that the current user has access to the referenced resource.
+   */
+  checkReferencesOnWrite?: boolean;
+
+  validateTerminology?: boolean;
+
+  /**
+   * Optional flag to include Medplum extended meta fields.
+   * Medplum tracks additional metadata for each resource, such as:
+   * 1) "author" - Reference to the last user who modified the resource.
+   * 2) "project" - Reference to the project that owns the resource.
+   * 3) "compartment" - References to all compartments the resource is in.
+   */
+  extendedMode?: boolean;
+
+  /**
+   * Optional flag to skip scheduling background jobs for writes.
+   */
+  skipBackgroundJobs?: boolean;
+}

--- a/packages/server/src/fhir/repository/row-builder.test.ts
+++ b/packages/server/src/fhir/repository/row-builder.test.ts
@@ -9,6 +9,7 @@ import { getConfig, loadTestConfig } from '../../config/loader';
 import type { ArrayColumnPaddingConfig, MedplumServerConfig } from '../../config/types';
 import { DatabaseMode, getDatabasePool } from '../../database';
 import { createTestProject, withTestContext } from '../../test.setup';
+import type { SystemRepository } from '../repo';
 import { getProjectSystemRepo, Repository } from '../repo';
 import type { ColumnValue } from './row-builder';
 import {
@@ -21,7 +22,7 @@ import {
 
 describe('Repository Row Builder', () => {
   let testProject: WithId<Project>;
-  let systemRepo: Repository;
+  let systemRepo: SystemRepository;
 
   beforeAll(async () => {
     const config = await loadTestConfig();

--- a/packages/server/src/fhir/repository/test-utils.ts
+++ b/packages/server/src/fhir/repository/test-utils.ts
@@ -9,7 +9,7 @@ import { PLACEHOLDER_SHARD_ID } from '../sharding';
  * no related Project is available yet.
  *
  * Prefer repo.getSystemRepo() or getProjectSystemRepo(project) when possible.
- * @param shardId The shard ID to use for the test system repository. Defaults to PLACEHOLDER_SHARD_ID.
+ * @param shardId - The shard ID to use for the test system repository. Defaults to PLACEHOLDER_SHARD_ID.
  * @returns A system repository for the specified shard ID.
  */
 export function getTestProjectSystemRepo(shardId = PLACEHOLDER_SHARD_ID): SystemRepository {

--- a/packages/server/src/fhir/repository/test-utils.ts
+++ b/packages/server/src/fhir/repository/test-utils.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { SystemRepository } from '../repo';
+import { getShardSystemRepo } from '../repo';
+import { PLACEHOLDER_SHARD_ID } from '../sharding';
+
+/**
+ * Returns a logically project-routed system repository for test fixtures when
+ * no related Project is available yet.
+ *
+ * Prefer repo.getSystemRepo() or getProjectSystemRepo(project) when possible.
+ * @param shardId The shard ID to use for the test system repository. Defaults to PLACEHOLDER_SHARD_ID.
+ * @returns A system repository for the specified shard ID.
+ */
+export function getTestProjectSystemRepo(shardId = PLACEHOLDER_SHARD_ID): SystemRepository {
+  return getShardSystemRepo(shardId);
+}

--- a/packages/server/src/fhir/repository/validation.test.ts
+++ b/packages/server/src/fhir/repository/validation.test.ts
@@ -10,10 +10,8 @@ import { initAppServices, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
 import { createTestProject, withTestContext } from '../../test.setup';
 import type { Repository } from '../repo';
-import { getGlobalSystemRepo } from '../repo';
 
 describe('Repository validation', () => {
-  const systemRepo = getGlobalSystemRepo();
   const rawUsCorePatientProfile = readFileSync(resolve(__dirname, '../__test__/us-core-patient.json'), 'utf8');
   const usCorePatientProfile = JSON.parse(rawUsCorePatientProfile) as StructureDefinition;
 
@@ -219,7 +217,7 @@ describe('Repository validation', () => {
         valueBoolean: true,
       };
 
-      await expect(systemRepo.createResource(observation)).resolves.toBeDefined();
+      await expect(repo.getSystemRepo().createResource(observation)).resolves.toBeDefined();
       await expect(repo.createResource(observation)).rejects.toThrow('Missing required property (Observation.subject)');
 
       observation.subject = { identifier: { value: randomUUID() } };

--- a/packages/server/src/fhir/rewrite.test.ts
+++ b/packages/server/src/fhir/rewrite.test.ts
@@ -11,6 +11,7 @@ import type { MedplumServerConfig } from '../config/types';
 import { withTestContext } from '../test.setup';
 import { Repository, getGlobalSystemRepo } from './repo';
 import { RewriteMode, rewriteAttachments } from './rewrite';
+import { PLACEHOLDER_SHARD_ID } from './sharding';
 
 describe('URL rewrite', () => {
   const systemRepo = getGlobalSystemRepo();
@@ -309,6 +310,7 @@ describe('URL rewrite', () => {
     // Repo1: Can read both Binary and Patient
     // This should successfully rewrite the binary to a presigned URL
     const repo1 = new Repository({
+      routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
       author: createReference(patient),
       accessPolicy: {
         resourceType: 'AccessPolicy',
@@ -322,6 +324,7 @@ describe('URL rewrite', () => {
     // Repo2: Can only read Binary, not Patient
     // This should not rewrite the binary to a presigned URL
     const repo2 = new Repository({
+      routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
       author: createReference(patient),
       accessPolicy: {
         resourceType: 'AccessPolicy',
@@ -335,6 +338,7 @@ describe('URL rewrite', () => {
     // Repo3: AccessPolicy limits to specific Patient
     // This should successfully rewrite the binary to a presigned URL
     const repo3 = new Repository({
+      routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
       author: createReference(patient),
       accessPolicy: {
         resourceType: 'AccessPolicy',
@@ -348,6 +352,7 @@ describe('URL rewrite', () => {
     // Repo3: AccessPolicy limits to different Patient
     // This should not rewrite the binary to a presigned URL
     const repo4 = new Repository({
+      routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
       author: createReference(patient),
       accessPolicy: {
         resourceType: 'AccessPolicy',

--- a/packages/server/src/fhir/rewrite.test.ts
+++ b/packages/server/src/fhir/rewrite.test.ts
@@ -9,12 +9,13 @@ import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
 import { withTestContext } from '../test.setup';
-import { Repository, getGlobalSystemRepo } from './repo';
+import { Repository, getShardSystemRepo } from './repo';
 import { RewriteMode, rewriteAttachments } from './rewrite';
 import { PLACEHOLDER_SHARD_ID } from './sharding';
 
 describe('URL rewrite', () => {
-  const systemRepo = getGlobalSystemRepo();
+  const shardId = PLACEHOLDER_SHARD_ID;
+  const systemRepo = getShardSystemRepo(shardId);
   let config: MedplumServerConfig;
   let binary: WithId<Binary>;
 

--- a/packages/server/src/fhir/search-params.test.ts
+++ b/packages/server/src/fhir/search-params.test.ts
@@ -11,12 +11,11 @@ import type {
   PractitionerRole,
   Slot,
 } from '@medplum/fhirtypes';
-import { randomUUID } from 'node:crypto';
 import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
 import { createTestProject, withTestContext } from '../test.setup';
-import { Repository } from './repo';
+import type { Repository } from './repo';
 
 describe('Medplum Custom Search Parameters', () => {
   let config: MedplumServerConfig;
@@ -28,12 +27,7 @@ describe('Medplum Custom Search Parameters', () => {
   });
 
   beforeEach(async () => {
-    const { project } = await createTestProject();
-    repo = new Repository({
-      strictMode: true,
-      projects: [project],
-      author: { reference: 'User/' + randomUUID() },
-    });
+    ({ repo } = await createTestProject({ withRepo: true }));
   });
 
   afterAll(async () => {

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -60,8 +60,9 @@ import { loadTestConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
 import { bundleContains, createTestProject, withTestContext } from '../test.setup';
 import type { SystemRepository } from './repo';
-import { getGlobalSystemRepo, Repository } from './repo';
+import { Repository } from './repo';
 import { repoAccess } from './repository/access-tracker';
+import { getTestProjectSystemRepo } from './repository/test-utils';
 import type { ChainedSearchLink } from './search';
 import { clampEstimateCount, Direction, getCount, parseChainedParameter } from './search';
 import type { TokenColumnSearchParameterImplementation } from './searchparameter';
@@ -2693,7 +2694,7 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
         name: randomUUID(),
       });
 
-      const patient = await getGlobalSystemRepo().createResource({
+      const patient = await repo.getSystemRepo().createResource({
         resourceType: 'Patient',
         meta: { project: project.id },
         managingOrganization: createReference(organization),
@@ -5595,7 +5596,7 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
 });
 
 describe.each([true, false])('systemRepo', (rangeSearch) => {
-  const systemRepo = getGlobalSystemRepo();
+  const systemRepo = getTestProjectSystemRepo();
 
   beforeAll(async () => {
     const config = await loadTestConfig();
@@ -5616,17 +5617,13 @@ describe.each([true, false])('systemRepo', (rangeSearch) => {
       const patient1 = await systemRepo.createResource<Patient>({
         resourceType: 'Patient',
         identifier: [{ system: 'id', value: idValue }],
-        meta: {
-          project: project1,
-        },
+        meta: { project: project1 },
       });
 
       const patient2 = await systemRepo.createResource<Patient>({
         resourceType: 'Patient',
         identifier: [{ system: 'id', value: idValue }],
-        meta: {
-          project: project2,
-        },
+        meta: { project: project2 },
       });
 
       const patient3 = await systemRepo.createResource<Patient>({

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -66,6 +66,7 @@ import type { ChainedSearchLink } from './search';
 import { clampEstimateCount, Direction, getCount, parseChainedParameter } from './search';
 import type { TokenColumnSearchParameterImplementation } from './searchparameter';
 import { getSearchParameterImplementation } from './searchparameter';
+import { PLACEHOLDER_SHARD_ID } from './sharding';
 import { SelectQuery } from './sql';
 import { loadStructureDefinitions } from './structure';
 
@@ -81,6 +82,7 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
     await initAppServices(config);
     const { project } = await createTestProject({ project: { features } });
     repo = new Repository({
+      routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
       strictMode: true,
       projects: [project],
       author: { reference: 'User/' + randomUUID() },

--- a/packages/server/src/fhir/sharding.test.ts
+++ b/packages/server/src/fhir/sharding.test.ts
@@ -3,6 +3,7 @@
 
 import { getStatus, OperationOutcomeError } from '@medplum/core';
 import type { ResourceType } from '@medplum/fhirtypes';
+import type { Mock } from 'vitest';
 import { getLogger } from '../logger';
 import { GLOBAL_SHARD_ID, normalizeShardId, PLACEHOLDER_SHARD_ID, resolveShardId, TODO_SHARD_ID } from './sharding';
 
@@ -28,59 +29,115 @@ describe('normalizeShardId', () => {
   });
 });
 
+function resolveProjectShardId(shardId: string, resourceTypes: ReadonlySet<ResourceType>, source?: string): string {
+  return resolveShardId({ kind: 'project-shard', shardId }, resourceTypes, source);
+}
+
+function resolveGlobalShardId(resourceTypes: ReadonlySet<ResourceType>, source?: string): string {
+  return resolveShardId({ kind: 'global-only' }, resourceTypes, source);
+}
+
 describe('resolveShardId', () => {
-  test('Routes global resource types to the global shard', () => {
-    expect(resolveShardId(PROJECT_SHARD_ID, types('User'))).toStrictEqual(GLOBAL_SHARD_ID);
-    expect(resolveShardId(PROJECT_SHARD_ID, types('Project', 'ProjectMembership', 'User'))).toStrictEqual(
-      GLOBAL_SHARD_ID
-    );
+  describe('for kind: global-only', () => {
+    let logSpy: Mock;
+    beforeEach(() => {
+      logSpy = vi.spyOn(getLogger(), 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      logSpy.mockRestore();
+    });
+
+    test('Routes global resource types to the global shard', () => {
+      expect(resolveGlobalShardId(types('User'))).toStrictEqual(GLOBAL_SHARD_ID);
+      expect(resolveGlobalShardId(types('Project', 'ProjectMembership', 'User'))).toStrictEqual(GLOBAL_SHARD_ID);
+    });
+
+    test('logs warning on project-scoped resource types', () => {
+      resolveGlobalShardId(types('Patient'), 'shard-project');
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.any(Number),
+        expect.stringContaining('Operation cannot be routed to a project shard from global-only'),
+        expect.objectContaining({
+          project: 'Patient',
+          source: 'shard-project',
+        })
+      );
+    });
+
+    test('logs warning when an operation mixes global and project resource types', () => {
+      resolveGlobalShardId(types('ProjectMembership', 'Practitioner'), 'shard-span');
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.any(Number),
+        expect.stringContaining('Operation cannot be routed to a project shard from global-only'),
+        expect.objectContaining({
+          project: 'Practitioner',
+          source: 'shard-span',
+        })
+      );
+    });
   });
 
-  test('Routes project-scoped resource types to the project shard', () => {
-    expect(resolveShardId(PROJECT_SHARD_ID, types('Patient'))).toStrictEqual(PROJECT_SHARD_ID);
-    expect(resolveShardId(PROJECT_SHARD_ID, types('Patient', 'Observation'))).toStrictEqual(PROJECT_SHARD_ID);
-  });
+  describe('for kind: project-shard', () => {
+    test('Routes global resource types to the global shard', () => {
+      expect(resolveProjectShardId(PROJECT_SHARD_ID, types('User'))).toStrictEqual(GLOBAL_SHARD_ID);
+      expect(resolveProjectShardId(PROJECT_SHARD_ID, types('Project', 'ProjectMembership', 'User'))).toStrictEqual(
+        GLOBAL_SHARD_ID
+      );
+    });
 
-  test('Refuses to route an operation naming no resource types', () => {
-    expect(() => resolveShardId(PROJECT_SHARD_ID, types(), 'sharding.test')).toThrow(
-      'Cannot route an operation that specifies no resource types'
-    );
-    expect(() => resolveShardId(GLOBAL_SHARD_ID, types())).toThrow(
-      'Cannot route an operation that specifies no resource types'
-    );
-  });
+    test('Routes project-scoped resource types to the project shard', () => {
+      expect(resolveProjectShardId(PROJECT_SHARD_ID, types('Patient'))).toStrictEqual(PROJECT_SHARD_ID);
+      expect(resolveProjectShardId(PROJECT_SHARD_ID, types('Patient', 'Observation'))).toStrictEqual(PROJECT_SHARD_ID);
+    });
 
-  test('Normalizes the context shard ID', () => {
-    expect(resolveShardId(PLACEHOLDER_SHARD_ID, types('Patient'))).toStrictEqual(GLOBAL_SHARD_ID);
-    expect(resolveShardId(TODO_SHARD_ID, types('Patient'))).toStrictEqual(GLOBAL_SHARD_ID);
-  });
+    test('Refuses to route an operation naming no resource types', () => {
+      expect(() => resolveProjectShardId(PROJECT_SHARD_ID, types(), 'sharding.test')).toThrow(
+        'Cannot route an operation that specifies no resource types'
+      );
+      expect(() => resolveProjectShardId(GLOBAL_SHARD_ID, types())).toThrow(
+        'Cannot route an operation that specifies no resource types'
+      );
+    });
 
-  test('Throws when an operation spans shards', () => {
-    expect(() => resolveShardId(PROJECT_SHARD_ID, types('ProjectMembership', 'Practitioner'), 'shard-span')).toThrow(
-      `Operation cannot span shards (${GLOBAL_SHARD_ID}: ProjectMembership, ${PROJECT_SHARD_ID}: Practitioner, source: shard-span)`
-    );
-  });
+    test('Normalizes the context shard ID', () => {
+      expect(resolveProjectShardId(PLACEHOLDER_SHARD_ID, types('Patient'))).toStrictEqual(GLOBAL_SHARD_ID);
+      expect(resolveProjectShardId(TODO_SHARD_ID, types('Patient'))).toStrictEqual(GLOBAL_SHARD_ID);
+    });
 
-  test('Throws an OperationOutcomeError', () => {
-    let err: unknown;
-    try {
-      resolveShardId(PROJECT_SHARD_ID, types('User', 'Patient'));
-    } catch (caught) {
-      err = caught;
-    }
+    test('Throws when an operation spans shards', () => {
+      expect(() =>
+        resolveProjectShardId(PROJECT_SHARD_ID, types('ProjectMembership', 'Practitioner'), 'shard-span')
+      ).toThrow(
+        `Operation cannot span shards (${GLOBAL_SHARD_ID}: ProjectMembership, ${PROJECT_SHARD_ID}: Practitioner, source: shard-span)`
+      );
+    });
 
-    expect(err).toBeInstanceOf(OperationOutcomeError);
-    expect(getStatus((err as OperationOutcomeError).outcome)).toStrictEqual(500);
-  });
+    test('Throws an OperationOutcomeError', () => {
+      let err: unknown;
+      try {
+        resolveProjectShardId(PROJECT_SHARD_ID, types('User', 'Patient'));
+      } catch (caught) {
+        err = caught;
+      }
 
-  test('Resolves mixed resource types to the global shard when the project lives there', () => {
-    const infoSpy = vi.spyOn(getLogger(), 'info').mockImplementation(() => {});
-    try {
-      expect(resolveShardId(GLOBAL_SHARD_ID, types('Project', 'Patient'), 'sharding.test')).toBe(GLOBAL_SHARD_ID);
-      // Recording the mixed access is `RepositoryAccessTracker`'s job; this function only resolves.
-      expect(infoSpy).not.toHaveBeenCalled();
-    } finally {
-      infoSpy.mockRestore();
-    }
+      expect(err).toBeInstanceOf(OperationOutcomeError);
+      expect(getStatus((err as OperationOutcomeError).outcome)).toStrictEqual(500);
+    });
+
+    test('Resolves mixed resource types to the global shard when the project lives there', () => {
+      const logSpy = vi.spyOn(getLogger(), 'log').mockImplementation(() => {});
+      try {
+        expect(resolveProjectShardId(GLOBAL_SHARD_ID, types('Project', 'Patient'), 'sharding.test')).toBe(
+          GLOBAL_SHARD_ID
+        );
+        // Recording the mixed access is `RepositoryAccessTracker`'s job; this function only resolves.
+        expect(logSpy).not.toHaveBeenCalled();
+      } finally {
+        logSpy.mockRestore();
+      }
+    });
   });
 });

--- a/packages/server/src/fhir/sharding.test.ts
+++ b/packages/server/src/fhir/sharding.test.ts
@@ -74,7 +74,7 @@ describe('resolveShardId', () => {
         expect.any(Number),
         expect.stringContaining('Operation cannot be routed to a project shard from global-only'),
         expect.objectContaining({
-          project: 'Patient',
+          projectTypes: 'Patient',
           source: 'shard-project',
         })
       );
@@ -92,7 +92,7 @@ describe('resolveShardId', () => {
         expect.any(Number),
         expect.stringContaining('Operation cannot be routed to a project shard from global-only'),
         expect.objectContaining({
-          project: 'Practitioner',
+          projectTypes: 'Practitioner',
           source: 'shard-span',
         })
       );

--- a/packages/server/src/fhir/sharding.test.ts
+++ b/packages/server/src/fhir/sharding.test.ts
@@ -5,7 +5,15 @@ import { getStatus, OperationOutcomeError } from '@medplum/core';
 import type { ResourceType } from '@medplum/fhirtypes';
 import type { Mock } from 'vitest';
 import { getLogger } from '../logger';
-import { GLOBAL_SHARD_ID, normalizeShardId, PLACEHOLDER_SHARD_ID, resolveShardId, TODO_SHARD_ID } from './sharding';
+import {
+  GLOBAL_SHARD_ID,
+  normalizeShardId,
+  PLACEHOLDER_SHARD_ID,
+  resetStrictShardingEnforcement,
+  resolveShardId,
+  setStrictShardingEnforcement,
+  TODO_SHARD_ID,
+} from './sharding';
 
 const PROJECT_SHARD_ID = 'shard-1';
 
@@ -54,7 +62,12 @@ describe('resolveShardId', () => {
     });
 
     test('logs warning on project-scoped resource types', () => {
-      resolveGlobalShardId(types('Patient'), 'shard-project');
+      const fn = (): unknown => resolveGlobalShardId(types('Patient'), 'shard-project');
+      expect(fn).toThrow('Operation cannot be routed to a project shard from global-only');
+
+      setStrictShardingEnforcement(false);
+      expect(logSpy).toHaveBeenCalledTimes(0);
+      fn();
       expect(logSpy).toHaveBeenCalledTimes(1);
       expect(logSpy).toHaveBeenCalledWith(
         expect.any(Number),
@@ -64,10 +77,16 @@ describe('resolveShardId', () => {
           source: 'shard-project',
         })
       );
+      resetStrictShardingEnforcement();
     });
 
     test('logs warning when an operation mixes global and project resource types', () => {
-      resolveGlobalShardId(types('ProjectMembership', 'Practitioner'), 'shard-span');
+      const fn = (): unknown => resolveGlobalShardId(types('ProjectMembership', 'Practitioner'), 'shard-span');
+      expect(fn).toThrow('Operation cannot be routed to a project shard from global-only');
+
+      setStrictShardingEnforcement(false);
+      expect(logSpy).toHaveBeenCalledTimes(0);
+      fn();
       expect(logSpy).toHaveBeenCalledTimes(1);
       expect(logSpy).toHaveBeenCalledWith(
         expect.any(Number),

--- a/packages/server/src/fhir/sharding.test.ts
+++ b/packages/server/src/fhir/sharding.test.ts
@@ -54,6 +54,7 @@ describe('resolveShardId', () => {
 
     afterEach(() => {
       logSpy.mockRestore();
+      resetStrictShardingEnforcement();
     });
 
     test('Routes global resource types to the global shard', () => {
@@ -77,7 +78,6 @@ describe('resolveShardId', () => {
           source: 'shard-project',
         })
       );
-      resetStrictShardingEnforcement();
     });
 
     test('logs warning when an operation mixes global and project resource types', () => {

--- a/packages/server/src/fhir/sharding.ts
+++ b/packages/server/src/fhir/sharding.ts
@@ -3,6 +3,7 @@
 
 import { OperationOutcomeError } from '@medplum/core';
 import type { ResourceType } from '@medplum/fhirtypes';
+import { getLogger } from '../logger';
 
 /**
  * The shard ID for the global database.
@@ -25,6 +26,8 @@ export const PLACEHOLDER_SHARD_ID = 'placeholder';
  * {@link normalizeShardId}.
  */
 export const TODO_SHARD_ID = 'todo';
+
+export type ShardRouting = { kind: 'global-only' } | { kind: 'project-shard'; shardId: string };
 
 /**
  * Resource types that always live on the global shard, regardless of the project they belong to.
@@ -76,14 +79,14 @@ export function normalizeShardId(shardId: string | undefined): string {
  * An empty set is not allowed: "touches no resources" does not identify a destination. A default
  * could silently misroute under-specified requests.
  *
- * @param projectShardId - The shard ID of the current project context (normalized internally).
+ * @param routing - The context indicating whether the operation is global-only or tied to a project shard.
  * @param resourceTypes - The resource types the operation touches. Must not be empty.
  * @param source - Optional label for the call site, reported in the diagnostics when this throws.
  * @returns The shard ID to route the operation to.
  * @throws {OperationOutcomeError} When the operation spans multiple shards or names no resource types.
  */
 export function resolveShardId(
-  projectShardId: string,
+  routing: ShardRouting,
   resourceTypes: ReadonlySet<ResourceType>,
   source?: string
 ): string {
@@ -110,7 +113,24 @@ export function resolveShardId(
     return GLOBAL_SHARD_ID;
   }
 
-  const normalizedShardId = normalizeShardId(projectShardId);
+  if (routing.kind === 'global-only') {
+    // to strictly enforce that global-only routing cannot touch project-scoped resources,
+    // throw instead log
+    getLogger().warn('Operation cannot be routed to a project shard from global-only routing', {
+      project: projectTypes.join(', '),
+      source: source || 'unknown',
+    });
+    // throw shardRoutingError(
+    //   'Operation cannot be routed to a project shard from global-only routing',
+    //   `project: ${projectTypes.join(', ')}, source: ${source || 'unknown'}`
+    // );
+  }
+
+  // the fallback to global MUST go away when global-only routing touching
+  // project-scoped resources is throws instead of logs
+  const routingShardId = routing.kind === 'project-shard' ? routing.shardId : GLOBAL_SHARD_ID;
+
+  const normalizedShardId = normalizeShardId(routingShardId);
   if (!globalTypes) {
     return normalizedShardId;
   }
@@ -119,9 +139,10 @@ export function resolveShardId(
   if (normalizedShardId === GLOBAL_SHARD_ID) {
     return GLOBAL_SHARD_ID;
   }
+
   throw shardRoutingError(
     `Operation cannot span shards`,
-    `global: ${globalTypes.join(', ')}, ${projectShardId}: ${projectTypes.join(', ')}, source: ${source || 'unknown'}`
+    `global: ${globalTypes.join(', ')}, ${routingShardId}: ${projectTypes.join(', ')}, source: ${source || 'unknown'}`
   );
 }
 

--- a/packages/server/src/fhir/sharding.ts
+++ b/packages/server/src/fhir/sharding.ts
@@ -130,18 +130,18 @@ export function resolveShardId(
     if (strictShardingEnforcement) {
       throw shardRoutingError(
         'Operation cannot be routed to a project shard from global-only routing',
-        `project: ${projectTypes.join(', ')}, source: ${source || 'unknown'}`
+        `projectTypes: ${projectTypes.join(', ')}, source: ${source || 'unknown'}`
       );
     } else {
       getLogger().warn('Operation cannot be routed to a project shard from global-only routing', {
-        project: projectTypes.join(', '),
+        projectTypes: projectTypes.join(', '),
         source: source || 'unknown',
       });
     }
   }
 
   // fallback to GLOBAL_SHARD_ID MUST go away when global-only routing touching
-  // project-scoped resources always throws instead of logs
+  // project-scoped resources always throws
   // no need to gate the fallback on strictShardingEnforcement; it throws early before reaching this point.
   const routingShardId = routing.kind === 'project-shard' ? routing.shardId : GLOBAL_SHARD_ID;
 

--- a/packages/server/src/fhir/sharding.ts
+++ b/packages/server/src/fhir/sharding.ts
@@ -29,6 +29,16 @@ export const TODO_SHARD_ID = 'todo';
 
 export type ShardRouting = { kind: 'global-only' } | { kind: 'project-shard'; shardId: string };
 
+let strictShardingEnforcement = process.env.NODE_ENV === 'test';
+
+export function resetStrictShardingEnforcement(): void {
+  strictShardingEnforcement = process.env.NODE_ENV === 'test';
+}
+
+export function setStrictShardingEnforcement(value: boolean): void {
+  strictShardingEnforcement = value;
+}
+
 /**
  * Resource types that always live on the global shard, regardless of the project they belong to.
  *
@@ -50,6 +60,7 @@ export const globalShardResourceTypes: ReadonlySet<ResourceType> = new Set([
   'SmartHealthLink', // currently read by id, TODO add projectId to URLs and throw if not available so this line can be removed
   'SmartAppLaunch', // read by id during login
   'DomainConfiguration', // read by domain for external auth flow
+  'UserConfiguration', // TODO confirm this makes sense
 ]);
 
 /**
@@ -114,16 +125,17 @@ export function resolveShardId(
   }
 
   if (routing.kind === 'global-only') {
-    // to strictly enforce that global-only routing cannot touch project-scoped resources,
-    // throw instead log
-    getLogger().warn('Operation cannot be routed to a project shard from global-only routing', {
-      project: projectTypes.join(', '),
-      source: source || 'unknown',
-    });
-    // throw shardRoutingError(
-    //   'Operation cannot be routed to a project shard from global-only routing',
-    //   `project: ${projectTypes.join(', ')}, source: ${source || 'unknown'}`
-    // );
+    if (strictShardingEnforcement) {
+      throw shardRoutingError(
+        'Operation cannot be routed to a project shard from global-only routing',
+        `project: ${projectTypes.join(', ')}, source: ${source || 'unknown'}`
+      );
+    } else {
+      getLogger().warn('Operation cannot be routed to a project shard from global-only routing', {
+        project: projectTypes.join(', '),
+        source: source || 'unknown',
+      });
+    }
   }
 
   // the fallback to global MUST go away when global-only routing touching

--- a/packages/server/src/fhir/sharding.ts
+++ b/packages/server/src/fhir/sharding.ts
@@ -121,8 +121,10 @@ export function resolveShardId(
   }
 
   if (!projectTypes) {
+    // only globalTypes, either routing.kind is acceptable
     return GLOBAL_SHARD_ID;
   }
+  // projectTypes are present below here
 
   if (routing.kind === 'global-only') {
     if (strictShardingEnforcement) {
@@ -138,8 +140,9 @@ export function resolveShardId(
     }
   }
 
-  // the fallback to global MUST go away when global-only routing touching
-  // project-scoped resources is throws instead of logs
+  // fallback to GLOBAL_SHARD_ID MUST go away when global-only routing touching
+  // project-scoped resources always throws instead of logs
+  // no need to gate the fallback on strictShardingEnforcement; it throws early before reaching this point.
   const routingShardId = routing.kind === 'project-shard' ? routing.shardId : GLOBAL_SHARD_ID;
 
   const normalizedShardId = normalizeShardId(routingShardId);

--- a/packages/server/src/fhir/tokens.test.ts
+++ b/packages/server/src/fhir/tokens.test.ts
@@ -736,17 +736,9 @@ describe('Non-strict mode', () => {
   const val1 = 'ABCDEFGHIJ';
 
   beforeAll(async () => {
-    const { project } = await createTestProject();
-    nonStrictRepo = new Repository({
-      strictMode: false,
-      projects: [project],
-      author: { reference: 'User/' + randomUUID() },
-    });
-    repo = new Repository({
-      strictMode: true,
-      projects: [project],
-      author: { reference: 'User/' + randomUUID() },
-    });
+    ({ repo } = await createTestProject({ withRepo: true }));
+    expect(repo.getConfig().strictMode).toBe(true);
+    nonStrictRepo = new Repository({ ...repo.getConfig(), strictMode: false });
     patient = await nonStrictRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Henry'] }],
@@ -841,12 +833,7 @@ describe('Condition.code token queries', () => {
   const disp1 = 'The Quick Brown Fox';
 
   beforeAll(async () => {
-    const { project } = await createTestProject();
-    repo = new Repository({
-      strictMode: true,
-      projects: [project],
-      author: { reference: 'User/' + randomUUID() },
-    });
+    ({ repo } = await createTestProject({ withRepo: true }));
 
     patient = await repo.createResource<Patient>({ resourceType: 'Patient', name: [{ given: ['Henry'] }] });
     subject = createReference(patient);
@@ -1265,12 +1252,7 @@ describe('MedicationRequest.code legacy behavior', () => {
   const val2 = 'ZZZZZZZZZZ';
 
   beforeAll(async () => {
-    const { project } = await createTestProject();
-    repo = new Repository({
-      strictMode: true,
-      projects: [project],
-      author: { reference: 'User/' + randomUUID() },
-    });
+    ({ repo } = await createTestProject({ withRepo: true }));
 
     patient = await repo.createResource<Patient>({ resourceType: 'Patient', name: [{ given: ['Henry'] }] });
     mr1 = await repo.createResource<MedicationRequest>({

--- a/packages/server/src/fhir/tokens.test.ts
+++ b/packages/server/src/fhir/tokens.test.ts
@@ -17,7 +17,8 @@ import { randomUUID } from 'crypto';
 import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import { bundleContains, createTestProject, withTestContext } from '../test.setup';
-import { getGlobalSystemRepo, Repository } from './repo';
+import { Repository } from './repo';
+import { getTestProjectSystemRepo } from './repository/test-utils';
 import type { TokenColumnSearchParameterImplementation } from './searchparameter';
 import { getSearchParameterImplementation } from './searchparameter';
 import { loadStructureDefinitions } from './structure';
@@ -25,744 +26,1270 @@ import { TokenQueryOperators } from './token-column';
 import type { Token } from './tokens';
 import { buildTokensForSearchParameter } from './tokens';
 
-const systemRepo = getGlobalSystemRepo();
-
-beforeAll(async () => {
-  const config = await loadTestConfig();
-  await initAppServices(config);
-});
-
-afterAll(async () => {
-  await shutdownApp();
-});
-
-test('Identifier', () =>
-  withTestContext(async () => {
-    const identifier = randomUUID();
-    const text = 'this is some text';
-
-    const patient = await systemRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      name: [{ given: ['Alice'], family: 'Smith' }],
-      identifier: [{ system: 'https://www.example.com', value: identifier, type: { text } }],
-    });
-
-    const searchResult = await systemRepo.search({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'identifier',
-          operator: Operator.EQUALS,
-          value: identifier,
-        },
-      ],
-    });
-    expect(searchResult.entry?.length).toStrictEqual(1);
-    expect(searchResult.entry?.[0]?.resource?.id).toStrictEqual(patient.id);
-
-    const goodTextResult = await systemRepo.search({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'identifier',
-          operator: Operator.EQUALS,
-          value: identifier,
-        },
-        {
-          code: 'identifier',
-          operator: Operator.TEXT,
-          value: text,
-        },
-      ],
-    });
-    expect(goodTextResult.entry?.length).toStrictEqual(1);
-    expect(goodTextResult.entry?.[0]?.resource?.id).toStrictEqual(patient.id);
-
-    const badTextResult = await systemRepo.search({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'identifier',
-          operator: Operator.TEXT,
-          // :text on the identifier value itself should not match
-          value: identifier,
-        },
-      ],
-    });
-    expect(badTextResult.entry?.length).toStrictEqual(0);
-  }));
-
-test.each(TokenQueryOperators)('%s with empty value does not throw errors', async (operator) => {
-  const search = systemRepo.search({
-    resourceType: 'Patient',
-    filters: [
-      {
-        code: 'identifier',
-        operator: operator,
-        value: '',
-      },
-    ],
-  });
-
-  await expect(search).resolves.toBeDefined();
-});
-
-test('Multiple identifiers', () =>
-  withTestContext(async () => {
-    const identifier = randomUUID();
-    const other = randomUUID();
-
-    const patient = await systemRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      name: [{ given: ['Alice'], family: 'Smith' }],
-      identifier: [
-        { system: 'https://www.example.com', value: identifier },
-        { system: 'https://www.example.com', value: identifier },
-        { system: 'other', value: other },
-      ],
-    });
-
-    const searchResult = await systemRepo.search({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'identifier',
-          operator: Operator.EQUALS,
-          value: identifier,
-        },
-      ],
-    });
-    expect(searchResult.entry?.length).toStrictEqual(1);
-    expect(searchResult.entry?.[0]?.resource?.id).toStrictEqual(patient.id);
-
-    const searchResult2 = await systemRepo.search({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'identifier',
-          operator: Operator.EQUALS,
-          value: other,
-        },
-      ],
-    });
-    expect(searchResult2.entry?.length).toStrictEqual(1);
-    expect(searchResult2.entry?.[0]?.resource?.id).toStrictEqual(patient.id);
-  }));
-
-test('Update identifier', () =>
-  withTestContext(async () => {
-    const identifier1 = randomUUID();
-    const identifier2 = randomUUID();
-
-    const patient1 = await systemRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      name: [{ given: ['Alice'], family: 'Smith' }],
-      identifier: [{ system: 'https://www.example.com', value: identifier1 }],
-    });
-
-    const bundle2 = await systemRepo.search({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'identifier',
-          operator: Operator.EQUALS,
-          value: identifier1,
-        },
-      ],
-    });
-    expect(bundle2.entry?.length).toStrictEqual(1);
-    expect(bundle2.entry?.[0]?.resource?.id).toStrictEqual(patient1.id);
-
-    const bundle3 = await systemRepo.search({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'identifier',
-          operator: Operator.EQUALS,
-          value: identifier2,
-        },
-      ],
-    });
-    expect(bundle3.entry?.length).toStrictEqual(0);
-
-    await systemRepo.updateResource<Patient>({
-      ...patient1,
-      identifier: [{ system: 'https://www.example.com', value: identifier2 }],
-    });
-
-    const bundle5 = await systemRepo.search({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'identifier',
-          operator: Operator.EQUALS,
-          value: identifier1,
-        },
-      ],
-    });
-    expect(bundle5.entry?.length).toStrictEqual(0);
-
-    const bundle6 = await systemRepo.search({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'identifier',
-          operator: Operator.EQUALS,
-          value: identifier2,
-        },
-      ],
-    });
-    expect(bundle6.entry?.length).toStrictEqual(1);
-    expect(bundle6.entry?.[0]?.resource?.id).toStrictEqual(patient1.id);
-  }));
-
-test('Implicit exact', () =>
-  withTestContext(async () => {
-    const identifier = randomUUID();
-
-    const patient1 = await systemRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      name: [{ given: ['Alice'], family: 'Smith' }],
-      identifier: [{ system: 'https://www.example.com', value: identifier }],
-    });
-
-    const patient2 = await systemRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      name: [{ given: ['Alice'], family: 'Jones' }],
-      identifier: [{ system: 'https://www.example.com', value: identifier + 'xyz' }],
-    });
-
-    const searchResult1 = await systemRepo.search({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'identifier',
-          operator: Operator.EQUALS,
-          value: identifier,
-        },
-      ],
-    });
-    expect(searchResult1.entry?.length).toStrictEqual(1);
-    expect(bundleContains(searchResult1, patient1)).toBeDefined();
-    expect(bundleContains(searchResult1, patient2)).toBeUndefined();
-  }));
-
-test('Explicit exact', () =>
-  withTestContext(async () => {
-    const identifier = randomUUID();
-
-    const patient1 = await systemRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      name: [{ given: ['Alice'], family: 'Smith' }],
-      identifier: [{ system: 'https://www.example.com', value: identifier }],
-    });
-
-    const patient2 = await systemRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      name: [{ given: ['Alice'], family: 'Jones' }],
-      identifier: [{ system: 'https://www.example.com', value: identifier + 'xyz' }],
-    });
-
-    const searchResult1 = await systemRepo.search({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'identifier',
-          operator: Operator.EXACT,
-          value: identifier,
-        },
-      ],
-    });
-    expect(searchResult1.entry?.length).toStrictEqual(1);
-    expect(bundleContains(searchResult1, patient1)).toBeDefined();
-    expect(bundleContains(searchResult1, patient2)).toBeUndefined();
-  }));
-
-describe(':contains', () => {
-  const baseIdentifierValue = randomUUID();
-  const identifier = randomUUID();
-  let patient1: Patient;
-  const baseFilters = [
-    {
-      code: 'identifier',
-      operator: Operator.EQUALS,
-      value: baseIdentifierValue,
-    },
-  ];
-
+describe('Token-based searches', () => {
   beforeAll(async () => {
-    const baseIdentifier = { system: 'https://hi.com', value: baseIdentifierValue };
-
-    patient1 = await systemRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      name: [{ given: ['Alice'], family: 'Smith' }],
-      telecom: [
-        { system: 'email', value: 'prefix-email-postfix' },
-        { system: 'phone', value: 'prefix-phone-postfix' },
-        { system: 'pager', value: 'prefix-pager-postfix' },
-      ],
-      identifier: [baseIdentifier, { system: 'https://www.example.com', value: identifier }],
-    });
+    const config = await loadTestConfig();
+    await initAppServices(config);
   });
 
-  test('prefix on Patient-identifier', () =>
-    withTestContext(async () => {
-      const identifierResult = await systemRepo.search({
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  describe('With systemRepo', () => {
+    const systemRepo = getTestProjectSystemRepo();
+
+    test('Identifier', () =>
+      withTestContext(async () => {
+        const identifier = randomUUID();
+        const text = 'this is some text';
+
+        const patient = await systemRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'Smith' }],
+          identifier: [{ system: 'https://www.example.com', value: identifier, type: { text } }],
+        });
+
+        const searchResult = await systemRepo.search({
+          resourceType: 'Patient',
+          filters: [
+            {
+              code: 'identifier',
+              operator: Operator.EQUALS,
+              value: identifier,
+            },
+          ],
+        });
+        expect(searchResult.entry?.length).toStrictEqual(1);
+        expect(searchResult.entry?.[0]?.resource?.id).toStrictEqual(patient.id);
+
+        const goodTextResult = await systemRepo.search({
+          resourceType: 'Patient',
+          filters: [
+            {
+              code: 'identifier',
+              operator: Operator.EQUALS,
+              value: identifier,
+            },
+            {
+              code: 'identifier',
+              operator: Operator.TEXT,
+              value: text,
+            },
+          ],
+        });
+        expect(goodTextResult.entry?.length).toStrictEqual(1);
+        expect(goodTextResult.entry?.[0]?.resource?.id).toStrictEqual(patient.id);
+
+        const badTextResult = await systemRepo.search({
+          resourceType: 'Patient',
+          filters: [
+            {
+              code: 'identifier',
+              operator: Operator.TEXT,
+              // :text on the identifier value itself should not match
+              value: identifier,
+            },
+          ],
+        });
+        expect(badTextResult.entry?.length).toStrictEqual(0);
+      }));
+
+    test.each(TokenQueryOperators)('%s with empty value does not throw errors', async (operator) => {
+      const search = systemRepo.search({
         resourceType: 'Patient',
         filters: [
-          ...baseFilters,
           {
             code: 'identifier',
-            operator: Operator.CONTAINS,
-            value: identifier.slice(0, 5),
+            operator: operator,
+            value: '',
           },
         ],
       });
 
-      expect(identifierResult.entry?.length).toStrictEqual(0);
-    }));
+      await expect(search).resolves.toBeDefined();
+    });
 
-  test('infix on Patient-identifier', () =>
-    withTestContext(async () => {
-      const identifierResult = await systemRepo.search({
+    test('Multiple identifiers', () =>
+      withTestContext(async () => {
+        const identifier = randomUUID();
+        const other = randomUUID();
+
+        const patient = await systemRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'Smith' }],
+          identifier: [
+            { system: 'https://www.example.com', value: identifier },
+            { system: 'https://www.example.com', value: identifier },
+            { system: 'other', value: other },
+          ],
+        });
+
+        const searchResult = await systemRepo.search({
+          resourceType: 'Patient',
+          filters: [
+            {
+              code: 'identifier',
+              operator: Operator.EQUALS,
+              value: identifier,
+            },
+          ],
+        });
+        expect(searchResult.entry?.length).toStrictEqual(1);
+        expect(searchResult.entry?.[0]?.resource?.id).toStrictEqual(patient.id);
+
+        const searchResult2 = await systemRepo.search({
+          resourceType: 'Patient',
+          filters: [
+            {
+              code: 'identifier',
+              operator: Operator.EQUALS,
+              value: other,
+            },
+          ],
+        });
+        expect(searchResult2.entry?.length).toStrictEqual(1);
+        expect(searchResult2.entry?.[0]?.resource?.id).toStrictEqual(patient.id);
+      }));
+
+    test('Update identifier', () =>
+      withTestContext(async () => {
+        const identifier1 = randomUUID();
+        const identifier2 = randomUUID();
+
+        const patient1 = await systemRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'Smith' }],
+          identifier: [{ system: 'https://www.example.com', value: identifier1 }],
+        });
+
+        const bundle2 = await systemRepo.search({
+          resourceType: 'Patient',
+          filters: [
+            {
+              code: 'identifier',
+              operator: Operator.EQUALS,
+              value: identifier1,
+            },
+          ],
+        });
+        expect(bundle2.entry?.length).toStrictEqual(1);
+        expect(bundle2.entry?.[0]?.resource?.id).toStrictEqual(patient1.id);
+
+        const bundle3 = await systemRepo.search({
+          resourceType: 'Patient',
+          filters: [
+            {
+              code: 'identifier',
+              operator: Operator.EQUALS,
+              value: identifier2,
+            },
+          ],
+        });
+        expect(bundle3.entry?.length).toStrictEqual(0);
+
+        await systemRepo.updateResource<Patient>({
+          ...patient1,
+          identifier: [{ system: 'https://www.example.com', value: identifier2 }],
+        });
+
+        const bundle5 = await systemRepo.search({
+          resourceType: 'Patient',
+          filters: [
+            {
+              code: 'identifier',
+              operator: Operator.EQUALS,
+              value: identifier1,
+            },
+          ],
+        });
+        expect(bundle5.entry?.length).toStrictEqual(0);
+
+        const bundle6 = await systemRepo.search({
+          resourceType: 'Patient',
+          filters: [
+            {
+              code: 'identifier',
+              operator: Operator.EQUALS,
+              value: identifier2,
+            },
+          ],
+        });
+        expect(bundle6.entry?.length).toStrictEqual(1);
+        expect(bundle6.entry?.[0]?.resource?.id).toStrictEqual(patient1.id);
+      }));
+
+    test('Implicit exact', () =>
+      withTestContext(async () => {
+        const identifier = randomUUID();
+
+        const patient1 = await systemRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'Smith' }],
+          identifier: [{ system: 'https://www.example.com', value: identifier }],
+        });
+
+        const patient2 = await systemRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'Jones' }],
+          identifier: [{ system: 'https://www.example.com', value: identifier + 'xyz' }],
+        });
+
+        const searchResult1 = await systemRepo.search({
+          resourceType: 'Patient',
+          filters: [
+            {
+              code: 'identifier',
+              operator: Operator.EQUALS,
+              value: identifier,
+            },
+          ],
+        });
+        expect(searchResult1.entry?.length).toStrictEqual(1);
+        expect(bundleContains(searchResult1, patient1)).toBeDefined();
+        expect(bundleContains(searchResult1, patient2)).toBeUndefined();
+      }));
+
+    test('Explicit exact', () =>
+      withTestContext(async () => {
+        const identifier = randomUUID();
+
+        const patient1 = await systemRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'Smith' }],
+          identifier: [{ system: 'https://www.example.com', value: identifier }],
+        });
+
+        const patient2 = await systemRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'Jones' }],
+          identifier: [{ system: 'https://www.example.com', value: identifier + 'xyz' }],
+        });
+
+        const searchResult1 = await systemRepo.search({
+          resourceType: 'Patient',
+          filters: [
+            {
+              code: 'identifier',
+              operator: Operator.EXACT,
+              value: identifier,
+            },
+          ],
+        });
+        expect(searchResult1.entry?.length).toStrictEqual(1);
+        expect(bundleContains(searchResult1, patient1)).toBeDefined();
+        expect(bundleContains(searchResult1, patient2)).toBeUndefined();
+      }));
+
+    describe(':contains', () => {
+      const baseIdentifierValue = randomUUID();
+      const identifier = randomUUID();
+      let patient1: Patient;
+      const baseFilters = [
+        {
+          code: 'identifier',
+          operator: Operator.EQUALS,
+          value: baseIdentifierValue,
+        },
+      ];
+
+      beforeAll(async () => {
+        const baseIdentifier = { system: 'https://hi.com', value: baseIdentifierValue };
+
+        patient1 = await systemRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'Smith' }],
+          telecom: [
+            { system: 'email', value: 'prefix-email-postfix' },
+            { system: 'phone', value: 'prefix-phone-postfix' },
+            { system: 'pager', value: 'prefix-pager-postfix' },
+          ],
+          identifier: [baseIdentifier, { system: 'https://www.example.com', value: identifier }],
+        });
+      });
+
+      test('prefix on Patient-identifier', () =>
+        withTestContext(async () => {
+          const identifierResult = await systemRepo.search({
+            resourceType: 'Patient',
+            filters: [
+              ...baseFilters,
+              {
+                code: 'identifier',
+                operator: Operator.CONTAINS,
+                value: identifier.slice(0, 5),
+              },
+            ],
+          });
+
+          expect(identifierResult.entry?.length).toStrictEqual(0);
+        }));
+
+      test('infix on Patient-identifier', () =>
+        withTestContext(async () => {
+          const identifierResult = await systemRepo.search({
+            resourceType: 'Patient',
+            filters: [
+              ...baseFilters,
+              {
+                code: 'identifier',
+                operator: Operator.CONTAINS,
+                value: identifier.slice(5, 10),
+              },
+            ],
+          });
+
+          expect(identifierResult.entry?.length).toStrictEqual(0);
+        }));
+
+      test.each(['pager', 'PAGER', 'PaGeR'])('infix on Patient-telecom', (value) =>
+        withTestContext(async () => {
+          const result = await systemRepo.search({
+            resourceType: 'Patient',
+            filters: [
+              ...baseFilters,
+              {
+                code: 'telecom',
+                operator: Operator.CONTAINS,
+                value,
+              },
+            ],
+          });
+
+          expect(result.entry?.length).toStrictEqual(1);
+          expect(bundleContains(result, patient1)).toBeDefined();
+        })
+      );
+
+      test('infix on Patient-email', () =>
+        withTestContext(async () => {
+          const result = await systemRepo.search({
+            resourceType: 'Patient',
+            filters: [
+              ...baseFilters,
+              {
+                code: 'email',
+                operator: Operator.CONTAINS,
+                value: 'email',
+              },
+            ],
+          });
+
+          expect(result.entry?.length).toStrictEqual(1);
+          expect(bundleContains(result, patient1)).toBeDefined();
+        }));
+
+      test('infix on Patient-phone', () =>
+        withTestContext(async () => {
+          const result = await systemRepo.search({
+            resourceType: 'Patient',
+            filters: [
+              ...baseFilters,
+              {
+                code: 'phone',
+                operator: Operator.CONTAINS,
+                value: 'phone',
+              },
+            ],
+          });
+
+          expect(result.entry?.length).toStrictEqual(1);
+          expect(bundleContains(result, patient1)).toBeDefined();
+        }));
+    });
+
+    test('Not equals', () =>
+      withTestContext(async () => {
+        const identifier = randomUUID();
+        const name = randomUUID();
+
+        const patient1 = await systemRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: name }],
+          identifier: [{ system: 'https://www.example.com', value: identifier }],
+        });
+
+        const patient2 = await systemRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: name }],
+          identifier: [{ system: 'https://www.example.com', value: identifier + 'xyz' }],
+        });
+
+        const patient3 = await systemRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: name }],
+          // no identifiers should match NOT_EQUALS
+        });
+
+        const searchResult1 = await systemRepo.search({
+          resourceType: 'Patient',
+          filters: [
+            {
+              code: 'identifier',
+              operator: Operator.NOT_EQUALS,
+              value: identifier,
+            },
+            {
+              code: 'name',
+              operator: Operator.EQUALS,
+              value: name,
+            },
+          ],
+        });
+        expect(searchResult1.entry?.length).toStrictEqual(2);
+        expect(bundleContains(searchResult1, patient1)).toBeUndefined();
+        expect(bundleContains(searchResult1, patient2)).toBeDefined();
+        expect(bundleContains(searchResult1, patient3)).toBeDefined();
+      }));
+
+    test('Search comma separated identifier exact', () =>
+      withTestContext(async () => {
+        const identifier1 = randomUUID();
+        const identifier2 = randomUUID();
+
+        const patient1 = await systemRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'Smith' }],
+          identifier: [{ system: 'https://www.example.com', value: identifier1 }],
+        });
+
+        const patient2 = await systemRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'Jones' }],
+          identifier: [{ system: 'https://www.example.com', value: identifier2 }],
+        });
+
+        const searchResult1 = await systemRepo.search({
+          resourceType: 'Patient',
+          filters: [
+            {
+              code: 'identifier',
+              operator: Operator.EXACT,
+              value: `${identifier1},${identifier2}`,
+            },
+          ],
+        });
+        expect(searchResult1.entry?.length).toStrictEqual(2);
+        expect(bundleContains(searchResult1, patient1)).toBeDefined();
+        expect(bundleContains(searchResult1, patient2)).toBeDefined();
+      }));
+
+    test('Search on system', () =>
+      withTestContext(async () => {
+        const system1 = 'https://foo.com';
+        const system2 = 'https://bar.com';
+        const identifier = randomUUID();
+
+        const patient1 = await systemRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'Smith' }],
+          identifier: [{ system: system1, value: identifier }],
+        });
+
+        const patient2 = await systemRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'Jones' }],
+          identifier: [{ system: system2, value: identifier }],
+        });
+
+        const searchResult1 = await systemRepo.search({
+          resourceType: 'Patient',
+          filters: [
+            {
+              code: 'identifier',
+              operator: Operator.EXACT,
+              value: system1 + '|' + identifier,
+            },
+          ],
+        });
+        expect(searchResult1.entry?.length).toStrictEqual(1);
+        expect(bundleContains(searchResult1, patient1)).toBeDefined();
+        expect(bundleContains(searchResult1, patient2)).toBeUndefined();
+
+        const searchResult2 = await systemRepo.search({
+          resourceType: 'Patient',
+          filters: [
+            {
+              code: 'identifier',
+              operator: Operator.EXACT,
+              value: system2 + '|' + identifier,
+            },
+          ],
+        });
+        expect(searchResult2.entry?.length).toStrictEqual(1);
+        expect(bundleContains(searchResult2, patient1)).toBeUndefined();
+        expect(bundleContains(searchResult2, patient2)).toBeDefined();
+      }));
+
+    test('Non-array identifier', () =>
+      withTestContext(async () => {
+        const identifier = randomUUID();
+
+        const resource = await systemRepo.createResource<SpecimenDefinition>({
+          resourceType: 'SpecimenDefinition',
+          identifier: { system: 'https://www.example.com', value: identifier },
+        });
+
+        const searchResult = await systemRepo.search({
+          resourceType: 'SpecimenDefinition',
+          filters: [
+            {
+              code: 'identifier',
+              operator: Operator.EQUALS,
+              value: identifier,
+            },
+          ],
+        });
+        expect(searchResult.entry?.length).toStrictEqual(1);
+        expect(searchResult.entry?.[0]?.resource?.id).toStrictEqual(resource.id);
+      }));
+
+    test('Leading whitespace', () =>
+      withTestContext(async () => {
+        const identifier = randomUUID();
+
+        const resource = await systemRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          identifier: [{ system: 'https://www.example.com', value: ' ' + identifier }],
+        });
+
+        const searchResult = await systemRepo.search({
+          resourceType: 'Patient',
+          filters: [
+            {
+              code: 'identifier',
+              operator: Operator.EQUALS,
+              value: identifier,
+            },
+          ],
+        });
+        expect(searchResult.entry?.length).toStrictEqual(1);
+        expect(searchResult.entry?.[0]?.resource?.id).toStrictEqual(resource.id);
+      }));
+
+    test('CodeableConcept text', () =>
+      withTestContext(async () => {
+        const sr1 = await systemRepo.createResource<ServiceRequest>({
+          resourceType: 'ServiceRequest',
+          intent: 'order',
+          status: 'active',
+          subject: { reference: 'Patient/1' },
+          category: [{ text: randomUUID() }],
+        });
+
+        const sr2 = await systemRepo.createResource<ServiceRequest>({
+          resourceType: 'ServiceRequest',
+          intent: 'order',
+          status: 'active',
+          subject: { reference: 'Patient/1' },
+          category: [{ text: randomUUID() }],
+        });
+
+        const searchResult1 = await systemRepo.search({
+          resourceType: 'ServiceRequest',
+          filters: [
+            {
+              code: 'category',
+              operator: Operator.EQUALS,
+              value: sr1.category?.[0]?.text as string,
+            },
+          ],
+        });
+        expect(searchResult1.entry?.length).toStrictEqual(1);
+        expect(bundleContains(searchResult1, sr1)).toBeDefined();
+        expect(bundleContains(searchResult1, sr2)).toBeUndefined();
+      }));
+
+    test('Identifier value with pipe', () =>
+      withTestContext(async () => {
+        const system = randomUUID();
+        const base = randomUUID();
+        const id1 = base + '|1';
+        const id2 = base + '|2';
+
+        const p1 = await systemRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'Smith' }],
+          identifier: [{ system, value: id1 }],
+        });
+
+        await systemRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'Smith' }],
+          identifier: [{ system, value: id2 }],
+        });
+
+        const r1 = await systemRepo.search({
+          resourceType: 'Patient',
+          filters: [{ code: 'identifier', operator: Operator.EQUALS, value: `${system}|${id1}` }],
+        });
+        expect(r1.entry?.length).toStrictEqual(1);
+        expect(r1.entry?.[0]?.resource?.id).toStrictEqual(p1.id);
+      }));
+
+    describe('Missing/present', () => {
+      const family = randomUUID();
+      const email = randomUUID();
+      const identifier = randomUUID();
+      let p1: Patient;
+      let p2: Patient;
+
+      beforeAll(async () => {
+        p1 = await systemRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          meta: {
+            security: [{ code: '123' }],
+          },
+          name: [{ family }],
+          telecom: [{ system: 'email', value: email + 'abc' }],
+        });
+
+        p2 = await systemRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ family }],
+          telecom: [{ system: 'email', value: email + 'xyz' }],
+          identifier: [{ system: 'https://www.example.com', value: identifier }],
+        });
+      });
+
+      test.each([
+        ['identifier', Operator.MISSING, 'true', true, false, true],
+        ['identifier', Operator.MISSING, 'false', false, true, true],
+        ['identifier', Operator.PRESENT, 'true', false, true, true],
+        ['identifier', Operator.PRESENT, 'false', true, false, true],
+        ['telecom', Operator.MISSING, 'true', false, false, true],
+        ['telecom', Operator.MISSING, 'false', true, true, true],
+        ['telecom', Operator.PRESENT, 'true', true, true, true],
+        ['telecom', Operator.PRESENT, 'false', false, false, true],
+        ['_security', Operator.MISSING, 'true', false, true, false],
+        ['_security', Operator.MISSING, 'false', true, false, false],
+        ['_security', Operator.PRESENT, 'true', true, false, false],
+        ['_security', Operator.PRESENT, 'false', false, true, false],
+      ])('%s :%s %s', (code, operator, value, expected1, expected2, expectedHasDedicated) =>
+        withTestContext(async () => {
+          const searchParam = getSearchParameter('Patient', code) as SearchParameter;
+          const impl = getSearchParameterImplementation('Patient', searchParam);
+          expect(impl.searchStrategy).toStrictEqual('token-column');
+          expect((impl as TokenColumnSearchParameterImplementation).hasDedicatedColumns).toStrictEqual(
+            expectedHasDedicated
+          );
+
+          const res = await systemRepo.search({
+            resourceType: 'Patient',
+            filters: [
+              { code: 'name', operator: Operator.EQUALS, value: family },
+              { code, operator, value },
+            ],
+          });
+          expect(Boolean(bundleContains(res, p1))).toBe(expected1);
+          expect(Boolean(bundleContains(res, p2))).toBe(expected2);
+        })
+      );
+    });
+
+    test.each([[Operator.IN], [Operator.NOT_IN]])('Condition.code :%s search', (operator) =>
+      withTestContext(async () => {
+        // ValueSet: http://hl7.org/fhir/ValueSet/condition-code
+        // compose includes codes from http://snomed.info/sct
+        // but does not include codes from https://example.com
+
+        const p = await systemRepo.createResource({
+          resourceType: 'Patient',
+          name: [{ family: randomUUID() }],
+        });
+
+        await systemRepo.createResource<Condition>({
+          resourceType: 'Condition',
+          subject: createReference(p),
+          code: { coding: [{ system: SNOMED, code: '165002' }] },
+        });
+
+        await systemRepo.createResource<Condition>({
+          resourceType: 'Condition',
+          subject: createReference(p),
+          code: { coding: [{ system: 'https://example.com', code: 'test' }] },
+        });
+
+        await expect(
+          systemRepo.search({
+            resourceType: 'Condition',
+            filters: [
+              {
+                code: 'subject',
+                operator: Operator.EQUALS,
+                value: getReferenceString(p),
+              },
+              {
+                code: 'code',
+                operator: operator,
+                value: 'http://hl7.org/fhir/ValueSet/condition-code',
+              },
+            ],
+          })
+        ).rejects.toThrow('Invalid modifier');
+      })
+    );
+  });
+
+  describe('Non-strict mode', () => {
+    let nonStrictRepo: Repository;
+    let repo: Repository;
+    let patient: Patient;
+
+    const sys1 = 'http://sys.one';
+    const val1 = 'ABCDEFGHIJ';
+
+    beforeAll(async () => {
+      ({ repo } = await createTestProject({ withRepo: true }));
+      expect(repo.getConfig().strictMode).toBe(true);
+      nonStrictRepo = new Repository({ ...repo.getConfig(), strictMode: false });
+      patient = await nonStrictRepo.createResource<Patient>({
         resourceType: 'Patient',
+        name: [{ given: ['Henry'] }],
+      });
+    });
+
+    test('Handle malformed system', () =>
+      withTestContext(async () => {
+        const subject = createReference(patient);
+        await nonStrictRepo.createResource<Condition>({
+          resourceType: 'Condition',
+          subject,
+          code: {
+            coding: [
+              {
+                system: [sys1] as unknown as string, // Force malformed data
+                code: val1,
+              },
+            ],
+          },
+        });
+
+        const res = await repo.search<Condition>({
+          resourceType: 'Condition',
+          filters: [
+            {
+              code: 'code',
+              operator: Operator.EQUALS,
+              value: sys1 + '|',
+            },
+          ],
+        });
+        //TODO what is actually the expected behavior here?
+        expect(toIdentifierValues(res)).toContainExactly([]);
+      }));
+
+    test('Handle malformed value', () =>
+      withTestContext(async () => {
+        const subject = createReference(patient);
+        await nonStrictRepo.createResource<Condition>({
+          resourceType: 'Condition',
+          subject,
+          code: {
+            coding: [
+              {
+                system: 'https://example.com',
+                code: ['test1'] as unknown as string, // Force malformed data
+              },
+            ],
+          },
+        });
+
+        const res = await repo.search<Condition>({
+          resourceType: 'Condition',
+          filters: [
+            {
+              code: 'code',
+              operator: Operator.EQUALS,
+              value: val1,
+            },
+          ],
+        });
+        //TODO what is actually the expected behavior here?
+        expect(toIdentifierValues(res)).toContainExactly([undefined]);
+      }));
+  });
+
+  describe('Condition.code token queries', () => {
+    let repo: Repository;
+
+    let patient: WithId<Patient>;
+    let subject: Reference<Patient> & { reference: string };
+
+    const conditionNames = [
+      'noCodeNoCat',
+      'noCodeCatOne',
+      'codeOneNoCat',
+      'codeOneCatOne',
+      'codeOneCatTwo',
+      'codeOneWithoutSystemNoCat',
+      'codeTwoWithoutSystemCatTwo',
+    ] as const;
+    type Conditions = (typeof conditionNames)[number];
+    const cond: Record<Conditions, Condition & { id: string }> = {} as Record<Conditions, Condition & { id: string }>;
+
+    const sys1 = 'http://sys.one';
+    const sys2 = 'http://sys.two';
+
+    const val1 = 'ABCDEFGHIJ';
+    const val2 = '0123456789';
+
+    const disp1 = 'The Quick Brown Fox';
+
+    beforeAll(async () => {
+      ({ repo } = await createTestProject({ withRepo: true }));
+
+      patient = await repo.createResource<Patient>({ resourceType: 'Patient', name: [{ given: ['Henry'] }] });
+      subject = createReference(patient);
+
+      const partial = cond as Record<string, Condition>;
+      partial.noCodeNoCat = await repo.createResource<Condition>({
+        resourceType: 'Condition',
+        subject,
+        identifier: [{ value: 'noCodeNoCat' }],
+      });
+      partial.noCodeCatOne = await repo.createResource<Condition>({
+        resourceType: 'Condition',
+        subject,
+        identifier: [{ value: 'noCodeCatOne' }],
+        category: [{ coding: [{ system: sys1, code: val1, display: disp1 }] }],
+      });
+      partial.codeOneNoCat = await repo.createResource<Condition>({
+        resourceType: 'Condition',
+        subject,
+        identifier: [{ value: 'codeOneNoCat' }],
+        code: { coding: [{ system: sys1, code: val1, display: disp1 }] },
+      });
+      partial.codeOneCatOne = await repo.createResource<Condition>({
+        resourceType: 'Condition',
+        subject,
+        identifier: [{ value: 'codeOneCatOne' }],
+        code: { coding: [{ system: sys1, code: val1 }] },
+        category: [{ coding: [{ system: sys1, code: val1 }] }],
+      });
+      partial.codeOneCatTwo = await repo.createResource<Condition>({
+        resourceType: 'Condition',
+        subject,
+        identifier: [{ value: 'codeOneCatTwo' }],
+        code: { coding: [{ system: sys1, code: val1 }] },
+        category: [{ coding: [{ system: sys2, code: val2 }] }],
+      });
+      partial.codeOneWithoutSystemNoCat = await repo.createResource<Condition>({
+        resourceType: 'Condition',
+        subject,
+        identifier: [{ value: 'codeOneWithoutSystemNoCat' }],
+        code: { coding: [{ code: val1 }] },
+      });
+      partial.codeTwoWithoutSystemCatTwo = await repo.createResource<Condition>({
+        resourceType: 'Condition',
+        subject,
+        identifier: [{ value: 'codeTwoWithoutSystemCatTwo' }],
+        code: { coding: [{ code: val2 }] },
+        category: [{ coding: [{ system: sys2, code: val2 }] }],
+      });
+
+      for (const name of conditionNames) {
+        if (!cond[name]?.id) {
+          throw new Error('Condition "' + name + '" not created');
+        }
+        expect(cond[name].identifier?.[0].value).toEqual(name);
+      }
+      expect(Object.keys(cond)).toHaveLength(conditionNames.length);
+    });
+
+    test('Sort by identifier', () =>
+      withTestContext(async () => {
+        const system = randomUUID();
+        await repo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'None' }],
+          identifier: [{ system }],
+        });
+
+        await repo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'AAA' }],
+          identifier: [{ system, value: 'AAA' }],
+        });
+
+        await repo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'ZZZ' }],
+          identifier: [{ system, value: 'ZZZ' }],
+        });
+
+        const ascending = await repo.search<Patient>({
+          resourceType: 'Patient',
+          filters: [{ code: 'identifier', operator: Operator.EQUALS, value: system + '|' }],
+          sortRules: [{ code: 'identifier', descending: false }],
+        });
+        expect(ascending.entry?.map((e) => e.resource?.name?.[0]?.family)).toStrictEqual(['AAA', 'ZZZ', 'None']);
+
+        const descending = await repo.search<Patient>({
+          resourceType: 'Patient',
+          filters: [{ code: 'identifier', operator: Operator.EQUALS, value: system + '|' }],
+          sortRules: [{ code: 'identifier', descending: true }],
+        });
+        expect(descending.entry?.map((e) => e.resource?.name?.[0]?.family)).toStrictEqual(['None', 'ZZZ', 'AAA']);
+      }));
+
+    test('Sort by identifier with multiple values', () =>
+      withTestContext(async () => {
+        const system = randomUUID();
+        await repo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'First' }],
+          identifier: [
+            { system, value: 'AAA' },
+            { system, value: 'ZZZ' },
+          ],
+        });
+
+        await repo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'Second' }],
+          identifier: [{ system, value: 'LLL' }],
+        });
+
+        const ascending = await repo.search<Patient>({
+          resourceType: 'Patient',
+          filters: [{ code: 'identifier', operator: Operator.EQUALS, value: system + '|' }],
+          sortRules: [{ code: 'identifier', descending: false }],
+        });
+
+        const descending = await repo.search<Patient>({
+          resourceType: 'Patient',
+          filters: [{ code: 'identifier', operator: Operator.EQUALS, value: system + '|' }],
+          sortRules: [{ code: 'identifier', descending: true }],
+        });
+
+        // Ideally ASC and DESC would have the same sort order since
+        // ascending should use "AAA" and descending should use "ZZZ",
+        // but a simpler sort implementation is used
+        expect(ascending.entry?.map((e) => e.resource?.name?.[0]?.family)).toStrictEqual(['First', 'Second']);
+        expect(descending.entry?.map((e) => e.resource?.name?.[0]?.family)).toStrictEqual(['Second', 'First']);
+      }));
+
+    test.each<[string, Conditions[]]>([
+      [sys1, ['codeOneNoCat', 'codeOneCatOne', 'codeOneCatTwo']],
+      [sys2, []],
+      [val1, []], // incorrectly passing val as a system
+    ])('code by system %s', async (value, expected) => {
+      const res = await repo.search<Condition>({
+        resourceType: 'Condition',
         filters: [
-          ...baseFilters,
           {
-            code: 'identifier',
-            operator: Operator.CONTAINS,
-            value: identifier.slice(5, 10),
+            code: 'code',
+            operator: Operator.EQUALS,
+            value: value + '|',
           },
         ],
       });
+      expect(toIdentifierValues(res)).toContainExactly(expected);
+    });
 
-      expect(identifierResult.entry?.length).toStrictEqual(0);
-    }));
-
-  test.each(['pager', 'PAGER', 'PaGeR'])('infix on Patient-telecom', (value) =>
-    withTestContext(async () => {
-      const result = await systemRepo.search({
-        resourceType: 'Patient',
+    test.each<[string, Conditions[]]>([
+      [sys1, []], // incorrectly passing sys as a value
+      [val1, ['codeOneNoCat', 'codeOneCatOne', 'codeOneCatTwo', 'codeOneWithoutSystemNoCat']],
+      [val2, ['codeTwoWithoutSystemCatTwo']],
+    ])('code by value %s', async (value, expected) => {
+      const resEquals = await repo.search<Condition>({
+        resourceType: 'Condition',
         filters: [
-          ...baseFilters,
           {
-            code: 'telecom',
+            code: 'code',
+            operator: Operator.EQUALS,
+            value,
+          },
+        ],
+      });
+      expect(toIdentifierValues(resEquals)).toContainExactly(expected);
+
+      const resContains = await repo.search<Condition>({
+        resourceType: 'Condition',
+        filters: [
+          {
+            code: 'code',
             operator: Operator.CONTAINS,
             value,
           },
         ],
       });
-
-      expect(result.entry?.length).toStrictEqual(1);
-      expect(bundleContains(result, patient1)).toBeDefined();
-    })
-  );
-
-  test('infix on Patient-email', () =>
-    withTestContext(async () => {
-      const result = await systemRepo.search({
-        resourceType: 'Patient',
-        filters: [
-          ...baseFilters,
-          {
-            code: 'email',
-            operator: Operator.CONTAINS,
-            value: 'email',
-          },
-        ],
-      });
-
-      expect(result.entry?.length).toStrictEqual(1);
-      expect(bundleContains(result, patient1)).toBeDefined();
-    }));
-
-  test('infix on Patient-phone', () =>
-    withTestContext(async () => {
-      const result = await systemRepo.search({
-        resourceType: 'Patient',
-        filters: [
-          ...baseFilters,
-          {
-            code: 'phone',
-            operator: Operator.CONTAINS,
-            value: 'phone',
-          },
-        ],
-      });
-
-      expect(result.entry?.length).toStrictEqual(1);
-      expect(bundleContains(result, patient1)).toBeDefined();
-    }));
-});
-
-test('Not equals', () =>
-  withTestContext(async () => {
-    const identifier = randomUUID();
-    const name = randomUUID();
-
-    const patient1 = await systemRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      name: [{ given: ['Alice'], family: name }],
-      identifier: [{ system: 'https://www.example.com', value: identifier }],
+      expect(toIdentifierValues(resContains)).toContainExactly([]);
     });
 
-    const patient2 = await systemRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      name: [{ given: ['Alice'], family: name }],
-      identifier: [{ system: 'https://www.example.com', value: identifier + 'xyz' }],
-    });
-
-    const patient3 = await systemRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      name: [{ given: ['Alice'], family: name }],
-      // no identifiers should match NOT_EQUALS
-    });
-
-    const searchResult1 = await systemRepo.search({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'identifier',
-          operator: Operator.NOT_EQUALS,
-          value: identifier,
-        },
-        {
-          code: 'name',
-          operator: Operator.EQUALS,
-          value: name,
-        },
-      ],
-    });
-    expect(searchResult1.entry?.length).toStrictEqual(2);
-    expect(bundleContains(searchResult1, patient1)).toBeUndefined();
-    expect(bundleContains(searchResult1, patient2)).toBeDefined();
-    expect(bundleContains(searchResult1, patient3)).toBeDefined();
-  }));
-
-test('Search comma separated identifier exact', () =>
-  withTestContext(async () => {
-    const identifier1 = randomUUID();
-    const identifier2 = randomUUID();
-
-    const patient1 = await systemRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      name: [{ given: ['Alice'], family: 'Smith' }],
-      identifier: [{ system: 'https://www.example.com', value: identifier1 }],
-    });
-
-    const patient2 = await systemRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      name: [{ given: ['Alice'], family: 'Jones' }],
-      identifier: [{ system: 'https://www.example.com', value: identifier2 }],
-    });
-
-    const searchResult1 = await systemRepo.search({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'identifier',
-          operator: Operator.EXACT,
-          value: `${identifier1},${identifier2}`,
-        },
-      ],
-    });
-    expect(searchResult1.entry?.length).toStrictEqual(2);
-    expect(bundleContains(searchResult1, patient1)).toBeDefined();
-    expect(bundleContains(searchResult1, patient2)).toBeDefined();
-  }));
-
-test('Search on system', () =>
-  withTestContext(async () => {
-    const system1 = 'https://foo.com';
-    const system2 = 'https://bar.com';
-    const identifier = randomUUID();
-
-    const patient1 = await systemRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      name: [{ given: ['Alice'], family: 'Smith' }],
-      identifier: [{ system: system1, value: identifier }],
-    });
-
-    const patient2 = await systemRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      name: [{ given: ['Alice'], family: 'Jones' }],
-      identifier: [{ system: system2, value: identifier }],
-    });
-
-    const searchResult1 = await systemRepo.search({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'identifier',
-          operator: Operator.EXACT,
-          value: system1 + '|' + identifier,
-        },
-      ],
-    });
-    expect(searchResult1.entry?.length).toStrictEqual(1);
-    expect(bundleContains(searchResult1, patient1)).toBeDefined();
-    expect(bundleContains(searchResult1, patient2)).toBeUndefined();
-
-    const searchResult2 = await systemRepo.search({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'identifier',
-          operator: Operator.EXACT,
-          value: system2 + '|' + identifier,
-        },
-      ],
-    });
-    expect(searchResult2.entry?.length).toStrictEqual(1);
-    expect(bundleContains(searchResult2, patient1)).toBeUndefined();
-    expect(bundleContains(searchResult2, patient2)).toBeDefined();
-  }));
-
-test('Non-array identifier', () =>
-  withTestContext(async () => {
-    const identifier = randomUUID();
-
-    const resource = await systemRepo.createResource<SpecimenDefinition>({
-      resourceType: 'SpecimenDefinition',
-      identifier: { system: 'https://www.example.com', value: identifier },
-    });
-
-    const searchResult = await systemRepo.search({
-      resourceType: 'SpecimenDefinition',
-      filters: [
-        {
-          code: 'identifier',
-          operator: Operator.EQUALS,
-          value: identifier,
-        },
-      ],
-    });
-    expect(searchResult.entry?.length).toStrictEqual(1);
-    expect(searchResult.entry?.[0]?.resource?.id).toStrictEqual(resource.id);
-  }));
-
-test('Leading whitespace', () =>
-  withTestContext(async () => {
-    const identifier = randomUUID();
-
-    const resource = await systemRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      identifier: [{ system: 'https://www.example.com', value: ' ' + identifier }],
-    });
-
-    const searchResult = await systemRepo.search({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'identifier',
-          operator: Operator.EQUALS,
-          value: identifier,
-        },
-      ],
-    });
-    expect(searchResult.entry?.length).toStrictEqual(1);
-    expect(searchResult.entry?.[0]?.resource?.id).toStrictEqual(resource.id);
-  }));
-
-test('CodeableConcept text', () =>
-  withTestContext(async () => {
-    const sr1 = await systemRepo.createResource<ServiceRequest>({
-      resourceType: 'ServiceRequest',
-      intent: 'order',
-      status: 'active',
-      subject: { reference: 'Patient/1' },
-      category: [{ text: randomUUID() }],
-    });
-
-    const sr2 = await systemRepo.createResource<ServiceRequest>({
-      resourceType: 'ServiceRequest',
-      intent: 'order',
-      status: 'active',
-      subject: { reference: 'Patient/1' },
-      category: [{ text: randomUUID() }],
-    });
-
-    const searchResult1 = await systemRepo.search({
-      resourceType: 'ServiceRequest',
-      filters: [
-        {
-          code: 'category',
-          operator: Operator.EQUALS,
-          value: sr1.category?.[0]?.text as string,
-        },
-      ],
-    });
-    expect(searchResult1.entry?.length).toStrictEqual(1);
-    expect(bundleContains(searchResult1, sr1)).toBeDefined();
-    expect(bundleContains(searchResult1, sr2)).toBeUndefined();
-  }));
-
-test('Identifier value with pipe', () =>
-  withTestContext(async () => {
-    const system = randomUUID();
-    const base = randomUUID();
-    const id1 = base + '|1';
-    const id2 = base + '|2';
-
-    const p1 = await systemRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      name: [{ given: ['Alice'], family: 'Smith' }],
-      identifier: [{ system, value: id1 }],
-    });
-
-    await systemRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      name: [{ given: ['Alice'], family: 'Smith' }],
-      identifier: [{ system, value: id2 }],
-    });
-
-    const r1 = await systemRepo.search({
-      resourceType: 'Patient',
-      filters: [{ code: 'identifier', operator: Operator.EQUALS, value: `${system}|${id1}` }],
-    });
-    expect(r1.entry?.length).toStrictEqual(1);
-    expect(r1.entry?.[0]?.resource?.id).toStrictEqual(p1.id);
-  }));
-
-describe('Missing/present', () => {
-  const family = randomUUID();
-  const email = randomUUID();
-  const identifier = randomUUID();
-  let p1: Patient;
-  let p2: Patient;
-
-  beforeAll(async () => {
-    p1 = await systemRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      meta: {
-        security: [{ code: '123' }],
-      },
-      name: [{ family }],
-      telecom: [{ system: 'email', value: email + 'abc' }],
-    });
-
-    p2 = await systemRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      name: [{ family }],
-      telecom: [{ system: 'email', value: email + 'xyz' }],
-      identifier: [{ system: 'https://www.example.com', value: identifier }],
-    });
-  });
-
-  test.each([
-    ['identifier', Operator.MISSING, 'true', true, false, true],
-    ['identifier', Operator.MISSING, 'false', false, true, true],
-    ['identifier', Operator.PRESENT, 'true', false, true, true],
-    ['identifier', Operator.PRESENT, 'false', true, false, true],
-    ['telecom', Operator.MISSING, 'true', false, false, true],
-    ['telecom', Operator.MISSING, 'false', true, true, true],
-    ['telecom', Operator.PRESENT, 'true', true, true, true],
-    ['telecom', Operator.PRESENT, 'false', false, false, true],
-    ['_security', Operator.MISSING, 'true', false, true, false],
-    ['_security', Operator.MISSING, 'false', true, false, false],
-    ['_security', Operator.PRESENT, 'true', true, false, false],
-    ['_security', Operator.PRESENT, 'false', false, true, false],
-  ])('%s :%s %s', (code, operator, value, expected1, expected2, expectedHasDedicated) =>
-    withTestContext(async () => {
-      const searchParam = getSearchParameter('Patient', code) as SearchParameter;
-      const impl = getSearchParameterImplementation('Patient', searchParam);
-      expect(impl.searchStrategy).toStrictEqual('token-column');
-      expect((impl as TokenColumnSearchParameterImplementation).hasDedicatedColumns).toStrictEqual(
-        expectedHasDedicated
-      );
-
-      const res = await systemRepo.search({
-        resourceType: 'Patient',
-        filters: [
-          { code: 'name', operator: Operator.EQUALS, value: family },
-          { code, operator, value },
-        ],
-      });
-      expect(Boolean(bundleContains(res, p1))).toBe(expected1);
-      expect(Boolean(bundleContains(res, p2))).toBe(expected2);
-    })
-  );
-});
-
-test.each([[Operator.IN], [Operator.NOT_IN]])('Condition.code :%s search', (operator) =>
-  withTestContext(async () => {
-    // ValueSet: http://hl7.org/fhir/ValueSet/condition-code
-    // compose includes codes from http://snomed.info/sct
-    // but does not include codes from https://example.com
-
-    const p = await systemRepo.createResource({
-      resourceType: 'Patient',
-      name: [{ family: randomUUID() }],
-    });
-
-    await systemRepo.createResource<Condition>({
-      resourceType: 'Condition',
-      subject: createReference(p),
-      code: { coding: [{ system: SNOMED, code: '165002' }] },
-    });
-
-    await systemRepo.createResource<Condition>({
-      resourceType: 'Condition',
-      subject: createReference(p),
-      code: { coding: [{ system: 'https://example.com', code: 'test' }] },
-    });
-
-    await expect(
-      systemRepo.search({
-        resourceType: 'Condition',
-        filters: [
-          {
-            code: 'subject',
-            operator: Operator.EQUALS,
-            value: getReferenceString(p),
-          },
-          {
-            code: 'code',
-            operator: operator,
-            value: 'http://hl7.org/fhir/ValueSet/condition-code',
-          },
-        ],
-      })
-    ).rejects.toThrow('Invalid modifier');
-  })
-);
-
-describe('Non-strict mode', () => {
-  let nonStrictRepo: Repository;
-  let repo: Repository;
-  let patient: Patient;
-
-  const sys1 = 'http://sys.one';
-  const val1 = 'ABCDEFGHIJ';
-
-  beforeAll(async () => {
-    ({ repo } = await createTestProject({ withRepo: true }));
-    expect(repo.getConfig().strictMode).toBe(true);
-    nonStrictRepo = new Repository({ ...repo.getConfig(), strictMode: false });
-    patient = await nonStrictRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      name: [{ given: ['Henry'] }],
-    });
-  });
-
-  test('Handle malformed system', () =>
-    withTestContext(async () => {
-      const subject = createReference(patient);
-      await nonStrictRepo.createResource<Condition>({
-        resourceType: 'Condition',
-        subject,
-        code: {
-          coding: [
-            {
-              system: [sys1] as unknown as string, // Force malformed data
-              code: val1,
-            },
-          ],
-        },
-      });
-
+    test.each<[string, string, Conditions[]]>([
+      [sys1, val1, ['codeOneNoCat', 'codeOneCatOne', 'codeOneCatTwo']],
+      [sys1, val2, []],
+      [sys2, val1, []],
+      [sys2, val2, []],
+    ])('code by system and value %s|%s', async (system, value, expected) => {
       const res = await repo.search<Condition>({
         resourceType: 'Condition',
+        filters: [
+          {
+            code: 'code',
+            operator: Operator.EQUALS,
+            value: system + '|' + value,
+          },
+        ],
+      });
+      expect(toIdentifierValues(res)).toContainExactly(expected);
+    });
+
+    test.each<[string, Conditions[]]>([
+      [val1, ['codeOneWithoutSystemNoCat']],
+      [val2, ['codeTwoWithoutSystemCatTwo']],
+    ])('code by missing system and value %s', async (value, expected) => {
+      const res = await repo.search<Condition>({
+        resourceType: 'Condition',
+        filters: [
+          {
+            code: 'code',
+            operator: Operator.EQUALS,
+            value: '|' + value,
+          },
+        ],
+      });
+      expect(toIdentifierValues(res)).toContainExactly(expected);
+    });
+
+    test.each<[string, string, Conditions[]]>([
+      [val1, val1, ['codeOneCatOne']],
+      [val1, val2, ['codeOneCatTwo']],
+      [val2, val1, []],
+      [sys1 + '|', val2, ['codeOneCatTwo']],
+      ['|' + val1, val1, []],
+      ['|' + val2, sys2 + '|' + val2, ['codeTwoWithoutSystemCatTwo']],
+    ])('code and category by code=%s category=%s', async (codeValue, categoryValue, expected) => {
+      const res = await repo.search<Condition>({
+        resourceType: 'Condition',
+        filters: [
+          {
+            code: 'code',
+            operator: Operator.EQUALS,
+            value: codeValue,
+          },
+          {
+            code: 'category',
+            operator: Operator.EQUALS,
+            value: categoryValue,
+          },
+        ],
+      });
+      expect(toIdentifierValues(res)).toContainExactly(expected);
+    });
+
+    test.each<string>([val1, val1.slice(0, 3)])('code :contains beginning of value %s', async (value) => {
+      const resContains = await repo.search<Condition>({
+        resourceType: 'Condition',
+        filters: [
+          {
+            code: 'code',
+            operator: Operator.CONTAINS,
+            value,
+          },
+        ],
+      });
+      expect(toIdentifierValues(resContains)).toContainExactly([]);
+    });
+
+    test.each<[string]>([[val1.slice(1, 3)], [val2.slice(1, 3)]])(
+      `code :contains middle of value %s`,
+      async (value) => {
+        const resContains = await repo.search<Condition>({
+          resourceType: 'Condition',
+          filters: [
+            {
+              code: 'code',
+              operator: Operator.CONTAINS,
+              value,
+            },
+          ],
+        });
+        // Token columns don't support :contains on `code`
+        // Token lookup tables don't support infix queries
+        expect(toIdentifierValues(resContains).length).toBe(0);
+      }
+    );
+
+    test.each<[string, Conditions[]]>([
+      [disp1, ['codeOneNoCat']],
+      [disp1.split(' ').slice(0, 2).join(' '), ['codeOneNoCat']],
+      [disp1.split(' ').slice(1, 3).join(' '), ['codeOneNoCat']],
+      [disp1.split(' ').slice(-2).join(' '), ['codeOneNoCat']],
+    ])('code :text %s', async (value, expected) => {
+      const resContains = await repo.search<Condition>({
+        resourceType: 'Condition',
+        filters: [
+          {
+            code: 'code',
+            operator: Operator.TEXT,
+            value,
+          },
+        ],
+      });
+      expect(toIdentifierValues(resContains)).toContainExactly(expected);
+    });
+
+    describe('code :text search for special chars', () => {
+      const identifier = randomUUID();
+      let condWithSpecialChars: WithId<Condition>;
+      beforeAll(async () => {
+        condWithSpecialChars = await repo.createResource<Condition>({
+          resourceType: 'Condition',
+          code: {
+            coding: [
+              {
+                system: sys1,
+                code: 'some-value',
+                display: '.^$*+?()[]{}\\|hello|',
+              },
+            ],
+          },
+          subject,
+          identifier: [
+            {
+              system: sys1,
+              value: identifier,
+            },
+          ],
+        });
+      });
+
+      // same behavior between token columns and lookup tables
+      test.each<[string, boolean]>([
+        ['.', true],
+        ['^', true],
+        ['$', true],
+        ['*', true],
+        ['+', true],
+        ['?', true],
+        ['(', true],
+        [')', true],
+        ['[', true],
+        [']', true],
+        ['{', true],
+        ['}', true],
+        ['\\', true],
+        ['()', true],
+        ['[]', true],
+        ['{}', true],
+
+        ['.^', true],
+        ['.^$*+', true],
+        ['$', true],
+        ['+?', true],
+        [']{', true],
+        ['hello', true],
+
+        ['||', false],
+      ])(':text search for %s should match? %s', async (query, shouldBeFound) => {
+        const res = await repo.search<Condition>({
+          resourceType: 'Condition',
+          filters: [
+            {
+              code: 'subject',
+              operator: Operator.EQUALS,
+              value: subject.reference,
+            },
+            {
+              code: 'identifier',
+              operator: Operator.EQUALS,
+              value: identifier,
+            },
+            {
+              code: 'code',
+              operator: Operator.TEXT,
+              value: query,
+            },
+          ],
+        });
+        if (shouldBeFound) {
+          expect(res.entry?.length).toBe(1);
+          expect(res.entry?.[0].resource?.id).toBe(condWithSpecialChars.id);
+        } else {
+          expect(res.entry?.length).toBe(0);
+        }
+      });
+
+      // differing behavior between token columns and lookup tables
+      test.each<[string, boolean]>([
+        ['|', true],
+        ['|hello|', true],
+        ['.()', false],
+      ])(':text search for %s should match? %s', async (query, shouldBeFound) => {
+        const res = await repo.search<Condition>({
+          resourceType: 'Condition',
+          filters: [
+            {
+              code: 'subject',
+              operator: Operator.EQUALS,
+              value: subject.reference,
+            },
+            {
+              code: 'identifier',
+              operator: Operator.EQUALS,
+              value: identifier,
+            },
+            {
+              code: 'code',
+              operator: Operator.TEXT,
+              value: query,
+            },
+          ],
+        });
+        if (shouldBeFound) {
+          expect(res.entry?.length).toBe(1);
+          expect(res.entry?.[0].resource?.id).toBe(condWithSpecialChars.id);
+        } else {
+          expect(res.entry?.length).toBe(0);
+        }
+      });
+    });
+  });
+  describe('MedicationRequest.code legacy behavior', () => {
+    let repo: Repository;
+    let patient: WithId<Patient>;
+    let mr1: WithId<MedicationRequest>;
+    let mr2: WithId<MedicationRequest>;
+    const sys1 = 'http://sys.one';
+
+    const val1 = 'ABCDEFGHIJ';
+    const val2 = 'ZZZZZZZZZZ';
+
+    beforeAll(async () => {
+      ({ repo } = await createTestProject({ withRepo: true }));
+
+      patient = await repo.createResource<Patient>({ resourceType: 'Patient', name: [{ given: ['Henry'] }] });
+      mr1 = await repo.createResource<MedicationRequest>({
+        resourceType: 'MedicationRequest',
+        status: 'active',
+        intent: 'order',
+        subject: createReference(patient),
+        medicationCodeableConcept: { coding: [{ system: sys1, code: val1 }] },
+      });
+      mr2 = await repo.createResource<MedicationRequest>({
+        resourceType: 'MedicationRequest',
+        status: 'active',
+        intent: 'order',
+        subject: createReference(patient),
+        medicationCodeableConcept: { coding: [{ system: sys1, code: val2 }] },
+      });
+    });
+
+    test('Formerly "legacy" column implementation search params use `token-column` strategy', async () => {
+      const searchParam = getSearchParameter('MedicationRequest', 'code');
+      if (!searchParam) {
+        throw new Error('Could not find MedicationRequest-code search parameter');
+      }
+      const impl = getSearchParameterImplementation('MedicationRequest', searchParam);
+      expect(impl.searchStrategy).toBe('token-column');
+    });
+
+    test('Search by system only works when using token columns', async () => {
+      const searchResult = await repo.search<MedicationRequest>({
+        resourceType: 'MedicationRequest',
         filters: [
           {
             code: 'code',
@@ -771,28 +1298,14 @@ describe('Non-strict mode', () => {
           },
         ],
       });
-      //TODO what is actually the expected behavior here?
-      expect(toIdentifierValues(res)).toContainExactly([]);
-    }));
+      expect(searchResult.entry?.length).toStrictEqual(2);
+      expect(searchResult.entry?.map((e) => e.resource?.id)).toContain(mr1.id);
+      expect(searchResult.entry?.map((e) => e.resource?.id)).toContain(mr2.id);
+    });
 
-  test('Handle malformed value', () =>
-    withTestContext(async () => {
-      const subject = createReference(patient);
-      await nonStrictRepo.createResource<Condition>({
-        resourceType: 'Condition',
-        subject,
-        code: {
-          coding: [
-            {
-              system: 'https://example.com',
-              code: ['test1'] as unknown as string, // Force malformed data
-            },
-          ],
-        },
-      });
-
-      const res = await repo.search<Condition>({
-        resourceType: 'Condition',
+    test('Search by value always works', async () => {
+      const searchResult = await repo.search({
+        resourceType: 'MedicationRequest',
         filters: [
           {
             code: 'code',
@@ -801,609 +1314,104 @@ describe('Non-strict mode', () => {
           },
         ],
       });
-      //TODO what is actually the expected behavior here?
-      expect(toIdentifierValues(res)).toContainExactly([undefined]);
-    }));
-});
-
-describe('Condition.code token queries', () => {
-  let repo: Repository;
-
-  let patient: WithId<Patient>;
-  let subject: Reference<Patient> & { reference: string };
-
-  const conditionNames = [
-    'noCodeNoCat',
-    'noCodeCatOne',
-    'codeOneNoCat',
-    'codeOneCatOne',
-    'codeOneCatTwo',
-    'codeOneWithoutSystemNoCat',
-    'codeTwoWithoutSystemCatTwo',
-  ] as const;
-  type Conditions = (typeof conditionNames)[number];
-  const cond: Record<Conditions, Condition & { id: string }> = {} as Record<Conditions, Condition & { id: string }>;
-
-  const sys1 = 'http://sys.one';
-  const sys2 = 'http://sys.two';
-
-  const val1 = 'ABCDEFGHIJ';
-  const val2 = '0123456789';
-
-  const disp1 = 'The Quick Brown Fox';
-
-  beforeAll(async () => {
-    ({ repo } = await createTestProject({ withRepo: true }));
-
-    patient = await repo.createResource<Patient>({ resourceType: 'Patient', name: [{ given: ['Henry'] }] });
-    subject = createReference(patient);
-
-    const partial = cond as Record<string, Condition>;
-    partial.noCodeNoCat = await repo.createResource<Condition>({
-      resourceType: 'Condition',
-      subject,
-      identifier: [{ value: 'noCodeNoCat' }],
-    });
-    partial.noCodeCatOne = await repo.createResource<Condition>({
-      resourceType: 'Condition',
-      subject,
-      identifier: [{ value: 'noCodeCatOne' }],
-      category: [{ coding: [{ system: sys1, code: val1, display: disp1 }] }],
-    });
-    partial.codeOneNoCat = await repo.createResource<Condition>({
-      resourceType: 'Condition',
-      subject,
-      identifier: [{ value: 'codeOneNoCat' }],
-      code: { coding: [{ system: sys1, code: val1, display: disp1 }] },
-    });
-    partial.codeOneCatOne = await repo.createResource<Condition>({
-      resourceType: 'Condition',
-      subject,
-      identifier: [{ value: 'codeOneCatOne' }],
-      code: { coding: [{ system: sys1, code: val1 }] },
-      category: [{ coding: [{ system: sys1, code: val1 }] }],
-    });
-    partial.codeOneCatTwo = await repo.createResource<Condition>({
-      resourceType: 'Condition',
-      subject,
-      identifier: [{ value: 'codeOneCatTwo' }],
-      code: { coding: [{ system: sys1, code: val1 }] },
-      category: [{ coding: [{ system: sys2, code: val2 }] }],
-    });
-    partial.codeOneWithoutSystemNoCat = await repo.createResource<Condition>({
-      resourceType: 'Condition',
-      subject,
-      identifier: [{ value: 'codeOneWithoutSystemNoCat' }],
-      code: { coding: [{ code: val1 }] },
-    });
-    partial.codeTwoWithoutSystemCatTwo = await repo.createResource<Condition>({
-      resourceType: 'Condition',
-      subject,
-      identifier: [{ value: 'codeTwoWithoutSystemCatTwo' }],
-      code: { coding: [{ code: val2 }] },
-      category: [{ coding: [{ system: sys2, code: val2 }] }],
+      expect(searchResult.entry?.length).toStrictEqual(1);
+      expect(searchResult.entry?.[0]?.resource?.id).toStrictEqual(mr1.id);
     });
 
-    for (const name of conditionNames) {
-      if (!cond[name]?.id) {
-        throw new Error('Condition "' + name + '" not created');
-      }
-      expect(cond[name].identifier?.[0].value).toEqual(name);
-    }
-    expect(Object.keys(cond)).toHaveLength(conditionNames.length);
-  });
-
-  test('Sort by identifier', () =>
-    withTestContext(async () => {
-      const system = randomUUID();
-      await repo.createResource<Patient>({
-        resourceType: 'Patient',
-        name: [{ given: ['Alice'], family: 'None' }],
-        identifier: [{ system }],
-      });
-
-      await repo.createResource<Patient>({
-        resourceType: 'Patient',
-        name: [{ given: ['Alice'], family: 'AAA' }],
-        identifier: [{ system, value: 'AAA' }],
-      });
-
-      await repo.createResource<Patient>({
-        resourceType: 'Patient',
-        name: [{ given: ['Alice'], family: 'ZZZ' }],
-        identifier: [{ system, value: 'ZZZ' }],
-      });
-
-      const ascending = await repo.search<Patient>({
-        resourceType: 'Patient',
-        filters: [{ code: 'identifier', operator: Operator.EQUALS, value: system + '|' }],
-        sortRules: [{ code: 'identifier', descending: false }],
-      });
-      expect(ascending.entry?.map((e) => e.resource?.name?.[0]?.family)).toStrictEqual(['AAA', 'ZZZ', 'None']);
-
-      const descending = await repo.search<Patient>({
-        resourceType: 'Patient',
-        filters: [{ code: 'identifier', operator: Operator.EQUALS, value: system + '|' }],
-        sortRules: [{ code: 'identifier', descending: true }],
-      });
-      expect(descending.entry?.map((e) => e.resource?.name?.[0]?.family)).toStrictEqual(['None', 'ZZZ', 'AAA']);
-    }));
-
-  test('Sort by identifier with multiple values', () =>
-    withTestContext(async () => {
-      const system = randomUUID();
-      await repo.createResource<Patient>({
-        resourceType: 'Patient',
-        name: [{ given: ['Alice'], family: 'First' }],
-        identifier: [
-          { system, value: 'AAA' },
-          { system, value: 'ZZZ' },
-        ],
-      });
-
-      await repo.createResource<Patient>({
-        resourceType: 'Patient',
-        name: [{ given: ['Alice'], family: 'Second' }],
-        identifier: [{ system, value: 'LLL' }],
-      });
-
-      const ascending = await repo.search<Patient>({
-        resourceType: 'Patient',
-        filters: [{ code: 'identifier', operator: Operator.EQUALS, value: system + '|' }],
-        sortRules: [{ code: 'identifier', descending: false }],
-      });
-
-      const descending = await repo.search<Patient>({
-        resourceType: 'Patient',
-        filters: [{ code: 'identifier', operator: Operator.EQUALS, value: system + '|' }],
-        sortRules: [{ code: 'identifier', descending: true }],
-      });
-
-      // Ideally ASC and DESC would have the same sort order since
-      // ascending should use "AAA" and descending should use "ZZZ",
-      // but a simpler sort implementation is used
-      expect(ascending.entry?.map((e) => e.resource?.name?.[0]?.family)).toStrictEqual(['First', 'Second']);
-      expect(descending.entry?.map((e) => e.resource?.name?.[0]?.family)).toStrictEqual(['Second', 'First']);
-    }));
-
-  test.each<[string, Conditions[]]>([
-    [sys1, ['codeOneNoCat', 'codeOneCatOne', 'codeOneCatTwo']],
-    [sys2, []],
-    [val1, []], // incorrectly passing val as a system
-  ])('code by system %s', async (value, expected) => {
-    const res = await repo.search<Condition>({
-      resourceType: 'Condition',
-      filters: [
-        {
-          code: 'code',
-          operator: Operator.EQUALS,
-          value: value + '|',
-        },
-      ],
-    });
-    expect(toIdentifierValues(res)).toContainExactly(expected);
-  });
-
-  test.each<[string, Conditions[]]>([
-    [sys1, []], // incorrectly passing sys as a value
-    [val1, ['codeOneNoCat', 'codeOneCatOne', 'codeOneCatTwo', 'codeOneWithoutSystemNoCat']],
-    [val2, ['codeTwoWithoutSystemCatTwo']],
-  ])('code by value %s', async (value, expected) => {
-    const resEquals = await repo.search<Condition>({
-      resourceType: 'Condition',
-      filters: [
-        {
-          code: 'code',
-          operator: Operator.EQUALS,
-          value,
-        },
-      ],
-    });
-    expect(toIdentifierValues(resEquals)).toContainExactly(expected);
-
-    const resContains = await repo.search<Condition>({
-      resourceType: 'Condition',
-      filters: [
-        {
-          code: 'code',
-          operator: Operator.CONTAINS,
-          value,
-        },
-      ],
-    });
-    expect(toIdentifierValues(resContains)).toContainExactly([]);
-  });
-
-  test.each<[string, string, Conditions[]]>([
-    [sys1, val1, ['codeOneNoCat', 'codeOneCatOne', 'codeOneCatTwo']],
-    [sys1, val2, []],
-    [sys2, val1, []],
-    [sys2, val2, []],
-  ])('code by system and value %s|%s', async (system, value, expected) => {
-    const res = await repo.search<Condition>({
-      resourceType: 'Condition',
-      filters: [
-        {
-          code: 'code',
-          operator: Operator.EQUALS,
-          value: system + '|' + value,
-        },
-      ],
-    });
-    expect(toIdentifierValues(res)).toContainExactly(expected);
-  });
-
-  test.each<[string, Conditions[]]>([
-    [val1, ['codeOneWithoutSystemNoCat']],
-    [val2, ['codeTwoWithoutSystemCatTwo']],
-  ])('code by missing system and value %s', async (value, expected) => {
-    const res = await repo.search<Condition>({
-      resourceType: 'Condition',
-      filters: [
-        {
-          code: 'code',
-          operator: Operator.EQUALS,
-          value: '|' + value,
-        },
-      ],
-    });
-    expect(toIdentifierValues(res)).toContainExactly(expected);
-  });
-
-  test.each<[string, string, Conditions[]]>([
-    [val1, val1, ['codeOneCatOne']],
-    [val1, val2, ['codeOneCatTwo']],
-    [val2, val1, []],
-    [sys1 + '|', val2, ['codeOneCatTwo']],
-    ['|' + val1, val1, []],
-    ['|' + val2, sys2 + '|' + val2, ['codeTwoWithoutSystemCatTwo']],
-  ])('code and category by code=%s category=%s', async (codeValue, categoryValue, expected) => {
-    const res = await repo.search<Condition>({
-      resourceType: 'Condition',
-      filters: [
-        {
-          code: 'code',
-          operator: Operator.EQUALS,
-          value: codeValue,
-        },
-        {
-          code: 'category',
-          operator: Operator.EQUALS,
-          value: categoryValue,
-        },
-      ],
-    });
-    expect(toIdentifierValues(res)).toContainExactly(expected);
-  });
-
-  test.each<string>([val1, val1.slice(0, 3)])('code :contains beginning of value %s', async (value) => {
-    const resContains = await repo.search<Condition>({
-      resourceType: 'Condition',
-      filters: [
-        {
-          code: 'code',
-          operator: Operator.CONTAINS,
-          value,
-        },
-      ],
-    });
-    expect(toIdentifierValues(resContains)).toContainExactly([]);
-  });
-
-  test.each<[string]>([[val1.slice(1, 3)], [val2.slice(1, 3)]])(`code :contains middle of value %s`, async (value) => {
-    const resContains = await repo.search<Condition>({
-      resourceType: 'Condition',
-      filters: [
-        {
-          code: 'code',
-          operator: Operator.CONTAINS,
-          value,
-        },
-      ],
-    });
-    // Token columns don't support :contains on `code`
-    // Token lookup tables don't support infix queries
-    expect(toIdentifierValues(resContains).length).toBe(0);
-  });
-
-  test.each<[string, Conditions[]]>([
-    [disp1, ['codeOneNoCat']],
-    [disp1.split(' ').slice(0, 2).join(' '), ['codeOneNoCat']],
-    [disp1.split(' ').slice(1, 3).join(' '), ['codeOneNoCat']],
-    [disp1.split(' ').slice(-2).join(' '), ['codeOneNoCat']],
-  ])('code :text %s', async (value, expected) => {
-    const resContains = await repo.search<Condition>({
-      resourceType: 'Condition',
-      filters: [
-        {
-          code: 'code',
-          operator: Operator.TEXT,
-          value,
-        },
-      ],
-    });
-    expect(toIdentifierValues(resContains)).toContainExactly(expected);
-  });
-
-  describe('code :text search for special chars', () => {
-    const identifier = randomUUID();
-    let condWithSpecialChars: WithId<Condition>;
-    beforeAll(async () => {
-      condWithSpecialChars = await repo.createResource<Condition>({
-        resourceType: 'Condition',
-        code: {
-          coding: [
-            {
-              system: sys1,
-              code: 'some-value',
-              display: '.^$*+?()[]{}\\|hello|',
-            },
-          ],
-        },
-        subject,
-        identifier: [
-          {
-            system: sys1,
-            value: identifier,
-          },
-        ],
-      });
-    });
-
-    // same behavior between token columns and lookup tables
-    test.each<[string, boolean]>([
-      ['.', true],
-      ['^', true],
-      ['$', true],
-      ['*', true],
-      ['+', true],
-      ['?', true],
-      ['(', true],
-      [')', true],
-      ['[', true],
-      [']', true],
-      ['{', true],
-      ['}', true],
-      ['\\', true],
-      ['()', true],
-      ['[]', true],
-      ['{}', true],
-
-      ['.^', true],
-      ['.^$*+', true],
-      ['$', true],
-      ['+?', true],
-      [']{', true],
-      ['hello', true],
-
-      ['||', false],
-    ])(':text search for %s should match? %s', async (query, shouldBeFound) => {
-      const res = await repo.search<Condition>({
-        resourceType: 'Condition',
+    test('Search by system and value only works when using token columns', async () => {
+      const searchResult = await repo.search({
+        resourceType: 'MedicationRequest',
         filters: [
           {
-            code: 'subject',
-            operator: Operator.EQUALS,
-            value: subject.reference,
-          },
-          {
-            code: 'identifier',
-            operator: Operator.EQUALS,
-            value: identifier,
-          },
-          {
             code: 'code',
-            operator: Operator.TEXT,
-            value: query,
+            operator: Operator.EQUALS,
+            value: sys1 + '|' + val1,
           },
         ],
       });
-      if (shouldBeFound) {
-        expect(res.entry?.length).toBe(1);
-        expect(res.entry?.[0].resource?.id).toBe(condWithSpecialChars.id);
-      } else {
-        expect(res.entry?.length).toBe(0);
-      }
+      expect(searchResult.entry?.length).toStrictEqual(1);
+      expect(searchResult.entry?.[0]?.resource?.id).toStrictEqual(mr1.id);
     });
 
-    // differing behavior between token columns and lookup tables
-    test.each<[string, boolean]>([
-      ['|', true],
-      ['|hello|', true],
-      ['.()', false],
-    ])(':text search for %s should match? %s', async (query, shouldBeFound) => {
-      const res = await repo.search<Condition>({
-        resourceType: 'Condition',
+    test('Sort by code always works', async () => {
+      const ascResult = await repo.search<MedicationRequest>({
+        resourceType: 'MedicationRequest',
         filters: [
           {
-            code: 'subject',
+            code: 'patient',
             operator: Operator.EQUALS,
-            value: subject.reference,
-          },
-          {
-            code: 'identifier',
-            operator: Operator.EQUALS,
-            value: identifier,
-          },
-          {
-            code: 'code',
-            operator: Operator.TEXT,
-            value: query,
+            value: patient.id,
           },
         ],
+        sortRules: [{ code: 'code', descending: false }],
       });
-      if (shouldBeFound) {
-        expect(res.entry?.length).toBe(1);
-        expect(res.entry?.[0].resource?.id).toBe(condWithSpecialChars.id);
-      } else {
-        expect(res.entry?.length).toBe(0);
+      expect(ascResult.entry?.length).toStrictEqual(2);
+      expect(ascResult.entry?.map((e) => e.resource?.id)).toContain(mr1.id);
+      expect(ascResult.entry?.map((e) => e.resource?.id)).toContain(mr2.id);
+      expect(ascResult.entry?.map((e) => e.resource?.medicationCodeableConcept?.coding?.[0]?.code)).toStrictEqual([
+        'ABCDEFGHIJ',
+        'ZZZZZZZZZZ',
+      ]);
+
+      const descResult = await repo.search<MedicationRequest>({
+        resourceType: 'MedicationRequest',
+        filters: [
+          {
+            code: 'patient',
+            operator: Operator.EQUALS,
+            value: patient.id,
+          },
+        ],
+        sortRules: [{ code: 'code', descending: true }],
+      });
+      expect(descResult.entry?.length).toStrictEqual(2);
+      expect(descResult.entry?.map((e) => e.resource?.id)).toContain(mr1.id);
+      expect(descResult.entry?.map((e) => e.resource?.id)).toContain(mr2.id);
+      expect(descResult.entry?.map((e) => e.resource?.medicationCodeableConcept?.coding?.[0]?.code)).toStrictEqual([
+        'ZZZZZZZZZZ',
+        'ABCDEFGHIJ',
+      ]);
+    });
+  });
+
+  describe('buildTokens', () => {
+    beforeAll(() => {
+      loadStructureDefinitions();
+    });
+
+    test('empty resource', () => {
+      const identifierSearchParam = getSearchParameter('Patient', 'identifier');
+      if (!identifierSearchParam) {
+        throw new Error('Could not find identifier search parameter');
       }
+      const r1: WithId<Patient> = {
+        resourceType: 'Patient',
+        id: '1',
+        identifier: undefined,
+      };
+      const result1: Token[] = [];
+      buildTokensForSearchParameter(result1, r1, identifierSearchParam);
+      expect(result1).toStrictEqual([]);
+
+      const validIdentifiers: Identifier[] = [
+        {},
+        { system: 'http://example.com', value: '123' },
+        { system: 'http://example.com', value: '123' },
+        { system: 'http://example.com', value: '456' },
+        { use: 'official' },
+      ];
+      const r2: WithId<Patient> = {
+        resourceType: 'Patient',
+        id: '2',
+        identifier: [null, undefined, ...validIdentifiers] as unknown as Identifier[],
+      };
+      const result2: Token[] = [];
+      buildTokensForSearchParameter(result2, r2, identifierSearchParam);
+      expect(result2).toStrictEqual([
+        { code: 'identifier', system: 'http://example.com', value: '123' },
+        { code: 'identifier', system: 'http://example.com', value: '456' },
+      ]);
     });
-  });
-});
-describe('MedicationRequest.code legacy behavior', () => {
-  let repo: Repository;
-  let patient: WithId<Patient>;
-  let mr1: WithId<MedicationRequest>;
-  let mr2: WithId<MedicationRequest>;
-  const sys1 = 'http://sys.one';
-
-  const val1 = 'ABCDEFGHIJ';
-  const val2 = 'ZZZZZZZZZZ';
-
-  beforeAll(async () => {
-    ({ repo } = await createTestProject({ withRepo: true }));
-
-    patient = await repo.createResource<Patient>({ resourceType: 'Patient', name: [{ given: ['Henry'] }] });
-    mr1 = await repo.createResource<MedicationRequest>({
-      resourceType: 'MedicationRequest',
-      status: 'active',
-      intent: 'order',
-      subject: createReference(patient),
-      medicationCodeableConcept: { coding: [{ system: sys1, code: val1 }] },
-    });
-    mr2 = await repo.createResource<MedicationRequest>({
-      resourceType: 'MedicationRequest',
-      status: 'active',
-      intent: 'order',
-      subject: createReference(patient),
-      medicationCodeableConcept: { coding: [{ system: sys1, code: val2 }] },
-    });
-  });
-
-  test('Formerly "legacy" column implementation search params use `token-column` strategy', async () => {
-    const searchParam = getSearchParameter('MedicationRequest', 'code');
-    if (!searchParam) {
-      throw new Error('Could not find MedicationRequest-code search parameter');
-    }
-    const impl = getSearchParameterImplementation('MedicationRequest', searchParam);
-    expect(impl.searchStrategy).toBe('token-column');
-  });
-
-  test('Search by system only works when using token columns', async () => {
-    const searchResult = await repo.search<MedicationRequest>({
-      resourceType: 'MedicationRequest',
-      filters: [
-        {
-          code: 'code',
-          operator: Operator.EQUALS,
-          value: sys1 + '|',
-        },
-      ],
-    });
-    expect(searchResult.entry?.length).toStrictEqual(2);
-    expect(searchResult.entry?.map((e) => e.resource?.id)).toContain(mr1.id);
-    expect(searchResult.entry?.map((e) => e.resource?.id)).toContain(mr2.id);
-  });
-
-  test('Search by value always works', async () => {
-    const searchResult = await repo.search({
-      resourceType: 'MedicationRequest',
-      filters: [
-        {
-          code: 'code',
-          operator: Operator.EQUALS,
-          value: val1,
-        },
-      ],
-    });
-    expect(searchResult.entry?.length).toStrictEqual(1);
-    expect(searchResult.entry?.[0]?.resource?.id).toStrictEqual(mr1.id);
-  });
-
-  test('Search by system and value only works when using token columns', async () => {
-    const searchResult = await repo.search({
-      resourceType: 'MedicationRequest',
-      filters: [
-        {
-          code: 'code',
-          operator: Operator.EQUALS,
-          value: sys1 + '|' + val1,
-        },
-      ],
-    });
-    expect(searchResult.entry?.length).toStrictEqual(1);
-    expect(searchResult.entry?.[0]?.resource?.id).toStrictEqual(mr1.id);
-  });
-
-  test('Sort by code always works', async () => {
-    const ascResult = await repo.search<MedicationRequest>({
-      resourceType: 'MedicationRequest',
-      filters: [
-        {
-          code: 'patient',
-          operator: Operator.EQUALS,
-          value: patient.id,
-        },
-      ],
-      sortRules: [{ code: 'code', descending: false }],
-    });
-    expect(ascResult.entry?.length).toStrictEqual(2);
-    expect(ascResult.entry?.map((e) => e.resource?.id)).toContain(mr1.id);
-    expect(ascResult.entry?.map((e) => e.resource?.id)).toContain(mr2.id);
-    expect(ascResult.entry?.map((e) => e.resource?.medicationCodeableConcept?.coding?.[0]?.code)).toStrictEqual([
-      'ABCDEFGHIJ',
-      'ZZZZZZZZZZ',
-    ]);
-
-    const descResult = await repo.search<MedicationRequest>({
-      resourceType: 'MedicationRequest',
-      filters: [
-        {
-          code: 'patient',
-          operator: Operator.EQUALS,
-          value: patient.id,
-        },
-      ],
-      sortRules: [{ code: 'code', descending: true }],
-    });
-    expect(descResult.entry?.length).toStrictEqual(2);
-    expect(descResult.entry?.map((e) => e.resource?.id)).toContain(mr1.id);
-    expect(descResult.entry?.map((e) => e.resource?.id)).toContain(mr2.id);
-    expect(descResult.entry?.map((e) => e.resource?.medicationCodeableConcept?.coding?.[0]?.code)).toStrictEqual([
-      'ZZZZZZZZZZ',
-      'ABCDEFGHIJ',
-    ]);
-  });
-});
-
-describe('buildTokens', () => {
-  beforeAll(() => {
-    loadStructureDefinitions();
-  });
-
-  test('empty resource', () => {
-    const identifierSearchParam = getSearchParameter('Patient', 'identifier');
-    if (!identifierSearchParam) {
-      throw new Error('Could not find identifier search parameter');
-    }
-    const r1: WithId<Patient> = {
-      resourceType: 'Patient',
-      id: '1',
-      identifier: undefined,
-    };
-    const result1: Token[] = [];
-    buildTokensForSearchParameter(result1, r1, identifierSearchParam);
-    expect(result1).toStrictEqual([]);
-
-    const validIdentifiers: Identifier[] = [
-      {},
-      { system: 'http://example.com', value: '123' },
-      { system: 'http://example.com', value: '123' },
-      { system: 'http://example.com', value: '456' },
-      { use: 'official' },
-    ];
-    const r2: WithId<Patient> = {
-      resourceType: 'Patient',
-      id: '2',
-      identifier: [null, undefined, ...validIdentifiers] as unknown as Identifier[],
-    };
-    const result2: Token[] = [];
-    buildTokensForSearchParameter(result2, r2, identifierSearchParam);
-    expect(result2).toStrictEqual([
-      { code: 'identifier', system: 'http://example.com', value: '123' },
-      { code: 'identifier', system: 'http://example.com', value: '456' },
-    ]);
   });
 });
 

--- a/packages/server/src/migrations/data/types.ts
+++ b/packages/server/src/migrations/data/types.ts
@@ -3,7 +3,7 @@
 import type { WithId } from '@medplum/core';
 import type { AsyncJob } from '@medplum/fhirtypes';
 import type { Job } from 'bullmq';
-import type { Repository } from '../../fhir/repo';
+import type { SystemRepository } from '../../fhir/repo';
 import type { PhasalMigration } from '../types';
 
 export interface PostDeployJobData {
@@ -32,7 +32,7 @@ export interface PostDeployMigration<T extends PostDeployJobData = PostDeployJob
    * 'ineligible' if the processor decided it was not capable of running the job, typically
    *            due to being an outdated version of Medplum.
    */
-  run(repo: Repository, job: Job<T> | undefined, data: T): Promise<PostDeployJobRunResult>;
+  run(repo: SystemRepository, job: Job<T> | undefined, data: T): Promise<PostDeployJobRunResult>;
 }
 
 // Custom Jobs

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -43,7 +43,8 @@ import { getUserConfiguration } from '../auth/me';
 import { getConfig } from '../config/loader';
 import { getAccessPolicyForLogin, getRepoForLogin } from '../fhir/accesspolicy';
 import type { Repository, SystemRepository } from '../fhir/repo';
-import { getGlobalSystemRepo, getProjectSystemRepo } from '../fhir/repo';
+import { getGlobalSystemRepo, getProjectSystemRepo, getShardSystemRepo } from '../fhir/repo';
+import { TODO_SHARD_ID } from '../fhir/sharding';
 import type { SmartScope } from '../fhir/smart';
 import { parseSmartScopes } from '../fhir/smart';
 import { getLogger } from '../logger';
@@ -1124,7 +1125,7 @@ export async function getLoginForBasicAuth(req: Request, token: string): Promise
 }
 
 async function makeAuthResult(
-  systemRepo: Repository,
+  systemRepo: SystemRepository,
   req: Request | IncomingMessage | undefined,
   login: Login,
   project: WithId<Project>,
@@ -1331,7 +1332,10 @@ async function tryExternalAuthLogin(
     }
 
     // Search for the profile
-    const profile = await systemRepo.searchOne<ProfileResource>(searchRequest);
+    // SHARDING there's no project context here and feels like a legitimate gap in
+    // the current external auth flow. Will need to require projectId be in the request path
+    const projectSystemRepo = getShardSystemRepo(TODO_SHARD_ID);
+    const profile = await projectSystemRepo.searchOne<ProfileResource>(searchRequest);
     if (!profile) {
       return undefined;
     }

--- a/packages/server/src/seed.test.ts
+++ b/packages/server/src/seed.test.ts
@@ -9,8 +9,9 @@ import { DatabaseMode, getDatabasePool } from './database';
 import type { OutputAction } from './fhir/operations/db-configure-indexes';
 import { configureGinIndexes, vacuumTable } from './fhir/operations/db-configure-indexes';
 import type { SystemRepository } from './fhir/repo';
-import { getGlobalSystemRepo } from './fhir/repo';
+import { getShardSystemRepo } from './fhir/repo';
 import { repoAccess } from './fhir/repository/access-tracker';
+import { PLACEHOLDER_SHARD_ID } from './fhir/sharding';
 import { SelectQuery } from './fhir/sql';
 import { globalLogger } from './logger';
 import { getPostDeployVersion, getPreDeployVersion } from './migration-sql';
@@ -79,7 +80,7 @@ describe('Seed', () => {
     globalLogger.write(`${new Date().toISOString()} - Initializing app services`);
     await initAppServices(config);
 
-    const repo = getGlobalSystemRepo();
+    const repo = getShardSystemRepo(PLACEHOLDER_SHARD_ID);
     // Run post-deploy migrations synchronously
     await synchronouslyRunAllPendingPostDeployMigrations(repo);
 

--- a/packages/server/src/seeds/searchparameters.ts
+++ b/packages/server/src/seeds/searchparameters.ts
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { rebuildBaseDefinitions } from '../fhir/operations/rebuild-base-definitions';
-import type { Repository } from '../fhir/repo';
+import type { SystemRepository } from '../fhir/repo';
 
 /**
  * Creates all SearchParameter resources.
  * @param systemRepo - The system repository to use
  */
-export async function rebuildR4SearchParameters(systemRepo: Repository): Promise<void> {
+export async function rebuildR4SearchParameters(systemRepo: SystemRepository): Promise<void> {
   await rebuildBaseDefinitions(systemRepo, ['SearchParameter']);
 }

--- a/packages/server/src/seeds/structuredefinitions.ts
+++ b/packages/server/src/seeds/structuredefinitions.ts
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { rebuildBaseDefinitions } from '../fhir/operations/rebuild-base-definitions';
-import type { Repository } from '../fhir/repo';
+import type { SystemRepository } from '../fhir/repo';
 
 /**
  * Creates all StructureDefinition resources.
  * @param systemRepo - The system repository to use
  */
-export async function rebuildR4StructureDefinitions(systemRepo: Repository): Promise<void> {
+export async function rebuildR4StructureDefinitions(systemRepo: SystemRepository): Promise<void> {
   await rebuildBaseDefinitions(systemRepo, ['StructureDefinition', 'OperationDefinition']);
 }

--- a/packages/server/src/seeds/valuesets.ts
+++ b/packages/server/src/seeds/valuesets.ts
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { rebuildBaseDefinitions } from '../fhir/operations/rebuild-base-definitions';
-import type { Repository } from '../fhir/repo';
+import type { SystemRepository } from '../fhir/repo';
 
 /**
  * Imports all built-in ValueSets and CodeSystems into the database.
  * @param systemRepo - The system repository to use
  */
-export async function rebuildR4ValueSets(systemRepo: Repository): Promise<void> {
+export async function rebuildR4ValueSets(systemRepo: SystemRepository): Promise<void> {
   await rebuildBaseDefinitions(systemRepo, ['CodeSystem', 'ValueSet']);
 }

--- a/packages/server/src/storage/routes.test.ts
+++ b/packages/server/src/storage/routes.test.ts
@@ -9,7 +9,7 @@ import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
-import { getGlobalSystemRepo } from '../fhir/repo';
+import { getTestProjectSystemRepo } from '../fhir/repository/test-utils';
 import { createTestProject, withTestContext } from '../test.setup';
 import { getBinaryStorage } from './loader';
 
@@ -18,7 +18,7 @@ let config: MedplumServerConfig;
 let binary: Binary;
 
 describe('Storage Routes', () => {
-  const systemRepo = getGlobalSystemRepo();
+  const systemRepo = getTestProjectSystemRepo();
   beforeAll(async () => {
     config = await loadTestConfig();
     await initApp(app, config);
@@ -167,10 +167,10 @@ describe('Storage Routes', () => {
     let projectBinary: Binary;
 
     beforeAll(async () => {
-      const { project } = await createTestProject();
+      const { project, repo } = await createTestProject({ withRepo: true });
       projectId = project.id;
       projectBinary = await withTestContext(async () => {
-        return systemRepo.createResource<Binary>({
+        return repo.createResource<Binary>({
           resourceType: 'Binary',
           contentType: ContentType.TEXT,
           meta: { project: projectId },

--- a/packages/server/src/storage/routes.ts
+++ b/packages/server/src/storage/routes.ts
@@ -9,7 +9,8 @@ import { createPrivateKey, createPublicKey, createVerify } from 'node:crypto';
 import { pipeline } from 'node:stream';
 import { promisify } from 'node:util';
 import { getConfig } from '../config/loader';
-import { getGlobalSystemRepo, getProjectSystemRepo } from '../fhir/repo';
+import { getProjectSystemRepo, getShardSystemRepo } from '../fhir/repo';
+import { TODO_SHARD_ID } from '../fhir/sharding';
 import { getBinaryStorage } from './loader';
 
 export const storageRouter = Router();
@@ -86,7 +87,8 @@ async function verifyAndLoadBinary(req: Request, res: Response, method: 'GET' | 
 
   const id = singularize(req.params.id) ?? '';
   const projectId = originalUrl.searchParams.get('Project');
-  const systemRepo = projectId ? await getProjectSystemRepo(projectId) : getGlobalSystemRepo();
+  // SHARDING: Drop support for URLs without Project: https://github.com/medplum/medplum/issues/10451
+  const systemRepo = projectId ? await getProjectSystemRepo(projectId) : getShardSystemRepo(TODO_SHARD_ID);
   return systemRepo.readResource<Binary>('Binary', id);
 }
 

--- a/packages/server/src/test.setup.ts
+++ b/packages/server/src/test.setup.ts
@@ -46,6 +46,8 @@ import { requestContextStore } from './request-context-store';
 // supertest v7 can cause websocket tests to hang without this
 setDefaultResultOrder('ipv4first');
 
+Error.stackTraceLimit = 20;
+
 // Many integration tests call initApp/shutdownApp in quick succession (e.g. resource-cap.test.ts
 // does both in beforeEach/afterEach). Without serialization, shutdown can overlap the next init,
 // leaving the DB pool or Redis in a bad state and causing intermittent HTTP failures in later tests.

--- a/packages/server/src/workers/batch.ts
+++ b/packages/server/src/workers/batch.ts
@@ -221,7 +221,7 @@ async function addBatchJobData(jobData: BatchJobData): Promise<Job<BatchJobData>
 }
 
 export async function queueBatchProcessing(bundle: Bundle, asyncJob: WithId<AsyncJob>): Promise<Job<BatchJobData>> {
-  const { authentication: authState, requestId, traceId } = getAuthenticatedContext();
+  const { authState, requestId, traceId } = getAuthenticatedContext();
   // Persist the (potentially large) input bundle to durable object storage rather than carrying it
   // in the BullMQ job data (see https://github.com/medplum/medplum/issues/9124). The worker loads
   // it on the first run to preprocess.
@@ -241,7 +241,7 @@ export async function queueLegacyBatchProcessing(
   bundle: Bundle,
   asyncJob: WithId<AsyncJob>
 ): Promise<Job<BatchJobData>> {
-  const { authentication: authState, requestId, traceId } = getAuthenticatedContext();
+  const { authState, requestId, traceId } = getAuthenticatedContext();
   const jobData: LegacyBatchJobData = { asyncJob, bundle, authState, requestId, traceId };
   return addBatchJobData(jobData);
 }

--- a/packages/server/src/workers/cron.test.ts
+++ b/packages/server/src/workers/cron.test.ts
@@ -27,6 +27,7 @@ import * as executeModule from '../bots/execute';
 import { loadTestConfig } from '../config/loader';
 import type { SystemRepository } from '../fhir/repo';
 import { Repository } from '../fhir/repo';
+import { PLACEHOLDER_SHARD_ID } from '../fhir/sharding';
 import { getBinaryStorage } from '../storage/loader';
 import type { TestProjectResult } from '../test.setup';
 import { createTestProject, withTestContext } from '../test.setup';
@@ -44,13 +45,9 @@ describe('Cron Worker', () => {
     await initAppServices(config);
 
     // Create a project
-    const botProjectDetails = await createTestProject({ withClient: true });
+    const botProjectDetails = await createTestProject({ withClient: true, withRepo: true });
     botProject = botProjectDetails.project;
-    botRepo = new Repository({
-      extendedMode: true,
-      projects: [botProjectDetails.project],
-      author: createReference(botProjectDetails.client),
-    });
+    botRepo = botProjectDetails.repo;
     systemRepo = botRepo.getSystemRepo();
   });
 
@@ -69,6 +66,7 @@ describe('Cron Worker', () => {
         cronTiming: {
           repeat: {
             period: 30,
+            periodUnit: 'd',
             dayOfWeek: ['mon', 'wed', 'fri'],
           },
         },
@@ -138,6 +136,7 @@ describe('Cron Worker', () => {
         cronTiming: {
           repeat: {
             period: 30,
+            periodUnit: 'd',
             dayOfWeek: ['mon', 'wed', 'fri'],
           },
         },
@@ -150,6 +149,7 @@ describe('Cron Worker', () => {
         cronTiming: {
           repeat: {
             period: 10,
+            periodUnit: 'd',
             dayOfWeek: ['mon'],
           },
         },
@@ -179,6 +179,7 @@ describe('Cron Worker', () => {
         cronTiming: {
           repeat: {
             period: 10,
+            periodUnit: 'd',
             dayOfWeek: ['mon'],
           },
         },
@@ -198,17 +199,14 @@ describe('Cron Worker', () => {
       const testProject = await systemRepo.createResource<Project>({
         resourceType: 'Project',
         name: 'Test Project',
-        owner: {
-          reference: 'User/' + randomUUID(),
-        },
+        owner: { reference: 'User/' + randomUUID() },
       });
 
       const repo = new Repository({
+        routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
         extendedMode: true,
         projects: [testProject],
-        author: {
-          reference: 'ClientApplication/' + randomUUID(),
-        },
+        author: { reference: 'ClientApplication/' + randomUUID() },
       });
 
       const bot = await repo.createResource<Bot>({
@@ -217,6 +215,7 @@ describe('Cron Worker', () => {
         cronTiming: {
           repeat: {
             period: 30,
+            periodUnit: 'd',
             dayOfWeek: ['mon', 'wed', 'fri'],
           },
         },
@@ -237,6 +236,7 @@ describe('Cron Worker', () => {
         cronTiming: {
           repeat: {
             period: 30,
+            periodUnit: 'd',
             dayOfWeek: ['mon', 'wed', 'fri'],
           },
         },
@@ -285,20 +285,20 @@ describe('Cron resource', () => {
   let systemRepo: SystemRepository;
   let bot: Bot;
   let botMembership: ProjectMembership;
+  let projectAdminRepo: Repository;
 
   beforeAll(async () => {
     const config = await loadTestConfig();
     await initAppServices(config);
 
-    const details = await createTestProject({ withClient: true, project: { features: ['cron'] } });
-    project = details.project;
-    repo = new Repository({
-      extendedMode: true,
-      // Constraints are only enforced in strict mode; the loose path logs them and moves on
-      strictMode: true,
-      projects: [details.project],
-      author: createReference(details.client),
+    const details = await createTestProject({
+      withClient: true,
+      withRepo: true,
+      project: { features: ['cron'] },
+      membership: { admin: true },
     });
+    project = details.project;
+    repo = details.repo;
     systemRepo = repo.getSystemRepo();
 
     bot = await withTestContext(() => repo.createResource<Bot>({ resourceType: 'Bot', name: 'cron-target' }));
@@ -310,6 +310,16 @@ describe('Cron resource', () => {
         profile: createReference(bot),
       })
     );
+
+    // meta.account is a project admin write, which is also who may author a Cron
+    projectAdminRepo = new Repository({
+      routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
+      extendedMode: true,
+      strictMode: true,
+      projectAdmin: true,
+      projects: [project],
+      author: createReference(bot),
+    });
   });
 
   afterAll(async () => {
@@ -493,12 +503,13 @@ describe('Cron resource', () => {
       const queue = getCronQueue() as any;
       queue.upsertJobScheduler.mockClear();
 
-      const plain = await createTestProject({ withClient: true, project: { features: [] } });
-      const plainRepo = new Repository({
-        extendedMode: true,
-        projects: [plain.project],
-        author: createReference(plain.client),
+      const plain = await createTestProject({
+        withClient: true,
+        withRepo: true,
+        project: { features: [] },
+        membership: { admin: true },
       });
+      const plainRepo = plain.repo;
 
       const plainBot = await plainRepo.createResource<Bot>({ resourceType: 'Bot', name: 'ungated-target' });
       const plainMembership = await systemRepo.createResource<ProjectMembership>({
@@ -519,29 +530,17 @@ describe('Cron resource', () => {
       expect(queue.upsertJobScheduler).not.toHaveBeenCalled();
     }));
 
-  // meta.account is a project admin write, which is also who may author a Cron
-  function projectAdminRepo(): Repository {
-    return new Repository({
-      extendedMode: true,
-      strictMode: true,
-      projectAdmin: true,
-      projects: [project],
-      author: createReference(bot),
-    });
-  }
-
   test('The AuditEvent takes its compartments from the Cron, not from the target bot', () =>
     withTestContext(async () => {
-      const adminRepo = projectAdminRepo();
       const botAccount = { reference: 'Organization/' + randomUUID() };
       const cronAccount = { reference: 'Organization/' + randomUUID() };
 
-      const accountedBot = await adminRepo.createResource<Bot>({
+      const accountedBot = await projectAdminRepo.createResource<Bot>({
         resourceType: 'Bot',
         name: 'accounted-target',
         meta: { account: botAccount },
       });
-      const cron = await adminRepo.createResource<Cron>({
+      const cron = await projectAdminRepo.createResource<Cron>({
         ...validCron(),
         targetReference: createReference(accountedBot),
         meta: { account: cronAccount },
@@ -563,14 +562,13 @@ describe('Cron resource', () => {
 
   test('A Cron without compartments does not fall back to the bot', () =>
     withTestContext(async () => {
-      const adminRepo = projectAdminRepo();
       const botAccount = { reference: 'Organization/' + randomUUID() };
-      const accountedBot = await adminRepo.createResource<Bot>({
+      const accountedBot = await projectAdminRepo.createResource<Bot>({
         resourceType: 'Bot',
         name: 'accounted-target-2',
         meta: { account: botAccount },
       });
-      const cron = await adminRepo.createResource<Cron>({
+      const cron = await projectAdminRepo.createResource<Cron>({
         ...validCron(),
         targetReference: createReference(accountedBot),
       });
@@ -646,12 +644,8 @@ describe('Cron resource', () => {
 
   test('Rejects a target bot in an unlinked project', () =>
     withTestContext(async () => {
-      const other = await createTestProject({ withClient: true, project: { features: ['cron'] } });
-      const otherRepo = new Repository({
-        extendedMode: true,
-        projects: [other.project],
-        author: createReference(other.client),
-      });
+      const other = await createTestProject({ withClient: true, withRepo: true, project: { features: ['cron'] } });
+      const otherRepo = other.repo;
       const otherBot = await otherRepo.createResource<Bot>({ resourceType: 'Bot', name: 'other-project-bot' });
 
       await expect(
@@ -675,12 +669,8 @@ describe('Cron resource', () => {
       const queue = getCronQueue() as any;
       queue.upsertJobScheduler.mockClear();
 
-      const other = await createTestProject({ withClient: true });
-      const otherRepo = new Repository({
-        extendedMode: true,
-        projects: [other.project],
-        author: createReference(other.client),
-      });
+      const other = await createTestProject({ withClient: true, withRepo: true });
+      const otherRepo = other.repo;
       const otherBot = await otherRepo.createResource<Bot>({ resourceType: 'Bot', name: 'never-scheduled' });
 
       await expect(
@@ -766,13 +756,13 @@ describe('Cron resource', () => {
   test('execBot skips a job whose project lost the cron feature, but keeps its schedule', () =>
     withTestContext(async () => {
       // A project of its own, so turning the feature off does not disturb the shared one
-      const gated = await createTestProject({ withClient: true, project: { features: ['cron'] } });
-      const gatedRepo = new Repository({
-        extendedMode: true,
-        strictMode: true,
-        projects: [gated.project],
-        author: createReference(gated.client),
+      const gated = await createTestProject({
+        withClient: true,
+        withRepo: true,
+        project: { features: ['cron'] },
+        membership: { admin: true },
       });
+      const gatedRepo = gated.repo;
       const gatedBot = await gatedRepo.createResource<Bot>({ resourceType: 'Bot', name: 'gated-target' });
       const gatedMembership = await systemRepo.createResource<ProjectMembership>({
         resourceType: 'ProjectMembership',
@@ -818,6 +808,7 @@ describe('Cron across linked projects', () => {
   // Mirrors the repo `getRepoForLogin` builds for a project that links another
   function customerRepoFor(customer: TestProjectResult<{ withClient: true }>, linked: WithId<Project>): Repository {
     return new Repository({
+      routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
       extendedMode: true,
       strictMode: true,
       projects: [customer.project, linked],
@@ -848,13 +839,9 @@ describe('Cron across linked projects', () => {
     const config = await loadTestConfig();
     await initAppServices(config);
 
-    const shared = await createTestProject({ withClient: true });
+    const shared = await createTestProject({ withClient: true, withRepo: true });
     sharedProject = shared.project;
-    const sharedRepo = new Repository({
-      extendedMode: true,
-      projects: [shared.project],
-      author: createReference(shared.client),
-    });
+    const sharedRepo = shared.repo;
     systemRepo = sharedRepo.getSystemRepo();
     sharedBot = await withTestContext(() =>
       sharedRepo.createResource<Bot>({ resourceType: 'Bot', name: 'marketplace-bot' })
@@ -940,12 +927,12 @@ describe('Cron across linked projects', () => {
 
   test('Rejects a linked bot when the project does not export Bot', () =>
     withTestContext(async () => {
-      const closed = await createTestProject({ withClient: true, project: { exportedResourceType: ['Patient'] } });
-      const closedRepo = new Repository({
-        extendedMode: true,
-        projects: [closed.project],
-        author: createReference(closed.client),
+      const closed = await createTestProject({
+        withClient: true,
+        withRepo: true,
+        project: { exportedResourceType: ['Patient'] },
       });
+      const closedRepo = closed.repo;
       const closedBot = await closedRepo.createResource<Bot>({ resourceType: 'Bot', name: 'unexported-bot' });
 
       const customer = await createTestProject({
@@ -980,12 +967,12 @@ describe('Cron across linked projects', () => {
     [['bots'], ['cron'], true],
   ])('Publisher features %j, customer features %j -> blocked=%s', (sharedFeatures, customerFeatures, blocked) =>
     withTestContext(async () => {
-      const shared = await createTestProject({ withClient: true, project: { features: sharedFeatures as [] } });
-      const publisherRepo = new Repository({
-        extendedMode: true,
-        projects: [shared.project],
-        author: createReference(shared.client),
+      const shared = await createTestProject({
+        withClient: true,
+        withRepo: true,
+        project: { features: sharedFeatures as [] },
       });
+      const publisherRepo = shared.repo;
       const bot = await publisherRepo.createResource<Bot>({ resourceType: 'Bot', name: 'published-bot' });
 
       const customer = await createTestProject({

--- a/packages/server/src/workers/dispatch.test.ts
+++ b/packages/server/src/workers/dispatch.test.ts
@@ -1,14 +1,13 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { DeleteFunctionCommand, LambdaClient, ResourceNotFoundException } from '@aws-sdk/client-lambda';
-import { createReference } from '@medplum/core';
 import type { Bot, Patient } from '@medplum/fhirtypes';
 import type { AwsClientStub } from 'aws-sdk-client-mock';
 import { mockClient } from 'aws-sdk-client-mock';
 import { vi } from 'vitest';
 import { initAppServices, shutdownApp } from '../app';
 import { getConfig, loadTestConfig } from '../config/loader';
-import { Repository } from '../fhir/repo';
+import type { Repository } from '../fhir/repo';
 import { getLogger } from '../logger';
 import { createTestProject, withTestContext } from '../test.setup';
 import { findAndExecDispatchJob } from './test-utils';
@@ -21,12 +20,8 @@ describe('Dispatch Worker', () => {
     const config = await loadTestConfig();
     await initAppServices(config);
 
-    const botProjectDetails = await createTestProject({ withClient: true });
-    botRepo = new Repository({
-      extendedMode: true,
-      projects: [botProjectDetails.project],
-      author: createReference(botProjectDetails.client),
-    });
+    const botProjectDetails = await createTestProject({ withClient: true, withRepo: true });
+    botRepo = botProjectDetails.repo;
   });
 
   afterAll(async () => {

--- a/packages/server/src/workers/post-deploy-migration.test.ts
+++ b/packages/server/src/workers/post-deploy-migration.test.ts
@@ -7,7 +7,8 @@ import { closeWorkers, initWorkers } from '.';
 import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
-import { getGlobalSystemRepo } from '../fhir/repo';
+import { getShardSystemRepo } from '../fhir/repo';
+import { GLOBAL_SHARD_ID } from '../fhir/sharding';
 import { globalLogger } from '../logger';
 import type {
   CustomPostDeployMigration,
@@ -35,7 +36,7 @@ import { queueRegistry } from './utils';
 describe('Post-Deploy Migration Worker', () => {
   let config: MedplumServerConfig;
   let mockRegisteredServers: ServerRegistryInfo[];
-  const systemRepo = getGlobalSystemRepo();
+  const systemRepo = getShardSystemRepo(GLOBAL_SHARD_ID);
 
   beforeAll(async () => {
     config = await loadTestConfig();

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -42,6 +42,7 @@ import { tryGetRequestContext } from '../context';
 import type { SystemRepository } from '../fhir/repo';
 import { Repository } from '../fhir/repo';
 import { setResourceCacheEntry } from '../fhir/repository/resource-cache';
+import { PLACEHOLDER_SHARD_ID } from '../fhir/sharding';
 import * as loggerModule from '../logger';
 import { globalLogger } from '../logger';
 import {
@@ -118,15 +119,16 @@ describe('Subscription Worker', () => {
 
     repo = _repo;
     systemRepo = repo.getSystemRepo();
-    superAdminRepo = new Repository({ extendedMode: true, superAdmin: true, author: createReference(client) });
+    superAdminRepo = new Repository({
+      routing: { kind: 'project-shard', shardId: PLACEHOLDER_SHARD_ID },
+      extendedMode: true,
+      superAdmin: true,
+      author: createReference(client),
+    });
 
     // Create another project, this one with bots enabled
-    const botProjectDetails = await createTestProject({ withClient: true });
-    botRepo = new Repository({
-      extendedMode: true,
-      projects: [botProjectDetails.project],
-      author: createReference(botProjectDetails.client),
-    });
+    const botProjectDetails = await createTestProject({ withClient: true, withRepo: true });
+    botRepo = botProjectDetails.repo;
 
     mockLambdaClient = mockClient(LambdaClient);
     mockLambdaClient.on(InvokeCommand).callsFake(({ Payload }) => {

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -671,7 +671,7 @@ export async function execSubscriptionJob(job: Job<SubscriptionJobData>): Promis
     if (subscription.channel?.endpoint?.startsWith('Bot/')) {
       await execBot(systemRepo, job, subscription, rewrittenResource, job.data.interaction, job.data.requestTime);
     } else {
-      await sendRestHook(job, subscription, rewrittenResource, job.data.interaction, job.data.requestTime);
+      await sendRestHook(systemRepo, job, subscription, rewrittenResource, job.data.interaction, job.data.requestTime);
     }
     // Success - reset the failure counter
     await clearSubscriptionFailures(subscription.id);
@@ -722,6 +722,7 @@ async function tryGetCurrentVersion<T extends Resource = Resource>(
 
 /**
  * Sends a rest-hook subscription.
+ * @param systemRepo - The system repository.
  * @param job - The subscription job details.
  * @param subscription - The subscription.
  * @param resource - The resource that triggered the subscription.
@@ -729,6 +730,7 @@ async function tryGetCurrentVersion<T extends Resource = Resource>(
  * @param requestTime - The request time.
  */
 async function sendRestHook(
+  systemRepo: SystemRepository,
   job: Job<SubscriptionJobData>,
   subscription: WithId<Subscription>,
   resource: Resource,
@@ -749,12 +751,6 @@ async function sendRestHook(
 
   const fetchStartTime = Date.now();
   let fetchEndTime: number;
-  let systemRepo: SystemRepository;
-  if (subscription.meta?.project) {
-    systemRepo = await getProjectSystemRepo(subscription.meta.project);
-  } else {
-    systemRepo = getGlobalSystemRepo(); // SHARDING is global correct if no project?
-  }
   try {
     log.info('Sending rest hook', {
       url,

--- a/packages/server/src/ws/subscriptions.test.ts
+++ b/packages/server/src/ws/subscriptions.test.ts
@@ -26,8 +26,7 @@ import { loadTestConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
 import type * as Constants from '../constants';
 import { WEBSOCKET_SUB_PUBLISH_CHANNEL } from '../constants';
-import type { SystemRepository } from '../fhir/repo';
-import { Repository } from '../fhir/repo';
+import type { Repository, SystemRepository } from '../fhir/repo';
 import type * as FhirRewrite from '../fhir/rewrite';
 import { globalLogger } from '../logger';
 import * as keysModule from '../oauth/keys';
@@ -1974,19 +1973,13 @@ describe('Subscription Heartbeat', () => {
       createTestProject({
         project: { features: ['websocket-subscriptions'] },
         withAccessToken: true,
+        withRepo: true,
       })
     );
 
     project = result.project;
+    repo = result.repo;
     accessToken = result.accessToken;
-
-    repo = new Repository({
-      extendedMode: true,
-      projects: [project],
-      author: {
-        reference: 'ClientApplication/' + randomUUID(),
-      },
-    });
 
     await new Promise<void>((resolve) => {
       server.listen(0, 'localhost', 8521, resolve);


### PR DESCRIPTION
Fixes #10442 in a log-only way on prod and errors thrown in test environments. Enabling in tests exposed a lot of places in code that were non-conformant which were addressed.

tl;dr `getGlobalSystemRepo()` is now meaningfully different from `getShardSystemRepo(GLOBAL_SHARD_ID)`. Attempting to intereact with non-global resource types through it logs and will eventually throw after all log instances have been burned down.
