### PR TITLE
Route WebSocket subscriptions on project-scoped URLs

### DIFF
--- a/packages/server/src/ws/routes.ts
+++ b/packages/server/src/ws/routes.ts
@@ -9,6 +9,7 @@ import { getConfig } from '../config/loader';
 import { RequestContext } from '../context';
 import { globalLogger } from '../logger';
 import { requestContextStore } from '../request-context-store';
+import { getNormalizedPath } from '../util/url';
 import { handleAgentConnection, stopAgentHeartbeat } from './agent';
 import { handleAiRealtimeConnection, stopAiRealtimeHeartbeat } from './ai-realtime';
 import { handleEchoConnection, initEchoHeartbeat, stopEchoHeartbeat } from './echo';
@@ -116,8 +117,16 @@ export function initWebSockets(server: http.Server): void {
   initEchoHeartbeat();
 }
 
+/**
+ * Returns the handler key for a WebSocket upgrade request.
+ *
+ * The URL is normalized first so that the `/api` and `/projects/{projectId}` mount prefixes used by
+ * the HTTP API resolve to the same handler as the bare path.
+ * @param path - The upgrade request URL.
+ * @returns The handler key, e.g. `subscriptions-r4`.
+ */
 function getWebSocketPath(path: string): string {
-  return path.split('/').filter(Boolean)[1];
+  return getNormalizedPath(path).split('/').filter(Boolean)[1];
 }
 
 /**

--- a/packages/server/src/ws/subscriptions.test.ts
+++ b/packages/server/src/ws/subscriptions.test.ts
@@ -92,7 +92,7 @@ vi.mock('../oauth/utils', async (importOriginal) => {
 describe('WebSocket Subscription', () => {
   let config: MedplumServerConfig;
   let server: Server;
-  let project: Project;
+  let project: WithId<Project>;
   let repo: Repository;
   let app: Express;
   let accessToken: string;
@@ -204,11 +204,7 @@ describe('WebSocket Subscription', () => {
           while (!subActive) {
             await sleep(0);
             subActive =
-              (await isSubscriptionActive(
-                project.id as string,
-                'Patient',
-                `Subscription/${patientSubscription?.id}`
-              )) === 1;
+              (await isSubscriptionActive(project.id, 'Patient', `Subscription/${patientSubscription?.id}`)) === 1;
           }
           expect(subActive).toStrictEqual(true);
         })
@@ -242,8 +238,7 @@ describe('WebSocket Subscription', () => {
       while (subActive || inCache) {
         await sleep(0);
         subActive =
-          (await isSubscriptionActive(project.id as string, 'Patient', `Subscription/${patientSubscription?.id}`)) ===
-          1;
+          (await isSubscriptionActive(project.id, 'Patient', `Subscription/${patientSubscription?.id}`)) === 1;
         try {
           await repo.readResource<Subscription>('Subscription', patientSubscription?.id);
           inCache = true;
@@ -336,11 +331,7 @@ describe('WebSocket Subscription', () => {
           while (!subActive) {
             await sleep(0);
             subActive =
-              (await isSubscriptionActive(
-                project.id as string,
-                'Patient',
-                `Subscription/${patientSubscription?.id}`
-              )) === 1;
+              (await isSubscriptionActive(project.id, 'Patient', `Subscription/${patientSubscription?.id}`)) === 1;
           }
           expect(subActive).toStrictEqual(true);
         })
@@ -367,11 +358,7 @@ describe('WebSocket Subscription', () => {
           while (subActive) {
             await sleep(0);
             subActive =
-              (await isSubscriptionActive(
-                project.id as string,
-                'Patient',
-                `Subscription/${patientSubscription?.id}`
-              )) === 1;
+              (await isSubscriptionActive(project.id, 'Patient', `Subscription/${patientSubscription?.id}`)) === 1;
           }
           expect(subActive).toStrictEqual(false);
         })
@@ -452,11 +439,9 @@ describe('WebSocket Subscription', () => {
           let observationActive = false;
           while (!patientActive || !observationActive) {
             await sleep(0);
-            patientActive =
-              (await isSubscriptionActive(project.id as string, 'Patient', `Subscription/${patientSub.id}`)) === 1;
+            patientActive = (await isSubscriptionActive(project.id, 'Patient', `Subscription/${patientSub.id}`)) === 1;
             observationActive =
-              (await isSubscriptionActive(project.id as string, 'Observation', `Subscription/${observationSub.id}`)) ===
-              1;
+              (await isSubscriptionActive(project.id, 'Observation', `Subscription/${observationSub.id}`)) === 1;
           }
           expect(patientActive).toStrictEqual(true);
           expect(observationActive).toStrictEqual(true);
@@ -469,11 +454,9 @@ describe('WebSocket Subscription', () => {
           let observationActive = true;
           while (patientActive || observationActive) {
             await sleep(0);
-            patientActive =
-              (await isSubscriptionActive(project.id as string, 'Patient', `Subscription/${patientSub.id}`)) === 1;
+            patientActive = (await isSubscriptionActive(project.id, 'Patient', `Subscription/${patientSub.id}`)) === 1;
             observationActive =
-              (await isSubscriptionActive(project.id as string, 'Observation', `Subscription/${observationSub.id}`)) ===
-              1;
+              (await isSubscriptionActive(project.id, 'Observation', `Subscription/${observationSub.id}`)) === 1;
           }
           expect(patientActive).toStrictEqual(false);
           expect(observationActive).toStrictEqual(false);
@@ -660,8 +643,7 @@ describe('WebSocket Subscription', () => {
           let subActive = false;
           while (!subActive) {
             await sleep(0);
-            subActive =
-              (await isSubscriptionActive(project.id as string, 'Patient', `Subscription/${subscription.id}`)) === 1;
+            subActive = (await isSubscriptionActive(project.id, 'Patient', `Subscription/${subscription.id}`)) === 1;
           }
           // Publish a v1 payload (array of [resource, subscriptionId, options] tuples)
           const v1Payload = [[patient, subscription.id, { includeResource: true }]];
@@ -728,8 +710,7 @@ describe('WebSocket Subscription', () => {
           let subActive = false;
           while (!subActive) {
             await sleep(0);
-            subActive =
-              (await isSubscriptionActive(project.id as string, 'Patient', `Subscription/${subscription.id}`)) === 1;
+            subActive = (await isSubscriptionActive(project.id, 'Patient', `Subscription/${subscription.id}`)) === 1;
           }
           // Publish a v2 payload ({ resource, events: [[subscriptionId, options]] })
           const v2Payload = { resource: patient, events: [[subscription.id, { includeResource: true }]] };
@@ -824,10 +805,8 @@ describe('WebSocket Subscription', () => {
           let sub2Active = false;
           while (!sub1Active || !sub2Active) {
             await sleep(0);
-            sub1Active =
-              (await isSubscriptionActive(project.id as string, 'Patient', `Subscription/${subscription1.id}`)) === 1;
-            sub2Active =
-              (await isSubscriptionActive(project.id as string, 'Patient', `Subscription/${subscription2.id}`)) === 1;
+            sub1Active = (await isSubscriptionActive(project.id, 'Patient', `Subscription/${subscription1.id}`)) === 1;
+            sub2Active = (await isSubscriptionActive(project.id, 'Patient', `Subscription/${subscription2.id}`)) === 1;
           }
           // Publish a single v2 payload with both subscriptions in the events array
           const v2Payload = {
@@ -958,11 +937,7 @@ describe('WebSocket Subscription', () => {
           while (!subActive) {
             await sleep(0);
             subActive =
-              (await isSubscriptionActive(
-                project.id as string,
-                'DocumentReference',
-                `Subscription/${subscription.id}`
-              )) === 1;
+              (await isSubscriptionActive(project.id, 'DocumentReference', `Subscription/${subscription.id}`)) === 1;
           }
           expect(subActive).toStrictEqual(true);
         })
@@ -1154,11 +1129,7 @@ describe('WebSocket Subscription', () => {
           while (!subActive) {
             await sleep(0);
             subActive =
-              (await isSubscriptionActive(
-                project.id as string,
-                'DocumentReference',
-                `Subscription/${subscription.id}`
-              )) === 1;
+              (await isSubscriptionActive(project.id, 'DocumentReference', `Subscription/${subscription.id}`)) === 1;
           }
           expect(subActive).toStrictEqual(true);
         })
@@ -1360,11 +1331,7 @@ describe('WebSocket Subscription', () => {
           while (subActive) {
             await sleep(0);
             subActive =
-              (await isSubscriptionActive(
-                project.id as string,
-                'DocumentReference',
-                `Subscription/${subscription.id}`
-              )) === 1;
+              (await isSubscriptionActive(project.id, 'DocumentReference', `Subscription/${subscription.id}`)) === 1;
           }
           expect(subActive).toStrictEqual(false);
         })
@@ -1443,11 +1410,7 @@ describe('WebSocket Subscription', () => {
           while (subActive) {
             await sleep(0);
             subActive =
-              (await isSubscriptionActive(
-                project.id as string,
-                'DocumentReference',
-                `Subscription/${subscription.id}`
-              )) === 1;
+              (await isSubscriptionActive(project.id, 'DocumentReference', `Subscription/${subscription.id}`)) === 1;
           }
 
           // Reset the spy call count
@@ -1697,7 +1660,7 @@ describe('WebSocket Subscription', () => {
         )
         .exec(async () => {
           await sleep(1000);
-          const active = await isSubscriptionActive(project.id as string, 'Patient', `Subscription/${subscription.id}`);
+          const active = await isSubscriptionActive(project.id, 'Patient', `Subscription/${subscription.id}`);
           expect(active).toBe(0);
         })
         .expectClosed()

--- a/packages/server/src/ws/subscriptions.test.ts
+++ b/packages/server/src/ws/subscriptions.test.ts
@@ -543,6 +543,78 @@ describe('WebSocket Subscription', () => {
         .expectClosed();
     }));
 
+  test.each([
+    ['project-scoped', (projectId: string) => `/projects/${projectId}/ws/subscriptions-r4`],
+    ['project-scoped with /api prefix', (projectId: string) => `/api/projects/${projectId}/ws/subscriptions-r4`],
+    ['/api prefix', () => '/api/ws/subscriptions-r4'],
+  ])('Binds on a %s URL', (_name, buildPath) =>
+    withTestContext(async () => {
+      const subscription = await repo.createResource<Subscription>({
+        resourceType: 'Subscription',
+        reason: 'test',
+        status: 'active',
+        criteria: 'Patient',
+        channel: { type: 'websocket' },
+      });
+
+      const res = await request(server)
+        .get(`/fhir/R4/Subscription/${subscription.id}/$get-ws-binding-token`)
+        .set('Authorization', 'Bearer ' + accessToken);
+      const token = (res.body as FhirParameters).parameter?.[0]?.valueString as string;
+      expect(token).toBeDefined();
+
+      await request(server)
+        .ws(buildPath(project.id))
+        .sendJson({ type: 'bind-with-token', payload: { token } })
+        .expectJson((actual) => {
+          expect(actual).toMatchObject({
+            resourceType: 'Bundle',
+            type: 'history',
+            entry: [
+              {
+                resource: {
+                  resourceType: 'SubscriptionStatus',
+                  type: 'handshake',
+                  subscription: { reference: `Subscription/${subscription.id}` },
+                },
+              },
+            ],
+          });
+        })
+        .close()
+        .expectClosed();
+    })
+  );
+
+  test('Rejects binding on a URL scoped to another project', () =>
+    withTestContext(async () => {
+      const subscription = await repo.createResource<Subscription>({
+        resourceType: 'Subscription',
+        reason: 'test',
+        status: 'active',
+        criteria: 'Patient',
+        channel: { type: 'websocket' },
+      });
+
+      const res = await request(server)
+        .get(`/fhir/R4/Subscription/${subscription.id}/$get-ws-binding-token`)
+        .set('Authorization', 'Bearer ' + accessToken);
+      const token = (res.body as FhirParameters).parameter?.[0]?.valueString as string;
+      expect(token).toBeDefined();
+
+      await request(server)
+        .ws(`/projects/${randomUUID()}/ws/subscriptions-r4`)
+        .sendJson({ type: 'bind-with-token', payload: { token } })
+        .expectJson((actual) => {
+          expect(actual).toMatchObject({
+            resourceType: 'OperationOutcome',
+            issue: [{ severity: 'error', code: 'forbidden' }],
+          });
+        })
+        .close()
+        .expectClosed();
+    }));
+
   test('Should respond with a pong if sent a ping', () =>
     withTestContext(async () => {
       await request(server)

--- a/packages/server/src/ws/subscriptions.ts
+++ b/packages/server/src/ws/subscriptions.ts
@@ -1,7 +1,14 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import { badRequest, createReference, EMPTY, normalizeErrorString, OperationOutcomeError } from '@medplum/core';
+import {
+  badRequest,
+  createReference,
+  EMPTY,
+  forbidden,
+  normalizeErrorString,
+  OperationOutcomeError,
+} from '@medplum/core';
 import type { Bundle, Project, Resource, ResourceType, Subscription } from '@medplum/fhirtypes';
 import type { Redis } from 'ioredis';
 import type { JWTPayload } from 'jose';
@@ -30,6 +37,7 @@ import {
   setActiveSubscription,
 } from '../pubsub';
 import { getCacheRedis, getPubSubRedisSubscriber } from '../redis';
+import { getProjectIdFromUrl } from '../util/url';
 
 interface BaseSubscriptionClientMsg {
   type: string;
@@ -402,6 +410,21 @@ export async function handleR4SubscriptionConnection(socket: WebSocket, request:
       return;
     }
     const cacheEntry = JSON.parse(cacheEntryStr) as CacheEntry<Subscription>;
+
+    // When the socket was opened on a project-scoped URL, the project in the URL must match the
+    // subscription's project. This mirrors the check that authenticateRequest applies to HTTP
+    // requests, so that a project-scoped WebSocket URL means the same thing as a project-scoped
+    // HTTP URL rather than being decorative.
+    const urlProjectId = getProjectIdFromUrl(request.url ?? '');
+    if (urlProjectId && urlProjectId !== cacheEntry.projectId) {
+      globalLogger.warn('[WS] Subscription project does not match the project-scoped URL', {
+        socketId,
+        subscriptionId: verifiedToken.subscription_id,
+        urlProjectId,
+      });
+      socket.send(JSON.stringify(forbidden));
+      return;
+    }
 
     // We can cast here because these criteria are proven to be valid when calling $get-ws-binding-token
     const criteriaResourceType = cacheEntry.resource.criteria.split('?')[0] as ResourceType;


### PR DESCRIPTION
A `MedplumClient` configured with a project-scoped `baseUrl` could not open a subscription WebSocket. The upgrade 404'd. The server now resolves the handler from the normalized path, so project-scoped URLs connect, and the project named in the URL is enforced at bind time.

`MedplumClient` builds the socket URL from its own `baseUrl` (`packages/core/src/client.ts`), so a project-scoped base URL produces `/projects/{projectId}/ws/subscriptions-r4`. The WebSocket router picked its handler from path segment index 1, which is the project ID in that URL rather than `subscriptions-r4`, so no handler matched and the upgrade returned 404. The same applied to `/api/ws/subscriptions-r4`, where segment 1 is `ws`.

The HTTP side already solves this with `getNormalizedPath`, which strips the `/api` and `/projects/{projectId}` mount prefixes. The WebSocket router just wasn't using it.