### PR TITLE
Fixes #9190 - Expire and supersede UserSecurityRequest tokens

### DIFF
--- a/packages/definitions/src/fhir/r4/fhir.schema.json
+++ b/packages/definitions/src/fhir/r4/fhir.schema.json
@@ -63716,6 +63716,10 @@
           "description": "Whether this request has been used, and is therefore no longer valid.",
           "$ref": "#/definitions/boolean"
         },
+        "expiresAt": {
+          "description": "The time at which this request expires, and is therefore no longer valid.",
+          "$ref": "#/definitions/instant"
+        },
         "redirectUri": {
           "description": "Redirect URI used when redirecting a client back to the client application.",
           "$ref": "#/definitions/uri"

--- a/packages/definitions/src/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/src/fhir/r4/profiles-medplum.json
@@ -3627,6 +3627,21 @@
             }
           },
           {
+            "id" : "UserSecurityRequest.expiresAt",
+            "path" : "UserSecurityRequest.expiresAt",
+            "definition" : "The time at which this request expires, and is therefore no longer valid.",
+            "min" : 0,
+            "max" : "1",
+            "type" : [{
+              "code" : "instant"
+            }],
+            "base" : {
+              "path" : "UserSecurityRequest.expiresAt",
+              "min" : 0,
+              "max" : "1"
+            }
+          },
+          {
             "id" : "UserSecurityRequest.redirectUri",
             "path" : "UserSecurityRequest.redirectUri",
             "definition" : "Redirect URI used when redirecting a client back to the client application.",

--- a/packages/docs/docs/api/auth/resetpassword.md
+++ b/packages/docs/docs/api/auth/resetpassword.md
@@ -47,6 +47,8 @@ await medplum.post('auth/resetpassword', {
 
 ### Notes
 
+- Reset links expire one hour after they are issued
+- Requesting a new reset invalidates any earlier reset link for that user
 - When resetting password for project-scoped users, `projectId` must be provided
 - Omit `projectId` when resetting password for system-level users
 - If you are building a custom reset password email, set sendEmail to false

--- a/packages/docs/docs/api/auth/setpassword.md
+++ b/packages/docs/docs/api/auth/setpassword.md
@@ -21,9 +21,16 @@ Sets a new password for a user using a security request token. This endpoint is 
 - Returns `200 OK` if the password was successfully set
 - Returns `400 Bad Request` if:
   - The security request has already been used
+  - The security request has expired
   - The secret is incorrect
   - The password is found in breach database
   - The password is less than 8 characters
+
+### Link expiration
+
+Security requests are single use and time limited. Password reset links expire one hour after they are
+issued, and invitation links expire after seven days. Requesting a new password reset also invalidates
+any earlier reset link for that user, so only the most recent link works.
 
 ### Example
 

--- a/packages/docs/static/data/medplumDefinitions/usersecurityrequest.json
+++ b/packages/docs/static/data/medplumDefinitions/usersecurityrequest.json
@@ -231,6 +231,22 @@
       "inherited": false
     },
     {
+      "name": "expiresAt",
+      "depth": 1,
+      "types": [
+        {
+          "datatype": "instant"
+        }
+      ],
+      "path": "UserSecurityRequest.expiresAt",
+      "min": 0,
+      "max": "1",
+      "short": "",
+      "definition": "The time at which this request expires, and is therefore no longer valid.",
+      "comment": "",
+      "inherited": false
+    },
+    {
       "name": "redirectUri",
       "depth": 1,
       "types": [

--- a/packages/fhirtypes/dist/UserSecurityRequest.d.ts
+++ b/packages/fhirtypes/dist/UserSecurityRequest.d.ts
@@ -115,6 +115,12 @@ export interface UserSecurityRequest {
   used?: boolean;
 
   /**
+   * The time at which this request expires, and is therefore no longer
+   * valid.
+   */
+  expiresAt?: string;
+
+  /**
    * Redirect URI used when redirecting a client back to the client
    * application.
    */

--- a/packages/server/src/auth/resetpassword.test.ts
+++ b/packages/server/src/auth/resetpassword.test.ts
@@ -15,6 +15,7 @@ import { getConfig, loadTestConfig } from '../config/loader';
 import { getGlobalSystemRepo } from '../fhir/repo';
 import { setupRecaptchaMock, withTestContext } from '../test.setup';
 import { registerNew } from './register';
+import { resetPassword } from './resetpassword';
 
 const { mockCreateTransport, mockSendMail } = vi.hoisted(() => {
   const mockSendMail = vi.fn().mockResolvedValue({ messageId: '123' });
@@ -505,5 +506,60 @@ describe('Reset Password', () => {
     // Verify parsed email content
     const parsed = await simpleParser(args.Content?.Raw?.Data as Buffer);
     expect(parsed.subject).toBe('Medplum Password Reset');
+  });
+  test('Sets expiration and supersedes prior requests', async () => {
+    const email = `supersede${randomUUID()}@example.com`;
+
+    const { user } = await withTestContext(() =>
+      registerNew({
+        firstName: 'Reset',
+        lastName: 'Reset',
+        projectName: 'Reset Project',
+        email,
+        password: 'password!@#',
+      })
+    );
+
+    const url = await withTestContext(() => resetPassword(systemRepo, user, 'reset'));
+    const firstId = url.split('/').slice(-2)[0];
+    const first = await systemRepo.readResource<UserSecurityRequest>('UserSecurityRequest', firstId);
+    expect(first.used).toBeUndefined();
+    expect(new Date(first.expiresAt as string).getTime()).toBeGreaterThan(Date.now());
+
+    await withTestContext(() => resetPassword(systemRepo, user, 'reset'));
+
+    // The first request is no longer redeemable
+    const firstAfter = await systemRepo.readResource<UserSecurityRequest>('UserSecurityRequest', firstId);
+    expect(firstAfter.used).toBe(true);
+
+    const res = await request(app).post('/auth/setpassword').type('json').send({
+      id: firstId,
+      secret: first.secret,
+      password: 'my-new-password',
+    });
+    expect(res).toHaveStatus(400);
+  });
+
+  test('Supersession is scoped to the request type', async () => {
+    const email = `supersede-type${randomUUID()}@example.com`;
+
+    const { user } = await withTestContext(() =>
+      registerNew({
+        firstName: 'Reset',
+        lastName: 'Reset',
+        projectName: 'Reset Project',
+        email,
+        password: 'password!@#',
+      })
+    );
+
+    const inviteUrl = await withTestContext(() => resetPassword(systemRepo, user, 'invite'));
+    const inviteId = inviteUrl.split('/').slice(-2)[0];
+
+    await withTestContext(() => resetPassword(systemRepo, user, 'reset'));
+
+    // A password reset does not invalidate an outstanding invite
+    const invite = await systemRepo.readResource<UserSecurityRequest>('UserSecurityRequest', inviteId);
+    expect(invite.used).toBeUndefined();
   });
 });

--- a/packages/server/src/auth/resetpassword.ts
+++ b/packages/server/src/auth/resetpassword.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { Filter } from '@medplum/core';
+import type { Filter, WithId } from '@medplum/core';
 import { allOk, badRequest, concatUrls, createReference, Operator, resolveId } from '@medplum/core';
 import type { Project, User, UserSecurityRequest } from '@medplum/fhirtypes';
 import type { Request, Response } from 'express';
@@ -13,6 +13,7 @@ import { getGlobalSystemRepo } from '../fhir/repo';
 import { generateSecret } from '../oauth/keys';
 import { makeValidationMiddleware } from '../util/validator';
 import { isExternalAuth } from './method';
+import { getSecurityRequestExpiration, supersedePriorSecurityRequests } from './securityrequest';
 
 export const resetPasswordValidator = makeValidationMiddleware([
   body('email')
@@ -109,10 +110,13 @@ export async function resetPasswordHandler(req: Request, res: Response): Promise
  */
 export async function resetPassword(
   systemRepo: SystemRepository,
-  user: User,
+  user: WithId<User>,
   type: UserSecurityRequest['type'],
   redirectUri?: string
 ): Promise<string> {
+  // Invalidate any prior requests of this type, so that only the newest link works
+  await supersedePriorSecurityRequests(systemRepo, user, type);
+
   // Create the password change request
   const { id, secret } = await systemRepo.createResource<UserSecurityRequest>({
     resourceType: 'UserSecurityRequest',
@@ -120,6 +124,7 @@ export async function resetPassword(
     type,
     user: createReference(user),
     secret: generateSecret(16),
+    expiresAt: getSecurityRequestExpiration(type),
     redirectUri,
   });
 

--- a/packages/server/src/auth/securityrequest.test.ts
+++ b/packages/server/src/auth/securityrequest.test.ts
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { UserSecurityRequest } from '@medplum/fhirtypes';
+import { USER_SECURITY_REQUEST_EXPIRATION_MS } from '../constants';
+import { getSecurityRequestExpiration, isSecurityRequestExpired } from './securityrequest';
+
+function makeRequest(overrides: Partial<UserSecurityRequest>): UserSecurityRequest {
+  return {
+    resourceType: 'UserSecurityRequest',
+    type: 'reset',
+    user: { reference: 'User/123' },
+    secret: 'secret',
+    ...overrides,
+  };
+}
+
+describe('getSecurityRequestExpiration', () => {
+  test('Uses the window for the request type', () => {
+    const before = Date.now();
+    const expiration = new Date(getSecurityRequestExpiration('invite')).getTime();
+    expect(expiration).toBeGreaterThanOrEqual(before + USER_SECURITY_REQUEST_EXPIRATION_MS.invite);
+  });
+
+  test('Reset expires sooner than invite', () => {
+    expect(USER_SECURITY_REQUEST_EXPIRATION_MS.reset).toBeLessThan(USER_SECURITY_REQUEST_EXPIRATION_MS.invite);
+  });
+});
+
+describe('isSecurityRequestExpired', () => {
+  test('Unexpired', () => {
+    const expiresAt = new Date(Date.now() + 60_000).toISOString();
+    expect(isSecurityRequestExpired(makeRequest({ expiresAt }))).toBe(false);
+  });
+
+  test('Expired', () => {
+    const expiresAt = new Date(Date.now() - 60_000).toISOString();
+    expect(isSecurityRequestExpired(makeRequest({ expiresAt }))).toBe(true);
+  });
+
+  test('Unparseable expiresAt is expired', () => {
+    expect(isSecurityRequestExpired(makeRequest({ expiresAt: 'not-a-date' }))).toBe(true);
+  });
+
+  test('Falls back to lastUpdated when expiresAt is absent', () => {
+    const recent = new Date(Date.now() - 60_000).toISOString();
+    expect(isSecurityRequestExpired(makeRequest({ meta: { lastUpdated: recent } }))).toBe(false);
+
+    const old = new Date(Date.now() - USER_SECURITY_REQUEST_EXPIRATION_MS.reset - 60_000).toISOString();
+    expect(isSecurityRequestExpired(makeRequest({ meta: { lastUpdated: old } }))).toBe(true);
+  });
+
+  test('Fallback uses the window for the request type', () => {
+    const lastUpdated = new Date(Date.now() - USER_SECURITY_REQUEST_EXPIRATION_MS.reset - 60_000).toISOString();
+    expect(isSecurityRequestExpired(makeRequest({ type: 'invite', meta: { lastUpdated } }))).toBe(false);
+    expect(isSecurityRequestExpired(makeRequest({ type: 'verify-email', meta: { lastUpdated } }))).toBe(false);
+  });
+
+  test('Missing type falls back to the reset window', () => {
+    const lastUpdated = new Date(Date.now() - USER_SECURITY_REQUEST_EXPIRATION_MS.reset - 60_000).toISOString();
+    expect(isSecurityRequestExpired(makeRequest({ type: undefined, meta: { lastUpdated } }))).toBe(true);
+  });
+
+  test('No timestamps at all is expired', () => {
+    expect(isSecurityRequestExpired(makeRequest({}))).toBe(true);
+  });
+});

--- a/packages/server/src/auth/securityrequest.ts
+++ b/packages/server/src/auth/securityrequest.ts
@@ -46,7 +46,8 @@ export function getSecurityRequestExpiration(type: UserSecurityRequest['type']):
  *
  * Requests created before `expiresAt` existed do not carry the field, so they fall back to their
  * creation time plus the window for their type. That retires previously unlimited tokens as soon
- * as this code is deployed. A request with no timestamps at all is treated as expired.
+ * as this code is deployed. A request with no timestamps at all, or an unparseable one, is treated
+ * as expired.
  * @param securityRequest - The request to check.
  * @returns True if the request has expired.
  */
@@ -54,7 +55,8 @@ export function isSecurityRequestExpired(securityRequest: UserSecurityRequest): 
   const expiresAt = securityRequest.expiresAt
     ? new Date(securityRequest.expiresAt).getTime()
     : new Date(securityRequest.meta?.lastUpdated ?? 0).getTime() + getExpirationMs(securityRequest.type);
-  return !(expiresAt > Date.now());
+  // An unparseable timestamp yields NaN, which loses every comparison, so check for it explicitly
+  return Number.isNaN(expiresAt) || Date.now() >= expiresAt;
 }
 
 /**
@@ -106,7 +108,10 @@ export async function supersedePriorSecurityRequests(
   for (const entry of priorRequests.entry ?? EMPTY) {
     const priorRequest = entry.resource as WithId<UserSecurityRequest>;
     if (priorRequest.type === type && !priorRequest.used) {
-      await systemRepo.updateResource<UserSecurityRequest>({ ...priorRequest, used: true });
+      // Patch rather than update, so that a request being consumed concurrently is not clobbered
+      await systemRepo.patchResource<UserSecurityRequest>('UserSecurityRequest', priorRequest.id, [
+        { op: 'add', path: '/used', value: true },
+      ]);
     }
   }
 }

--- a/packages/server/src/auth/securityrequest.ts
+++ b/packages/server/src/auth/securityrequest.ts
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import {
+  badRequest,
+  EMPTY,
+  getReferenceString,
+  getStatus,
+  isOperationOutcome,
+  OperationOutcomeError,
+  Operator,
+} from '@medplum/core';
+import type { User, UserSecurityRequest } from '@medplum/fhirtypes';
+import { USER_SECURITY_REQUEST_EXPIRATION_MS } from '../constants';
+import type { SystemRepository } from '../fhir/repo';
+
+/**
+ * How many of a user's most recent security requests are examined when superseding prior requests.
+ *
+ * Only unexpired requests are worth superseding, and expiration bounds how many of those can
+ * exist, so there is no need to walk a user's entire history.
+ */
+const MAX_SUPERSEDED_REQUESTS = 100;
+
+/**
+ * Returns how long a request of the given type stays valid, in milliseconds.
+ * @param type - The request type, absent on requests created before the field existed.
+ * @returns The validity window in milliseconds.
+ */
+function getExpirationMs(type: UserSecurityRequest['type']): number {
+  // Requests predating the `type` field are treated as password resets, the shortest window.
+  return USER_SECURITY_REQUEST_EXPIRATION_MS[type ?? 'reset'];
+}
+
+/**
+ * Returns the expiration timestamp to store on a newly created UserSecurityRequest.
+ * @param type - The type of request being created.
+ * @returns The expiration as an ISO 8601 instant.
+ */
+export function getSecurityRequestExpiration(type: UserSecurityRequest['type']): string {
+  return new Date(Date.now() + getExpirationMs(type)).toISOString();
+}
+
+/**
+ * Returns whether a security request is past its expiration and can no longer be used.
+ *
+ * Requests created before `expiresAt` existed do not carry the field, so they fall back to their
+ * creation time plus the window for their type. That retires previously unlimited tokens as soon
+ * as this code is deployed. A request with no timestamps at all is treated as expired.
+ * @param securityRequest - The request to check.
+ * @returns True if the request has expired.
+ */
+export function isSecurityRequestExpired(securityRequest: UserSecurityRequest): boolean {
+  const expiresAt = securityRequest.expiresAt
+    ? new Date(securityRequest.expiresAt).getTime()
+    : new Date(securityRequest.meta?.lastUpdated ?? 0).getTime() + getExpirationMs(securityRequest.type);
+  return !(expiresAt > Date.now());
+}
+
+/**
+ * Marks a security request as used, guarded by its version ID.
+ *
+ * `ifMatch` makes this a compare-and-swap: of several concurrent requests carrying the same
+ * token, exactly one gets past this point and the rest see "Already used".
+ * @param systemRepo - The system repository to use.
+ * @param securityRequest - The request to consume.
+ */
+export async function consumeSecurityRequest(
+  systemRepo: SystemRepository,
+  securityRequest: WithId<UserSecurityRequest>
+): Promise<void> {
+  try {
+    await systemRepo.updateResource<UserSecurityRequest>(
+      { ...securityRequest, used: true },
+      { ifMatch: securityRequest.meta?.versionId }
+    );
+  } catch (err) {
+    if (err instanceof OperationOutcomeError && isOperationOutcome(err.outcome) && getStatus(err.outcome) === 412) {
+      throw new OperationOutcomeError(badRequest('Already used'));
+    }
+    throw err;
+  }
+}
+
+/**
+ * Marks all of the user's prior unused requests of the given type as used.
+ *
+ * Issuing a new request invalidates the ones it replaces, so an older link that reached the
+ * wrong inbox cannot be redeemed after the user asks for a new one.
+ * @param systemRepo - The system repository to use.
+ * @param user - The user whose prior requests should be superseded.
+ * @param type - The type of request being superseded.
+ */
+export async function supersedePriorSecurityRequests(
+  systemRepo: SystemRepository,
+  user: WithId<User>,
+  type: UserSecurityRequest['type']
+): Promise<void> {
+  const priorRequests = await systemRepo.search<UserSecurityRequest>({
+    resourceType: 'UserSecurityRequest',
+    count: MAX_SUPERSEDED_REQUESTS,
+    sortRules: [{ code: '_lastUpdated', descending: true }],
+    filters: [{ code: 'user', operator: Operator.EQUALS, value: getReferenceString(user) }],
+  });
+
+  for (const entry of priorRequests.entry ?? EMPTY) {
+    const priorRequest = entry.resource as WithId<UserSecurityRequest>;
+    if (priorRequest.type === type && !priorRequest.used) {
+      await systemRepo.updateResource<UserSecurityRequest>({ ...priorRequest, used: true });
+    }
+  }
+}

--- a/packages/server/src/auth/setpassword.test.ts
+++ b/packages/server/src/auth/setpassword.test.ts
@@ -15,7 +15,7 @@ import { vi } from 'vitest';
 import { initApp, shutdownApp } from '../app';
 import { getConfig, loadTestConfig } from '../config/loader';
 import { USER_SECURITY_REQUEST_EXPIRATION_MS } from '../constants';
-import { getGlobalSystemRepo, getProjectSystemRepo } from '../fhir/repo';
+import { getGlobalSystemRepo, getProjectSystemRepo, Repository } from '../fhir/repo';
 import { generateSecret } from '../oauth/keys';
 import { tryLogin } from '../oauth/utils';
 import { setupPwnedPasswordMock, setupRecaptchaMock, withTestContext } from '../test.setup';
@@ -337,6 +337,68 @@ describe('Set Password', () => {
 
     // The link still works with an acceptable password
     setupPwnedPasswordMock(pwnedPassword as unknown as Mock, 0);
+    const res2 = await request(app).post('/auth/setpassword').type('json').send({
+      id: usr.id,
+      secret: usr.secret,
+      password: 'my-new-password',
+    });
+    expect(res2).toHaveStatus(200);
+  });
+
+  test('Failure to apply the password does not consume the UserSecurityRequest', async () => {
+    const email = `george${randomUUID()}@example.com`;
+
+    const { user, project } = await withTestContext(() =>
+      registerNew({
+        projectName: 'Set Password Project',
+        firstName: 'George',
+        lastName: 'Washington',
+        email,
+        password: 'password!@#',
+        scope: 'openid profile email',
+      })
+    );
+
+    const systemRepo = await getProjectSystemRepo(project);
+    const usr = await withTestContext(async () =>
+      systemRepo.createResource<UserSecurityRequest>({
+        resourceType: 'UserSecurityRequest',
+        meta: { project: project.id },
+        type: 'reset',
+        user: createReference(user),
+        secret: generateSecret(16),
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      })
+    );
+
+    // Fail the User update that follows the consume, so the transaction rolls back
+    const originalUpdate = Repository.prototype.updateResource;
+    const updateSpy = vi.spyOn(Repository.prototype, 'updateResource').mockImplementation(async function (
+      this: Repository,
+      resource,
+      options
+    ) {
+      if (resource.resourceType === 'User') {
+        throw new Error('Simulated failure');
+      }
+      return originalUpdate.call(this, resource, options);
+    });
+
+    try {
+      const res = await request(app).post('/auth/setpassword').type('json').send({
+        id: usr.id,
+        secret: usr.secret,
+        password: 'my-new-password',
+      });
+      expect(res.status).not.toBe(200);
+    } finally {
+      updateSpy.mockRestore();
+    }
+
+    // The request was not consumed, so the link still works
+    const check = await systemRepo.readResource<UserSecurityRequest>('UserSecurityRequest', usr.id);
+    expect(check.used).toBeFalsy();
+
     const res2 = await request(app).post('/auth/setpassword').type('json').send({
       id: usr.id,
       secret: usr.secret,

--- a/packages/server/src/auth/setpassword.test.ts
+++ b/packages/server/src/auth/setpassword.test.ts
@@ -14,6 +14,7 @@ import type { Mock } from 'vitest';
 import { vi } from 'vitest';
 import { initApp, shutdownApp } from '../app';
 import { getConfig, loadTestConfig } from '../config/loader';
+import { USER_SECURITY_REQUEST_EXPIRATION_MS } from '../constants';
 import { getGlobalSystemRepo, getProjectSystemRepo } from '../fhir/repo';
 import { generateSecret } from '../oauth/keys';
 import { tryLogin } from '../oauth/utils';
@@ -174,6 +175,174 @@ describe('Set Password', () => {
       scope: 'openid',
     });
     expect(res4).toHaveStatus(200);
+  });
+
+  test('Expired UserSecurityRequest', async () => {
+    const email = `george${randomUUID()}@example.com`;
+
+    const { user, project } = await withTestContext(() =>
+      registerNew({
+        projectName: 'Set Password Project',
+        firstName: 'George',
+        lastName: 'Washington',
+        email,
+        password: 'password!@#',
+        scope: 'openid profile email',
+      })
+    );
+
+    const systemRepo = await getProjectSystemRepo(project);
+    const usr = await withTestContext(async () =>
+      systemRepo.createResource<UserSecurityRequest>({
+        resourceType: 'UserSecurityRequest',
+        meta: { project: project.id },
+        type: 'reset',
+        user: createReference(user),
+        secret: generateSecret(16),
+        expiresAt: new Date(Date.now() - 1000).toISOString(),
+      })
+    );
+
+    const res = await request(app).post('/auth/setpassword').type('json').send({
+      id: usr.id,
+      secret: usr.secret,
+      password: 'my-new-password',
+    });
+    expect(res).toHaveStatus(400);
+    expect(res.body).toMatchObject(badRequest('Expired'));
+
+    // The old password still works
+    const res2 = await request(app).post('/auth/login').type('json').send({
+      email,
+      password: 'password!@#',
+      scope: 'openid',
+    });
+    expect(res2).toHaveStatus(200);
+  });
+
+  test('UserSecurityRequest without expiresAt expires from lastUpdated', async () => {
+    const email = `george${randomUUID()}@example.com`;
+
+    const { user, project } = await withTestContext(() =>
+      registerNew({
+        projectName: 'Set Password Project',
+        firstName: 'George',
+        lastName: 'Washington',
+        email,
+        password: 'password!@#',
+        scope: 'openid profile email',
+      })
+    );
+
+    // Predates the expiresAt field, so it falls back to lastUpdated plus the reset window
+    const systemRepo = await getProjectSystemRepo(project);
+    const usr = await withTestContext(async () =>
+      systemRepo.createResource<UserSecurityRequest>({
+        resourceType: 'UserSecurityRequest',
+        meta: {
+          project: project.id,
+          lastUpdated: new Date(Date.now() - USER_SECURITY_REQUEST_EXPIRATION_MS.reset - 60_000).toISOString(),
+        },
+        type: 'reset',
+        user: createReference(user),
+        secret: generateSecret(16),
+      })
+    );
+    expect(usr.expiresAt).toBeUndefined();
+
+    const res = await request(app).post('/auth/setpassword').type('json').send({
+      id: usr.id,
+      secret: usr.secret,
+      password: 'my-new-password',
+    });
+    expect(res).toHaveStatus(400);
+    expect(res.body).toMatchObject(badRequest('Expired'));
+  });
+
+  test('UserSecurityRequest cannot be used twice', async () => {
+    const email = `george${randomUUID()}@example.com`;
+
+    const { user, project } = await withTestContext(() =>
+      registerNew({
+        projectName: 'Set Password Project',
+        firstName: 'George',
+        lastName: 'Washington',
+        email,
+        password: 'password!@#',
+        scope: 'openid profile email',
+      })
+    );
+
+    const systemRepo = await getProjectSystemRepo(project);
+    const usr = await withTestContext(async () =>
+      systemRepo.createResource<UserSecurityRequest>({
+        resourceType: 'UserSecurityRequest',
+        meta: { project: project.id },
+        type: 'reset',
+        user: createReference(user),
+        secret: generateSecret(16),
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      })
+    );
+
+    const res = await request(app).post('/auth/setpassword').type('json').send({
+      id: usr.id,
+      secret: usr.secret,
+      password: 'my-new-password',
+    });
+    expect(res).toHaveStatus(200);
+
+    const res2 = await request(app).post('/auth/setpassword').type('json').send({
+      id: usr.id,
+      secret: usr.secret,
+      password: 'my-second-password',
+    });
+    expect(res2).toHaveStatus(400);
+    expect(res2.body).toMatchObject(badRequest('Already used'));
+  });
+
+  test('Breached password does not consume the UserSecurityRequest', async () => {
+    const email = `george${randomUUID()}@example.com`;
+
+    const { user, project } = await withTestContext(() =>
+      registerNew({
+        projectName: 'Set Password Project',
+        firstName: 'George',
+        lastName: 'Washington',
+        email,
+        password: 'password!@#',
+        scope: 'openid profile email',
+      })
+    );
+
+    const systemRepo = await getProjectSystemRepo(project);
+    const usr = await withTestContext(async () =>
+      systemRepo.createResource<UserSecurityRequest>({
+        resourceType: 'UserSecurityRequest',
+        meta: { project: project.id },
+        type: 'reset',
+        user: createReference(user),
+        secret: generateSecret(16),
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      })
+    );
+
+    setupPwnedPasswordMock(pwnedPassword as unknown as Mock, 10);
+    const res = await request(app).post('/auth/setpassword').type('json').send({
+      id: usr.id,
+      secret: usr.secret,
+      password: 'breached-password',
+    });
+    expect(res).toHaveStatus(400);
+
+    // The link still works with an acceptable password
+    setupPwnedPasswordMock(pwnedPassword as unknown as Mock, 0);
+    const res2 = await request(app).post('/auth/setpassword').type('json').send({
+      id: usr.id,
+      secret: usr.secret,
+      password: 'my-new-password',
+    });
+    expect(res2).toHaveStatus(200);
   });
 
   test('UserSecurityRequest invalid type', async () => {

--- a/packages/server/src/auth/setpassword.ts
+++ b/packages/server/src/auth/setpassword.ts
@@ -12,6 +12,7 @@ import type { SystemRepository } from '../fhir/repo';
 import { getGlobalSystemRepo } from '../fhir/repo';
 import { timingSafeEqualStr } from '../oauth/utils';
 import { makeValidationMiddleware } from '../util/validator';
+import { consumeSecurityRequest, isSecurityRequestExpired } from './securityrequest';
 import { bcryptHashPassword } from './utils';
 
 export const setPasswordValidator = makeValidationMiddleware([
@@ -39,25 +40,51 @@ export async function setPasswordHandler(req: Request, res: Response): Promise<v
     return;
   }
 
+  if (isSecurityRequestExpired(securityRequest)) {
+    sendOutcome(res, badRequest('Expired'));
+    return;
+  }
+
   if (!timingSafeEqualStr(securityRequest.secret, req.body.secret)) {
     sendOutcome(res, badRequest('Incorrect secret'));
     return;
   }
 
   const user = await systemRepo.readReference(securityRequest.user);
-  await setPassword(systemRepo, { ...user, emailVerified: true }, req.body.password);
-  await systemRepo.updateResource<typeof securityRequest>({ ...securityRequest, used: true });
+  await setPassword(systemRepo, { ...user, emailVerified: true }, req.body.password, securityRequest);
 
   sendOutcome(res, allOk);
 }
 
-export async function setPassword(systemRepo: SystemRepository, user: WithId<User>, password: string): Promise<void> {
+/**
+ * Sets the user's password and revokes their active sessions.
+ *
+ * When the change is authorized by a UserSecurityRequest, pass it as `securityRequest` so that it
+ * is consumed as part of the same operation. It is consumed after the password has been validated
+ * and hashed, so a password that fails validation does not burn the user's link, but before the
+ * password is applied, so the request cannot be redeemed twice.
+ * @param systemRepo - The system repository to use.
+ * @param user - The user whose password is being set.
+ * @param password - The new plaintext password.
+ * @param securityRequest - Optional security request authorizing the change, consumed on success.
+ */
+export async function setPassword(
+  systemRepo: SystemRepository,
+  user: WithId<User>,
+  password: string,
+  securityRequest?: WithId<UserSecurityRequest>
+): Promise<void> {
   const numPwns = await pwnedPassword(password);
   if (numPwns > 0) {
     throw new OperationOutcomeError(badRequest('Password found in breach database'));
   }
 
   const passwordHash = await bcryptHashPassword(password);
+
+  if (securityRequest) {
+    await consumeSecurityRequest(systemRepo, securityRequest);
+  }
+
   await systemRepo.updateResource<User>({ ...user, passwordHash });
 
   const activeSessions = await systemRepo.search<Login>({

--- a/packages/server/src/auth/setpassword.ts
+++ b/packages/server/src/auth/setpassword.ts
@@ -60,9 +60,10 @@ export async function setPasswordHandler(req: Request, res: Response): Promise<v
  * Sets the user's password and revokes their active sessions.
  *
  * When the change is authorized by a UserSecurityRequest, pass it as `securityRequest` so that it
- * is consumed as part of the same operation. It is consumed after the password has been validated
- * and hashed, so a password that fails validation does not burn the user's link, but before the
- * password is applied, so the request cannot be redeemed twice.
+ * is consumed in the same transaction that applies the password: either both land or neither does.
+ * It is consumed after the password has been validated and hashed, so a password that fails
+ * validation does not burn the user's link, but before the password is applied, so the request
+ * cannot be redeemed twice.
  * @param systemRepo - The system repository to use.
  * @param user - The user whose password is being set.
  * @param password - The new plaintext password.
@@ -81,11 +82,17 @@ export async function setPassword(
 
   const passwordHash = await bcryptHashPassword(password);
 
-  if (securityRequest) {
-    await consumeSecurityRequest(systemRepo, securityRequest);
-  }
-
-  await systemRepo.updateResource<User>({ ...user, passwordHash });
+  await systemRepo.withTransaction(
+    async (txRepo) => {
+      // Consume the request first, so that concurrent requests carrying the same token
+      // cannot both get through
+      if (securityRequest) {
+        await consumeSecurityRequest(txRepo, securityRequest);
+      }
+      await txRepo.updateResource<User>({ ...user, passwordHash });
+    },
+    { resourceTypes: ['User', 'UserSecurityRequest'], source: 'setPassword' }
+  );
 
   const activeSessions = await systemRepo.search<Login>({
     resourceType: 'Login',

--- a/packages/server/src/auth/verifyemail.test.ts
+++ b/packages/server/src/auth/verifyemail.test.ts
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import { createReference, resolveId } from '@medplum/core';
+import { badRequest, createReference, resolveId } from '@medplum/core';
 import type { User, UserSecurityRequest } from '@medplum/fhirtypes';
 import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
+import { USER_SECURITY_REQUEST_EXPIRATION_MS } from '../constants';
 import type { Repository } from '../fhir/repo';
 import { getGlobalSystemRepo } from '../fhir/repo';
 import { generateSecret } from '../oauth/keys';
@@ -18,7 +19,8 @@ const app = express();
 export async function createUserSecurityRequest(
   repo: Repository,
   user: User,
-  type: UserSecurityRequest['type']
+  type: UserSecurityRequest['type'],
+  overrides?: Partial<UserSecurityRequest>
 ): Promise<WithId<UserSecurityRequest>> {
   return repo.createResource<UserSecurityRequest>({
     resourceType: 'UserSecurityRequest',
@@ -28,6 +30,7 @@ export async function createUserSecurityRequest(
     type,
     user: createReference(user),
     secret: generateSecret(16),
+    ...overrides,
   });
 }
 
@@ -108,4 +111,58 @@ describe('Verify email handler', () => {
     });
     expect(res2).toHaveStatus(400);
   });
+  test('Sets expiration and supersedes prior requests', async () =>
+    withTestContext(async () => {
+      const first = await verifyEmail(systemRepo, user);
+      expect(new Date(first.expiresAt as string).getTime()).toBeGreaterThan(Date.now());
+
+      await verifyEmail(systemRepo, user);
+
+      const firstAfter = await systemRepo.readResource<UserSecurityRequest>('UserSecurityRequest', first.id);
+      expect(firstAfter.used).toBe(true);
+
+      const res = await request(app).post('/auth/verifyemail').type('json').send({
+        id: first.id,
+        secret: first.secret,
+      });
+      expect(res).toHaveStatus(400);
+    }));
+
+  test('Expired UserSecurityRequest', async () =>
+    withTestContext(async () => {
+      const usr = await createUserSecurityRequest(systemRepo, user, 'verify-email', {
+        expiresAt: new Date(Date.now() - 1000).toISOString(),
+      });
+
+      const res = await request(app).post('/auth/verifyemail').type('json').send({
+        id: usr.id,
+        secret: usr.secret,
+      });
+      expect(res).toHaveStatus(400);
+      expect(res.body).toMatchObject(badRequest('Expired'));
+
+      const userAfter = await systemRepo.readResource<User>('User', user.id);
+      expect(userAfter.emailVerified).not.toStrictEqual(true);
+    }));
+
+  test('UserSecurityRequest without expiresAt expires from lastUpdated', async () =>
+    withTestContext(async () => {
+      // Predates the expiresAt field, so it falls back to lastUpdated plus the verify-email window
+      const usr = await createUserSecurityRequest(systemRepo, user, 'verify-email', {
+        meta: {
+          project: resolveId(user.project),
+          lastUpdated: new Date(
+            Date.now() - USER_SECURITY_REQUEST_EXPIRATION_MS['verify-email'] - 60_000
+          ).toISOString(),
+        },
+      });
+      expect(usr.expiresAt).toBeUndefined();
+
+      const res = await request(app).post('/auth/verifyemail').type('json').send({
+        id: usr.id,
+        secret: usr.secret,
+      });
+      expect(res).toHaveStatus(400);
+      expect(res.body).toMatchObject(badRequest('Expired'));
+    }));
 });

--- a/packages/server/src/auth/verifyemail.ts
+++ b/packages/server/src/auth/verifyemail.ts
@@ -11,6 +11,12 @@ import { getGlobalSystemRepo } from '../fhir/repo';
 import { generateSecret } from '../oauth/keys';
 import { timingSafeEqualStr } from '../oauth/utils';
 import { makeValidationMiddleware } from '../util/validator';
+import {
+  consumeSecurityRequest,
+  getSecurityRequestExpiration,
+  isSecurityRequestExpired,
+  supersedePriorSecurityRequests,
+} from './securityrequest';
 
 export const verifyEmailValidator = makeValidationMiddleware([
   body('id').isUUID().withMessage('Invalid request ID'),
@@ -31,6 +37,11 @@ export async function verifyEmailHandler(req: Request, res: Response): Promise<v
     return;
   }
 
+  if (isSecurityRequestExpired(securityRequest)) {
+    sendOutcome(res, badRequest('Expired'));
+    return;
+  }
+
   if (!timingSafeEqualStr(securityRequest.secret, req.body.secret)) {
     sendOutcome(res, badRequest('Incorrect secret'));
     return;
@@ -40,8 +51,10 @@ export async function verifyEmailHandler(req: Request, res: Response): Promise<v
 
   await systemRepo.withTransaction(
     async (txRepo) => {
+      // Consume the request first, so that concurrent requests carrying the same token
+      // cannot both get through
+      await consumeSecurityRequest(txRepo, securityRequest);
       await txRepo.updateResource<User>({ ...user, emailVerified: true });
-      await txRepo.updateResource<UserSecurityRequest>({ ...securityRequest, used: true });
     },
     { resourceTypes: ['User', 'UserSecurityRequest'], source: 'verifyEmailHandler' }
   );
@@ -64,9 +77,12 @@ export async function verifyEmailHandler(req: Request, res: Response): Promise<v
  */
 export async function verifyEmail(
   systemRepo: SystemRepository,
-  user: User,
+  user: WithId<User>,
   redirectUri?: string
 ): Promise<WithId<UserSecurityRequest>> {
+  // Invalidate any prior verification requests, so that only the newest link works
+  await supersedePriorSecurityRequests(systemRepo, user, 'verify-email');
+
   // Create the email verification request
   return systemRepo.createResource<UserSecurityRequest>({
     resourceType: 'UserSecurityRequest',
@@ -74,6 +90,7 @@ export async function verifyEmail(
     type: 'verify-email',
     user: createReference(user),
     secret: generateSecret(16),
+    expiresAt: getSecurityRequestExpiration('verify-email'),
     redirectUri,
   });
 }

--- a/packages/server/src/constants.ts
+++ b/packages/server/src/constants.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import type { Project } from '@medplum/fhirtypes';
+import type { Project, UserSecurityRequest } from '@medplum/fhirtypes';
 
 /**
  * The hardcoded ID for the base FHIR R4 Project.
@@ -35,6 +35,19 @@ export const WEBSOCKET_SUB_PUBLISH_CHANNEL = 'medplum:subscriptions:r4:websocket
  * How long a single-use email MFA code remains valid before it expires, in milliseconds.
  */
 export const EMAIL_MFA_CODE_EXPIRATION_MS = 20 * 60 * 1000; // 20 minutes
+
+/**
+ * How long a UserSecurityRequest remains valid before it expires, in milliseconds, by request type.
+ *
+ * Password reset links get a short window because they hand over control of the account.
+ * Invite and email verification links are mailed to people who may not act on them right away,
+ * so they get a longer one.
+ */
+export const USER_SECURITY_REQUEST_EXPIRATION_MS: Record<NonNullable<UserSecurityRequest['type']>, number> = {
+  reset: 60 * 60 * 1000, // 1 hour
+  invite: 7 * 24 * 60 * 60 * 1000, // 7 days
+  'verify-email': 7 * 24 * 60 * 60 * 1000, // 7 days
+};
 
 /**
  * Minimum accepted password length, in bytes.


### PR DESCRIPTION
Fixes #9190

`UserSecurityRequest` resources backing the password reset, invite, and email verification flows had no time-based expiration and were not invalidated when a newer request replaced them. A reset link sent to a compromised mailbox stayed redeemable forever, and requesting a new reset left every earlier link live. This adds an `expiresAt` field, enforces it on redemption, supersedes prior requests of the same type, and closes a race that allowed a single token to be redeemed twice.

`setPasswordHandler` validated a token by checking the `used` boolean and doing a timing-safe secret compare. There was no time component anywhere in the schema or the handler. `resetPassword()` created a new request with a bare `createResource`, never looking for prior ones.

`verify-email` has the identical problem. `verifyEmailHandler` also checks only `used` and the secret, and `verifyEmail()` creates without expiry or supersession. These are minted by `$update-email`, so a stale link in an old mailbox could mark a changed address as verified indefinitely.

The single-use check was not atomic. `setPasswordHandler` read the resource, checked `used`, called `setPassword()`, which does a network round trip to haveibeenpwned plus a bcrypt hash, and only then wrote `used: true` with a plain `updateResource`.