### PR TITLE
[Scheduling] Add Appointment $reschedule operation

### DIFF
--- a/packages/docs/docs/scheduling/appointment-book.md
+++ b/packages/docs/docs/scheduling/appointment-book.md
@@ -292,6 +292,7 @@ The Scheduling API is under active development. This [beta](/docs/compliance/alp
 
 - [Appointment `$find`](/docs/scheduling/appointment-find) - Find available Slots before booking
 - [Appointment `$hold`](/docs/scheduling/appointment-hold) - Reserve an unconfirmed appointment
+- [Appointment `$reschedule`](/docs/scheduling/appointment-reschedule) - Cancel and book a new Appointment atomically
 - [Defining Availability](/docs/scheduling/defining-availability) - How to configure `SchedulingParameters` on a Schedule
 - [Scheduling Overview](/docs/scheduling) - High-level scheduling concepts
 - [`Appointment` resource](/docs/api/fhir/resources/appointment)

--- a/packages/docs/docs/scheduling/appointment-cancel.md
+++ b/packages/docs/docs/scheduling/appointment-cancel.md
@@ -124,6 +124,7 @@ All `Slot` resources that were referenced by the Appointment are deleted and do 
 ## Related
 
 - [Appointment `$book`](/docs/scheduling/appointment-book) - Book an Appointment (the inverse operation)
+- [Appointment `$reschedule`](/docs/scheduling/appointment-reschedule) - Cancel and book a new Appointment atomically
 - [Appointment `$find`](/docs/scheduling/appointment-find) - Find available slots
 - [Scheduling Overview](/docs/scheduling) - High-level scheduling concepts
 - [`Appointment` resource](/docs/api/fhir/resources/appointment)

--- a/packages/docs/docs/scheduling/appointment-reschedule.md
+++ b/packages/docs/docs/scheduling/appointment-reschedule.md
@@ -1,0 +1,165 @@
+---
+sidebar_label: Appointment $reschedule
+sidebar_position: 6
+---
+
+import ExampleCode from '!!raw-loader!@site/../examples/src/scheduling/reschedule.ts';
+import MedplumCodeBlock from '@site/src/components/MedplumCodeBlock';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Appointment $reschedule
+
+:::info[Beta]
+
+The `$reschedule` operation is currently in [beta](/docs/compliance/alpha-beta).
+
+:::
+
+The `$reschedule` operation atomically cancels an existing [`Appointment`](/docs/api/fhir/resources/appointment) and books a new one in a single FHIR transaction. It is equivalent to calling [`$cancel`](/docs/scheduling/appointment-cancel) followed by [`$book`](/docs/scheduling/appointment-book), without the window where the original slots have been released but the new booking has not yet committed.
+
+## Use Cases
+
+- **Patient-initiated reschedule**: Move an existing appointment to a new time chosen from `$find` results
+- **Staff-initiated reschedule**: Change an appointment from an admin or scheduling workflow
+- **Avoiding double-booking races**: Keep cancel and book in one serializable transaction so another request cannot take the new slot, and so a failed booking does not leave the original appointment cancelled
+
+## Invoke the `$reschedule` operation
+
+```
+[base]/R4/Appointment/:id/$reschedule
+```
+
+<Tabs>
+<TabItem value="ts" label="TypeScript">
+  <MedplumCodeBlock language="ts" selectBlocks="rescheduleOne">
+    {ExampleCode}
+  </MedplumCodeBlock>
+</TabItem>
+<TabItem value="curl" label="cURL">
+
+```bash
+curl -X POST 'https://api.medplum.com/fhir/R4/Appointment/my-appointment-id/$reschedule' \
+  -H "Content-Type: application/fhir+json" \
+  -H "Authorization: Bearer MY_ACCESS_TOKEN" \
+  -d '{
+    "resourceType": "Parameters",
+    "parameter": [
+      {
+        "name": "appointment",
+        "resource": {
+          "resourceType": "Appointment",
+          "status": "proposed",
+          "start": "2026-03-11T09:00:00.000Z",
+          "end": "2026-03-11T10:00:00.000Z",
+          "serviceType": [
+            {
+              "coding": [{ "code": "initial-visit" }],
+              "extension": [
+                {
+                  "url": "https://medplum.com/fhir/service-type-reference",
+                  "valueReference": { "reference": "HealthcareService/my-healthcareservice-id" }
+                }
+              ]
+            }
+          ],
+          "participant": [
+            {
+              "actor": { "reference": "Practitioner/dr-smith" },
+              "required": "required",
+              "status": "needs-action"
+            }
+          ],
+          "contained": [
+            {
+              "resourceType": "Slot",
+              "status": "busy",
+              "schedule": { "reference": "Schedule/dr-smith-schedule" },
+              "start": "2026-03-11T09:00:00.000Z",
+              "end": "2026-03-11T10:00:00.000Z"
+            }
+          ]
+        }
+      }
+    ]
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+## Parameters
+
+The appointment being replaced is identified by the `id` in the URL. The new time is supplied as a proposed `Appointment`, the same input [`$book`](/docs/scheduling/appointment-book) accepts.
+
+| Name          | Type          | Description                                                                                                       | Required |
+| ------------- | ------------- | ----------------------------------------------------------------------------------------------------------------- | -------- |
+| `appointment` | `Appointment` | A proposed `Appointment` resource (e.g. from `$find`). Must include `start`, `end`, `serviceType`, and contained Slots. | Yes      |
+
+### Constraints
+
+- The existing Appointment must have `status: booked` or `status: pending`. All other statuses are rejected.
+- All `Slot` resources referenced by the existing `Appointment.slot` must exist and be readable by the caller.
+- The proposed `appointment` parameter must satisfy the same constraints as [`$book`](/docs/scheduling/appointment-book).
+
+The easiest way to meet the input requirements is to use a result from a [`$find` operation](/docs/scheduling/appointment-find).
+
+## Output
+
+Returns `201 Created` with a [`Bundle`](/docs/api/fhir/resources/bundle) wrapping the newly persisted resources, identical to [`$book`](/docs/scheduling/appointment-book):
+
+- One [`Appointment`](/docs/api/fhir/resources/appointment) with `status: "booked"` (a new resource, not an update of the original)
+- One `Slot` per contained Slot with `status: "busy"`
+- Zero or more buffer `Slot` resources with `status: "busy-unavailable"`
+
+The original Appointment is updated to `status: cancelled` and its Slots are deleted. Those resources are not included in the response Bundle.
+
+## Reschedule Logic
+
+`$reschedule` performs the following steps atomically inside a database transaction:
+
+1. Validates the proposed Appointment (contained Slots, service type, scheduling parameters)
+2. Cancels the existing Appointment (`status: cancelled`) and deletes its Slots
+3. Checks that the new time is available (the original Slots no longer block it)
+4. Creates the new `Appointment`, busy `Slot`(s), and any buffer `Slot`(s)
+5. Returns the created resources in the response Bundle
+
+If the new time is not available, the entire transaction is rolled back and the original Appointment remains booked (or pending).
+
+## Error Responses
+
+### Appointment Not Found
+
+```json
+{
+  "resourceType": "OperationOutcome",
+  "issue": [{ "severity": "error", "code": "not-found", "details": { "text": "Not found" } }]
+}
+```
+
+### Appointment Not in Reschedulable State
+
+```json
+{
+  "resourceType": "OperationOutcome",
+  "issue": [{ "severity": "error", "code": "invalid", "details": { "text": "Appointment cannot be canceled in 'fulfilled' status" } }]
+}
+```
+
+### Time Not Available
+
+```json
+{
+  "resourceType": "OperationOutcome",
+  "issue": [{ "severity": "error", "code": "invalid", "details": { "text": "Requested time slot is not available" } }]
+}
+```
+
+## Related
+
+- [Appointment `$book`](/docs/scheduling/appointment-book) - Book an Appointment
+- [Appointment `$cancel`](/docs/scheduling/appointment-cancel) - Cancel an Appointment
+- [Appointment `$find`](/docs/scheduling/appointment-find) - Find available slots
+- [Scheduling Overview](/docs/scheduling) - High-level scheduling concepts
+- [`Appointment` resource](/docs/api/fhir/resources/appointment)
+- [`Slot` resource](/docs/api/fhir/resources/slot)

--- a/packages/docs/docs/scheduling/index.md
+++ b/packages/docs/docs/scheduling/index.md
@@ -75,10 +75,11 @@ Once a desired slot has been found, the appointment booking process can be handl
 
 | Operation                                          | Description                     | Status   |
 | -------------------------------------------------- | ------------------------------- | -------- |
-| [`$book`](/docs/scheduling/appointment-book)       | Book an appointment in one step | **Beta** |
-| [`$hold`](/docs/scheduling/appointment-hold)       | Create a pending appointment    | **Beta** |
-| [`$confirm`](/docs/scheduling/appointment-confirm) | Confirm a held appointment      | **Beta** |
-| [`$cancel`](/docs/scheduling/appointment-cancel)   | Cancel an appointment           | **Beta** |
+| [`$book`](/docs/scheduling/appointment-book)             | Book an appointment in one step                         | **Beta** |
+| [`$hold`](/docs/scheduling/appointment-hold)             | Create a pending appointment                            | **Beta** |
+| [`$confirm`](/docs/scheduling/appointment-confirm)       | Confirm a held appointment                              | **Beta** |
+| [`$cancel`](/docs/scheduling/appointment-cancel)         | Cancel an appointment                                   | **Beta** |
+| [`$reschedule`](/docs/scheduling/appointment-reschedule) | Cancel and book a new appointment in one transaction    | **Beta** |
 
 ---
 

--- a/packages/examples/src/scheduling/reschedule.ts
+++ b/packages/examples/src/scheduling/reschedule.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// start-block rescheduleOne
+import { isResource, MedplumClient } from '@medplum/core';
+import type { Appointment, Bundle, Slot } from '@medplum/fhirtypes';
+
+const medplum = new MedplumClient();
+
+// 1. Find a new available time
+const findUrl = medplum.fhirUrl('Appointment', '$find');
+findUrl.searchParams.append('start', '2026-03-11T00:00:00Z');
+findUrl.searchParams.append('end', '2026-03-11T23:59:59Z');
+findUrl.searchParams.append('service-type-reference', 'HealthcareService/my-healthcare-service-id');
+findUrl.searchParams.append('schedule', 'Schedule/my-schedule-id');
+const findBundle = (await medplum.get<Bundle<Appointment>>(findUrl)) as Bundle;
+
+// 2. Pick a proposed appointment from the results
+const proposedAppointment = findBundle.entry?.[0]?.resource as Appointment;
+
+// 3. Reschedule the existing appointment onto that new time
+const bundle = await medplum.post<Bundle<Appointment | Slot>>(
+  medplum.fhirUrl('Appointment', 'my-appointment-id', '$reschedule'),
+  {
+    resourceType: 'Parameters',
+    parameter: [
+      {
+        name: 'appointment',
+        resource: proposedAppointment,
+      },
+    ],
+  }
+);
+
+const appointment = bundle.entry?.map((e) => e.resource)?.find((e) => isResource<Appointment>(e, 'Appointment'));
+// end-block rescheduleOne
+
+console.log(appointment);

--- a/packages/server/src/fhir/operations/cancel.ts
+++ b/packages/server/src/fhir/operations/cancel.ts
@@ -6,6 +6,7 @@ import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type { Appointment } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
 import { withPaths } from '../../util/withpath';
+import type { Repository } from '../repo';
 import { makeOperationDefinition } from './definitions';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 import { assertAllLoaded } from './utils/scheduling';
@@ -20,6 +21,30 @@ const cancelOperation = makeOperationDefinition(
 );
 
 type CancelParameters = {};
+
+/**
+ * Cancels an Appointment and deletes the Slot resources it occupies.
+ * Must be called inside a transaction so concurrent booking cannot race.
+ *
+ * @param repo - The repository to use (typically a transaction-scoped repo).
+ * @param appointmentId - The Appointment id to cancel.
+ * @returns The updated Appointment with status `cancelled`.
+ */
+export async function cancelAppointment(repo: Repository, appointmentId: string): Promise<Appointment> {
+  const appointment = await repo.readResource<Appointment>('Appointment', appointmentId);
+  const slots = await repo.readReferences(appointment.slot ?? []).then((slots) => withPaths(slots, 'appointment.slot'));
+  assertAllLoaded(slots, 'Loading slots failed');
+
+  if (appointment.status !== 'pending' && appointment.status !== 'booked') {
+    throw new OperationOutcomeError(badRequest(`Appointment cannot be canceled in '${appointment.status}' status`));
+  }
+
+  appointment.status = 'cancelled';
+
+  const updatedAppointment = await repo.updateResource(appointment);
+  await Promise.all(slots.map((slot) => repo.deleteResource('Slot', slot.id)));
+  return updatedAppointment;
+}
 
 /**
  * Handles HTTP requests for the Appointment $cancel operation.
@@ -37,23 +62,7 @@ export async function appointmentCancelHandler(req: FhirRequest): Promise<FhirRe
   const appointmentId = req.params.id;
 
   const updatedAppointment = await ctx.repo.withTransaction(
-    async (txRepo) => {
-      const appointment = await txRepo.readResource<Appointment>('Appointment', appointmentId);
-      const slots = await txRepo
-        .readReferences(appointment.slot ?? [])
-        .then((slots) => withPaths(slots, 'appointment.slot'));
-      assertAllLoaded(slots, 'Loading slots failed');
-
-      if (appointment.status !== 'pending' && appointment.status !== 'booked') {
-        throw new OperationOutcomeError(badRequest(`Appointment cannot be canceled in '${appointment.status}' status`));
-      }
-
-      appointment.status = 'cancelled';
-
-      const updatedAppointment = await txRepo.updateResource(appointment);
-      await Promise.all(slots.map((slot) => txRepo.deleteResource('Slot', slot.id)));
-      return updatedAppointment;
-    },
+    async (txRepo) => cancelAppointment(txRepo, appointmentId),
     {
       resourceTypes: ['Appointment', 'Slot'],
       source: 'appointmentCancelHandler',

--- a/packages/server/src/fhir/operations/reschedule.test.ts
+++ b/packages/server/src/fhir/operations/reschedule.test.ts
@@ -1,0 +1,307 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import { createReference, isDefined, parseSearchRequest, toServiceTypeCodeableConcepts } from '@medplum/core';
+import type {
+  Appointment,
+  Bundle,
+  CodeableConcept,
+  HealthcareService,
+  Practitioner,
+  Resource,
+  Schedule,
+  Slot,
+} from '@medplum/fhirtypes';
+import express from 'express';
+import supertest from 'supertest';
+import { initApp, shutdownApp } from '../../app';
+import { loadTestConfig } from '../../config/loader';
+import { getGlobalSystemRepo } from '../../fhir/repo';
+import type { TestProjectResult } from '../../test.setup';
+import { createTestProject } from '../../test.setup';
+import type { SchedulingParametersExtensionExtension } from './utils/scheduling-parameters';
+
+const systemRepo = getGlobalSystemRepo();
+const app = express();
+const request = supertest(app);
+
+function isAppointment(obj: Resource): obj is Appointment {
+  return obj.resourceType === 'Appointment';
+}
+
+function isSlot(obj: Resource): obj is Slot {
+  return obj.resourceType === 'Slot';
+}
+
+const threeDayAvailability: SchedulingParametersExtensionExtension = {
+  url: 'availability',
+  extension: [
+    {
+      url: 'availableTime',
+      extension: [
+        { url: 'daysOfWeek', valueCode: 'tue' },
+        { url: 'daysOfWeek', valueCode: 'wed' },
+        { url: 'daysOfWeek', valueCode: 'thu' },
+        { url: 'availableStartTime', valueTime: '09:00:00' },
+        { url: 'availableEndTime', valueTime: '17:00:00' },
+      ],
+    },
+  ],
+};
+
+describe('Appointment/$reschedule', () => {
+  let project: TestProjectResult<{ withAccessToken: true }>;
+  let practitioner: WithId<Practitioner>;
+  let officeVisitService: WithId<HealthcareService>;
+  let schedule: WithId<Schedule>;
+
+  const officeVisit: CodeableConcept = {
+    coding: [{ system: 'https://example.com/fhir', code: 'office-visit' }],
+  };
+
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    config.transactionAttempts = 5;
+    await initApp(app, config);
+    project = await createTestProject({ withAccessToken: true });
+
+    practitioner = await systemRepo.createResource<Practitioner>({
+      resourceType: 'Practitioner',
+      meta: { project: project.project.id },
+      extension: [{ url: 'http://hl7.org/fhir/StructureDefinition/timezone', valueCode: 'America/New_York' }],
+    });
+
+    officeVisitService = await systemRepo.createResource<HealthcareService>({
+      resourceType: 'HealthcareService',
+      name: 'Office Visit',
+      type: [officeVisit],
+      meta: { project: project.project.id },
+    });
+
+    schedule = await systemRepo.createResource<Schedule>({
+      resourceType: 'Schedule',
+      meta: { project: project.project.id },
+      actor: [createReference(practitioner)],
+      serviceType: toServiceTypeCodeableConcepts(officeVisitService),
+      extension: [
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+          extension: [
+            threeDayAvailability,
+            { url: 'duration', valueDuration: { value: 60, unit: 'min' } },
+            { url: 'service', valueReference: createReference(officeVisitService) },
+          ],
+        },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  function proposedAppointment(start: string, end: string): Appointment {
+    return {
+      resourceType: 'Appointment',
+      status: 'proposed',
+      start,
+      end,
+      serviceType: toServiceTypeCodeableConcepts(officeVisitService),
+      participant: [{ actor: createReference(practitioner), status: 'tentative' }],
+      contained: [
+        {
+          resourceType: 'Slot',
+          status: 'busy',
+          schedule: createReference(schedule),
+          start,
+          end,
+        } satisfies Slot,
+      ],
+    };
+  }
+
+  async function bookAppointment(start: string, end: string): Promise<WithId<Appointment>> {
+    const response = await request
+      .post('/fhir/R4/Appointment/$book')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'appointment', resource: proposedAppointment(start, end) }],
+      });
+    expect(response).toHaveStatus(201);
+    const entries = ((response.body as Bundle).entry ?? []).map((e) => e.resource).filter(isDefined);
+    const appointment = entries.find(isAppointment);
+    expect(appointment?.id).toBeDefined();
+    return appointment as WithId<Appointment>;
+  }
+
+  test('cancels the original appointment and books a new one', async () => {
+    const original = await bookAppointment('2026-01-15T14:00:00Z', '2026-01-15T15:00:00Z');
+    const originalSlotIds = original.slot?.map((s) => s.reference?.split('/')[1]).filter(isDefined) ?? [];
+    const start = '2026-01-15T16:00:00Z';
+    const end = '2026-01-15T17:00:00Z';
+
+    const response = await request
+      .post(`/fhir/R4/Appointment/${original.id}/$reschedule`)
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'appointment', resource: proposedAppointment(start, end) }],
+      });
+
+    expect(response).toHaveStatus(201);
+
+    const entries = ((response.body as Bundle).entry ?? []).map((e) => e.resource).filter(isDefined);
+    const appointments = entries.filter(isAppointment);
+    expect(appointments).toHaveLength(1);
+    expect(appointments[0].id).not.toBe(original.id);
+    expect(appointments[0]).toMatchObject({ status: 'booked', start, end });
+
+    const slots = entries.filter(isSlot);
+    expect(slots).toHaveLength(1);
+    expect(slots[0]).toMatchObject({ status: 'busy', start, end });
+
+    const cancelled = await systemRepo.readResource<Appointment>('Appointment', original.id);
+    expect(cancelled.status).toBe('cancelled');
+
+    const remainingOriginalSlots = await systemRepo.searchResources<Slot>(
+      parseSearchRequest(`Slot?_id=${originalSlotIds.join(',')}`)
+    );
+    expect(remainingOriginalSlots).toHaveLength(0);
+  });
+
+  test('succeeds for a pending appointment', async () => {
+    const holdResponse = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'appointment', resource: proposedAppointment('2026-01-14T14:00:00Z', '2026-01-14T15:00:00Z') },
+        ],
+      });
+    expect(holdResponse).toHaveStatus(201);
+    const held = ((holdResponse.body as Bundle).entry ?? [])
+      .map((e) => e.resource)
+      .filter(isDefined)
+      .find(isAppointment);
+    expect(held?.id).toBeDefined();
+    expect(held?.status).toBe('pending');
+
+    const start = '2026-01-14T16:00:00Z';
+    const end = '2026-01-14T17:00:00Z';
+    const response = await request
+      .post(`/fhir/R4/Appointment/${held?.id}/$reschedule`)
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'appointment', resource: proposedAppointment(start, end) }],
+      });
+
+    expect(response).toHaveStatus(201);
+    const cancelled = await systemRepo.readResource<Appointment>('Appointment', held?.id as string);
+    expect(cancelled.status).toBe('cancelled');
+  });
+
+  test('can reuse the original time window after releasing its slots', async () => {
+    const start = '2026-01-13T14:00:00Z';
+    const end = '2026-01-13T15:00:00Z';
+    const original = await bookAppointment(start, end);
+
+    const response = await request
+      .post(`/fhir/R4/Appointment/${original.id}/$reschedule`)
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'appointment', resource: proposedAppointment(start, end) }],
+      });
+
+    expect(response).toHaveStatus(201);
+    const cancelled = await systemRepo.readResource<Appointment>('Appointment', original.id);
+    expect(cancelled.status).toBe('cancelled');
+  });
+
+  test('leaves the original appointment booked when the new time is unavailable', async () => {
+    const original = await bookAppointment('2026-01-15T18:00:00Z', '2026-01-15T19:00:00Z');
+    const start = '2026-01-15T07:00:00-04:00';
+    const end = '2026-01-15T08:00:00-04:00';
+
+    const response = await request
+      .post(`/fhir/R4/Appointment/${original.id}/$reschedule`)
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'appointment', resource: proposedAppointment(start, end) }],
+      });
+
+    expect(response).toHaveStatus(400);
+    expect(response.body).toMatchObject({
+      resourceType: 'OperationOutcome',
+      issue: [{ severity: 'error', code: 'invalid', details: { text: 'Requested time slot is not available' } }],
+    });
+
+    const stillBooked = await systemRepo.readResource<Appointment>('Appointment', original.id);
+    expect(stillBooked.status).toBe('booked');
+  });
+
+  test.each(['cancelled', 'fulfilled', 'noshow', 'entered-in-error'] as Appointment['status'][])(
+    'returns 400 for non-reschedulable status: %s',
+    async (status) => {
+      const noStartEnd: Appointment['status'][] = ['cancelled'];
+      const appointment = await systemRepo.createResource<Appointment>({
+        resourceType: 'Appointment',
+        status,
+        ...(noStartEnd.includes(status) ? {} : { start: '2026-01-15T14:00:00Z', end: '2026-01-15T15:00:00Z' }),
+        participant: [{ actor: createReference(practitioner), status: 'accepted' }],
+        meta: { project: project.project.id },
+      });
+
+      const response = await request
+        .post(`/fhir/R4/Appointment/${appointment.id}/$reschedule`)
+        .set('Authorization', `Bearer ${project.accessToken}`)
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'appointment', resource: proposedAppointment('2026-01-15T16:00:00Z', '2026-01-15T17:00:00Z') },
+          ],
+        });
+
+      expect(response).toHaveStatus(400);
+      expect(response.body).toMatchObject({
+        resourceType: 'OperationOutcome',
+        issue: [
+          {
+            severity: 'error',
+            code: 'invalid',
+            details: { text: `Appointment cannot be canceled in '${status}' status` },
+          },
+        ],
+      });
+    }
+  );
+
+  test('returns 404 when the original appointment does not exist', async () => {
+    const response = await request
+      .post('/fhir/R4/Appointment/00000000-0000-0000-0000-000000000000/$reschedule')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'appointment', resource: proposedAppointment('2026-01-15T16:00:00Z', '2026-01-15T17:00:00Z') },
+        ],
+      });
+
+    expect(response).toHaveStatus(404);
+  });
+
+  test('returns 400 when the appointment parameter is missing', async () => {
+    const original = await bookAppointment('2026-01-14T18:00:00Z', '2026-01-14T19:00:00Z');
+
+    const response = await request
+      .post(`/fhir/R4/Appointment/${original.id}/$reschedule`)
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({ resourceType: 'Parameters', parameter: [] });
+
+    expect(response).toHaveStatus(400);
+  });
+});

--- a/packages/server/src/fhir/operations/reschedule.ts
+++ b/packages/server/src/fhir/operations/reschedule.ts
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { created } from '@medplum/core';
+import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
+import type { Appointment } from '@medplum/fhirtypes';
+import { getAuthenticatedContext } from '../../context';
+import { withPath } from '../../util/withpath';
+import { cancelAppointment } from './cancel';
+import { makeOperationDefinition } from './definitions';
+import { buildOutputParameters, parseInputParameters } from './utils/parameters';
+import { createProposedAppointment } from './utils/scheduling';
+
+const rescheduleOperation = makeOperationDefinition(
+  { scope: 'instance', resource: 'Appointment' },
+  {
+    name: 'reschedule',
+    code: 'reschedule',
+    parameter: [
+      { use: 'in', name: 'appointment', type: 'Appointment', min: 1, max: '1' },
+      { use: 'out', name: 'return', type: 'Bundle', min: 0, max: '1' },
+    ],
+  }
+);
+
+type RescheduleParameters = {
+  appointment: Appointment;
+};
+
+/**
+ * Handles HTTP requests for the Appointment $reschedule operation.
+ *
+ * Atomically cancels the existing Appointment and books a new one in a single
+ * transaction, equivalent to `$cancel` followed by `$book`.
+ *
+ * Endpoints:
+ *   [fhir base]/Appointment/:id/$reschedule
+ *
+ * @experimental - Scheduling Beta API
+ * @param req - The FHIR request.
+ * @returns The FHIR response.
+ */
+export async function appointmentRescheduleHandler(req: FhirRequest): Promise<FhirResponse> {
+  const ctx = getAuthenticatedContext();
+  const params = parseInputParameters<RescheduleParameters>(rescheduleOperation, req);
+  const appointmentId = req.params.id;
+
+  const bundle = await createProposedAppointment(
+    ctx.repo,
+    withPath(params.appointment, 'Parameters.appointment'),
+    (appointment) => {
+      appointment.status = 'booked';
+    },
+    {
+      beforeCreate: async (txRepo) => {
+        await cancelAppointment(txRepo, appointmentId);
+      },
+    }
+  );
+
+  return [created, buildOutputParameters(rescheduleOperation, bundle)];
+}

--- a/packages/server/src/fhir/operations/utils/scheduling.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.ts
@@ -720,10 +720,20 @@ export async function validateAllAvailability(
   }
 }
 
+export type CreateProposedAppointmentOptions = {
+  /**
+   * Runs inside the same serializable transaction, before availability is
+   * checked and new Slot/Appointment resources are written. Used by $reschedule
+   * to cancel the previous appointment so its slots no longer block the new time.
+   */
+  beforeCreate?: (repo: Repository) => Promise<void>;
+};
+
 export async function createProposedAppointment(
   repo: Repository,
   proposedAppointment: WithPath<Appointment>,
-  customizer: (appointment: Appointment, slots: Slot[]) => void
+  customizer: (appointment: Appointment, slots: Slot[]) => void,
+  options?: CreateProposedAppointmentOptions
 ): Promise<Bundle<Appointment | Slot>> {
   const [appointment, slots, healthcareService, schedulingParametersGroup] = await validateProposedAppointment(
     repo,
@@ -741,6 +751,7 @@ export async function createProposedAppointment(
 
   const createdResources = await repo.withTransaction(
     async (txRepo) => {
+      await options?.beforeCreate?.(txRepo);
       await validateAllAvailability(txRepo, slots, healthcareService, schedulingParametersGroup);
       const createdSlots = await Promise.all(slots.map((slot) => txRepo.createResource<Slot>(slot)));
       const createdAppointment = await txRepo.createResource<Appointment>({

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -77,6 +77,7 @@ import { projectCloneHandler } from './operations/projectclone';
 import { projectInitHandler } from './operations/projectinit';
 import { rebuildBaseDefinitionsOperation } from './operations/rebuild-base-definitions';
 import { refreshReferenceDisplayHandler } from './operations/refresh-reference-display';
+import { appointmentRescheduleHandler } from './operations/reschedule';
 import { userRescopeOperation } from './operations/rescope';
 import { resourceGraphHandler } from './operations/resourcegraph';
 import { rotateSecretHandler } from './operations/rotatesecret';
@@ -424,6 +425,7 @@ function initInternalFhirRouter(): FhirRouter {
   router.add('POST', '/Appointment/$hold', appointmentHoldHandler);
   router.add('POST', '/Appointment/:id/$cancel', appointmentCancelHandler);
   router.add('POST', '/Appointment/:id/$confirm', appointmentConfirmHandler);
+  router.add('POST', '/Appointment/:id/$reschedule', appointmentRescheduleHandler);
 
   // PackageRelease $install operation
   router.add('POST', '/PackageRelease/:id/$install', packageInstallHandler);


### PR DESCRIPTION
## Summary
- Add `POST /fhir/R4/Appointment/:id/$reschedule`, which atomically cancels the existing appointment and books a new one in a single serializable transaction (`$cancel` + `$book`).
- If the new time is unavailable, the original appointment stays booked. The original time window can be reused because its slots are released before availability is checked.
- Document the beta operation and add server tests for the happy path, pending appointments, rollback, and invalid statuses.

Fixes #10423

## Test plan
- [x] `cd packages/server && npm t -- src/fhir/operations/reschedule.test.ts` (10 passed)
- [x] `cd packages/server && npm t -- src/fhir/operations/cancel.test.ts` (12 passed)
- [ ] Confirm GitHub CI is green
- [ ] Review the instance-level API: proposed `appointment` parameter matches `$book` input