### PR TITLE
[SchedulingWorkspace] Add appointment details with cancel button

### DIFF
--- a/packages/react-scheduling/src/MultiCalendar/MultiCalendar.module.css
+++ b/packages/react-scheduling/src/MultiCalendar/MultiCalendar.module.css
@@ -27,8 +27,13 @@
 }
 
 :global(.appointment.cancelled),
-:global(.appointment.noshow) {
+:global(.appointment.noshow),
+:global(.appointment.entered-in-error) {
   --status-color: var(--mantine-color-red-3);
+}
+
+:global(.appointment.waitlist) {
+  --status-color: var(--mantine-color-gray-3);
 }
 
 .eventTime {

--- a/packages/react-scheduling/src/SchedulingWorkspace/AppointmentDetails/AppointmentDetails.stories.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/AppointmentDetails/AppointmentDetails.stories.tsx
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Paper } from '@mantine/core';
+import type { WithId } from '@medplum/core';
+import type { Appointment } from '@medplum/fhirtypes';
+import type { Meta } from '@storybook/react';
+import type { JSX } from 'react';
+import { useState } from 'react';
+import { withFixtures, withMockedDate } from '../../stories/decorators';
+import { RiveraImagingAppointment } from '../../stories/scheduling';
+import { AppointmentDetails } from './AppointmentDetails';
+
+const STORY_FIXTURES = [RiveraImagingAppointment];
+
+export default {
+  title: 'Medplum/SchedulingWorkspace/AppointmentDetails',
+  component: AppointmentDetails,
+  decorators: [withFixtures(STORY_FIXTURES), withMockedDate],
+  parameters: {
+    skipDefaultSeeding: true,
+  },
+} as Meta;
+
+/**
+ * Everything on file for one visit, and controls for managing the visit.
+ *
+ * - Controls for rescheduling/reassigning coming soon!
+ *
+ * @returns The story.
+ */
+export const Basic = (): JSX.Element => {
+  const [appointment, setAppointment] = useState<WithId<Appointment>>(RiveraImagingAppointment);
+
+  return (
+    <Paper withBorder p="md" maw={320}>
+      <AppointmentDetails appointment={appointment} onCancelled={setAppointment} />
+    </Paper>
+  );
+};

--- a/packages/react-scheduling/src/SchedulingWorkspace/AppointmentDetails/AppointmentDetails.stories.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/AppointmentDetails/AppointmentDetails.stories.tsx
@@ -6,16 +6,40 @@ import type { Appointment } from '@medplum/fhirtypes';
 import type { Meta } from '@storybook/react';
 import type { JSX } from 'react';
 import { useState } from 'react';
-import { withFixtures, withMockedDate } from '../../stories/decorators';
+import { APPOINTMENT_CANCELLATION_REASON_CODE_SYSTEM } from '../../constants';
+import { withCancelStub, withFixtures, withMockedDate, withValueSetStub } from '../../stories/decorators';
 import { RiveraImagingAppointment } from '../../stories/scheduling';
 import { AppointmentDetails } from './AppointmentDetails';
 
-const STORY_FIXTURES = [RiveraImagingAppointment];
+const CancelledAppointment: WithId<Appointment> = {
+  ...RiveraImagingAppointment,
+  id: 'appt-rivera-imaging-tue-cancelled',
+  status: 'cancelled',
+  cancelationReason: {
+    coding: [
+      {
+        system: APPOINTMENT_CANCELLATION_REASON_CODE_SYSTEM,
+        code: 'pat-fb',
+        display: 'Patient: Feeling Better',
+      },
+    ],
+  },
+};
+
+const STORY_FIXTURES = [RiveraImagingAppointment, CancelledAppointment];
 
 export default {
   title: 'Medplum/SchedulingWorkspace/AppointmentDetails',
   component: AppointmentDetails,
-  decorators: [withFixtures(STORY_FIXTURES), withMockedDate],
+  decorators: [
+    // Mock out the `$cancel` operation in our MockClient
+    withCancelStub(),
+    // We use a ValueSet (`appointment-cancellation-reason`) that is not
+    // preloaded in the MockClient, so we set up a value set stub.
+    withValueSetStub(),
+    withFixtures(STORY_FIXTURES),
+    withMockedDate,
+  ],
   parameters: {
     skipDefaultSeeding: true,
   },
@@ -23,6 +47,10 @@ export default {
 
 /**
  * Everything on file for one visit, and controls for managing the visit.
+ *
+ * - Cancelling: requires selecting a `cancelationReason` from the
+ *   `appointment-cancellation-reason` value set, which is sent as part of a
+ *   `$cancel` request.
  *
  * - Controls for rescheduling/reassigning coming soon!
  *
@@ -37,3 +65,15 @@ export const Basic = (): JSX.Element => {
     </Paper>
   );
 };
+
+/**
+ * A visit that has already been called off: `$cancel` would refuse it, so there is no
+ * button and it says as much.
+ *
+ * @returns The story.
+ */
+export const Cancelled = (): JSX.Element => (
+  <Paper withBorder p="md" maw={320}>
+    <AppointmentDetails appointment={CancelledAppointment} />
+  </Paper>
+);

--- a/packages/react-scheduling/src/SchedulingWorkspace/AppointmentDetails/AppointmentDetails.test.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/AppointmentDetails/AppointmentDetails.test.tsx
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import type { Appointment, Slot } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import type { RenderResult } from '@testing-library/react';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { renderWithMedplum, screen } from '../../test-utils/render';
+import { AppointmentDetails } from './AppointmentDetails';
+
+const HELD_SLOT: WithId<Slot> = {
+  resourceType: 'Slot',
+  id: 'slot-rivera-tue',
+  status: 'busy',
+  schedule: { reference: 'Schedule/schedule-dr-rivera' },
+  start: '2020-05-05T17:00:00Z',
+  end: '2020-05-05T17:30:00Z',
+};
+
+const BOOKED_APPOINTMENT: WithId<Appointment> = {
+  resourceType: 'Appointment',
+  id: 'appt-rivera-imaging-tue',
+  status: 'booked',
+  start: '2020-05-05T17:00:00Z',
+  end: '2020-05-05T17:30:00Z',
+  serviceType: [{ text: 'Ultrasound Imaging' }],
+  comment: 'Bring prior films',
+  slot: [{ reference: `Slot/${HELD_SLOT.id}` }],
+  participant: [
+    { status: 'accepted', actor: { reference: 'Patient/pt-cooper', display: 'Miles Cooper' } },
+    { status: 'accepted', actor: { reference: 'Practitioner/dr-rivera', display: 'Dr. Maya Rivera' } },
+    { status: 'accepted', actor: { reference: 'Device/ultrasound-1', display: 'Ultrasound 1' } },
+  ],
+};
+
+let medplum: MockClient;
+
+beforeEach(async () => {
+  medplum = new MockClient();
+  await medplum.createResource(HELD_SLOT);
+  await medplum.createResource(BOOKED_APPOINTMENT);
+});
+
+function renderDetails(appointment: WithId<Appointment>): RenderResult {
+  return renderWithMedplum(<AppointmentDetails appointment={appointment} />, medplum);
+}
+
+describe('AppointmentDetails', () => {
+  test('describes the appointment', () => {
+    renderDetails(BOOKED_APPOINTMENT);
+
+    expect(screen.getByText('booked')).toBeInTheDocument();
+    expect(screen.getByText('Miles Cooper')).toBeInTheDocument();
+    expect(screen.getByText('Ultrasound Imaging')).toBeInTheDocument();
+    expect(screen.getByText('Bring prior films')).toBeInTheDocument();
+    // Everyone but the patient, in one line.
+    expect(screen.getByText('Dr. Maya Rivera, Ultrasound 1')).toBeInTheDocument();
+    // The day and the times it runs between, in the timezone the browser is in.
+    expect(screen.getByText(/Tuesday, May 5/)).toBeInTheDocument();
+  });
+
+  test('leaves out what is not on file', () => {
+    renderDetails({
+      resourceType: 'Appointment',
+      id: 'appt-bare',
+      status: 'booked',
+      participant: [{ status: 'accepted', actor: { reference: 'Practitioner/dr-rivera' } }],
+    });
+
+    expect(screen.queryByText('When')).not.toBeInTheDocument();
+    expect(screen.queryByText('Service')).not.toBeInTheDocument();
+    expect(screen.queryByText('Patient')).not.toBeInTheDocument();
+    expect(screen.queryByText('Notes')).not.toBeInTheDocument();
+    // A participant with no display name is still named, by what it points at.
+    expect(screen.getByText('Practitioner/dr-rivera')).toBeInTheDocument();
+  });
+});

--- a/packages/react-scheduling/src/SchedulingWorkspace/AppointmentDetails/AppointmentDetails.test.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/AppointmentDetails/AppointmentDetails.test.tsx
@@ -1,11 +1,14 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import type { Appointment, Slot } from '@medplum/fhirtypes';
+import type { Appointment, Parameters, Slot } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import type { RenderResult } from '@testing-library/react';
-import { beforeEach, describe, expect, test } from 'vitest';
-import { renderWithMedplum, screen } from '../../test-utils/render';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { APPOINTMENT_CANCELLATION_REASON_CODE_SYSTEM } from '../../constants';
+import { installCancelStub } from '../../stories/mockCancel';
+import { installValueSetStub } from '../../stories/mockValueSet';
+import { renderWithMedplum, screen, userEvent, waitFor } from '../../test-utils/render';
 import { AppointmentDetails } from './AppointmentDetails';
 
 const HELD_SLOT: WithId<Slot> = {
@@ -34,15 +37,40 @@ const BOOKED_APPOINTMENT: WithId<Appointment> = {
 };
 
 let medplum: MockClient;
+let restoreCancel: () => void;
+let restoreValueSet: () => void;
 
 beforeEach(async () => {
   medplum = new MockClient();
   await medplum.createResource(HELD_SLOT);
   await medplum.createResource(BOOKED_APPOINTMENT);
+  restoreCancel = installCancelStub(medplum);
+  restoreValueSet = installValueSetStub(medplum);
+  return () => {
+    restoreCancel();
+    restoreValueSet();
+  };
 });
 
-function renderDetails(appointment: WithId<Appointment>): RenderResult {
-  return renderWithMedplum(<AppointmentDetails appointment={appointment} />, medplum);
+function renderDetails(appointment: WithId<Appointment>, onCancelled?: (a: WithId<Appointment>) => void): RenderResult {
+  return renderWithMedplum(<AppointmentDetails appointment={appointment} onCancelled={onCancelled} />, medplum);
+}
+
+function cancelButton(): HTMLElement | null {
+  return screen.queryByRole('button', { name: 'Cancel Appointment' });
+}
+
+/**
+ * Chooses a reason for the cancellation, which nothing can be cancelled without.
+ *
+ * Typed rather than picked off the open list: the field asks the server for ten matches at
+ * a time, so a reason far down the code system is only offered once it is searched for.
+ *
+ * @param label - The reason to choose, as the expansion displays it.
+ */
+async function chooseReason(label = 'Patient: Feeling Better'): Promise<void> {
+  await userEvent.type(screen.getByPlaceholderText('Search reasons'), label);
+  await userEvent.click(await screen.findByRole('option', { name: label }));
 }
 
 describe('AppointmentDetails', () => {
@@ -73,5 +101,121 @@ describe('AppointmentDetails', () => {
     expect(screen.queryByText('Notes')).not.toBeInTheDocument();
     // A participant with no display name is still named, by what it points at.
     expect(screen.getByText('Practitioner/dr-rivera')).toBeInTheDocument();
+  });
+
+  test('cancelling posts $cancel and reports the cancelled appointment', async () => {
+    const post = vi.spyOn(medplum, 'post');
+    const onCancelled = vi.fn();
+    renderDetails(BOOKED_APPOINTMENT, onCancelled);
+
+    await chooseReason();
+    await userEvent.click(cancelButton() as HTMLElement);
+
+    await waitFor(() => expect(onCancelled).toHaveBeenCalled());
+    expect(post.mock.calls[0][0].toString()).toContain(`Appointment/${BOOKED_APPOINTMENT.id}/$cancel`);
+    expect(onCancelled.mock.calls[0][0]).toMatchObject({ id: BOOKED_APPOINTMENT.id, status: 'cancelled' });
+
+    // The appointment is cancelled on the server, and the time it held is gone.
+    const stored = await medplum.readResource('Appointment', BOOKED_APPOINTMENT.id);
+    expect(stored.status).toBe('cancelled');
+  });
+
+  test('announces the cancelled appointment and the times it released', async () => {
+    const notify = vi.spyOn(medplum, 'notifyResourceModified');
+    const onCancelled = vi.fn();
+    renderDetails(BOOKED_APPOINTMENT, onCancelled);
+
+    await chooseReason();
+    await userEvent.click(cancelButton() as HTMLElement);
+
+    await waitFor(() => expect(onCancelled).toHaveBeenCalled());
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceType: 'Appointment',
+        operation: 'update',
+        id: BOOKED_APPOINTMENT.id,
+        resource: expect.objectContaining({ status: 'cancelled' }),
+      })
+    );
+    expect(notify).toHaveBeenCalledWith({ resourceType: 'Slot', operation: 'delete', id: HELD_SLOT.id });
+  });
+
+  test('shows the refusal when $cancel fails', async () => {
+    const onCancelled = vi.fn();
+    vi.spyOn(medplum, 'post').mockRejectedValue(new Error('Appointment cannot be canceled'));
+    renderDetails(BOOKED_APPOINTMENT, onCancelled);
+
+    await chooseReason();
+    await userEvent.click(cancelButton() as HTMLElement);
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.getByText('Appointment cannot be canceled')).toBeInTheDocument();
+    expect(onCancelled).not.toHaveBeenCalled();
+    // Still offering to try again.
+    expect(cancelButton()).toBeInTheDocument();
+  });
+
+  test('offers no cancellation until a reason is chosen', async () => {
+    renderDetails(BOOKED_APPOINTMENT);
+
+    expect(cancelButton()).toBeDisabled();
+
+    await chooseReason();
+
+    expect(cancelButton()).toBeEnabled();
+  });
+
+  test('sends the chosen reason to $cancel', async () => {
+    const post = vi.spyOn(medplum, 'post');
+    const onCancelled = vi.fn();
+    renderDetails(BOOKED_APPOINTMENT, onCancelled);
+
+    await chooseReason('Provider: Hospitalized');
+    await userEvent.click(cancelButton() as HTMLElement);
+
+    await waitFor(() => expect(onCancelled).toHaveBeenCalled());
+    const parameters = post.mock.calls[0][1] as Parameters;
+    expect(parameters.parameter).toEqual([
+      {
+        name: 'cancelationReason',
+        valueCodeableConcept: {
+          coding: [
+            {
+              system: APPOINTMENT_CANCELLATION_REASON_CODE_SYSTEM,
+              code: 'prov-hosp',
+              display: 'Provider: Hospitalized',
+            },
+          ],
+        },
+      },
+    ]);
+
+    // And it is on the appointment the operation wrote.
+    const stored = await medplum.readResource('Appointment', BOOKED_APPOINTMENT.id);
+    expect(stored.cancelationReason?.coding?.[0].code).toBe('prov-hosp');
+  });
+
+  test('shows the reason a cancelled appointment carries', () => {
+    renderDetails({
+      ...BOOKED_APPOINTMENT,
+      status: 'cancelled',
+      cancelationReason: { coding: [{ code: 'pat-fb', display: 'Patient: Feeling Better' }] },
+    });
+
+    expect(screen.getByText('Patient: Feeling Better')).toBeInTheDocument();
+  });
+
+  test('offers no cancellation for an appointment $cancel would refuse', () => {
+    renderDetails({ ...BOOKED_APPOINTMENT, status: 'cancelled' });
+
+    expect(cancelButton()).not.toBeInTheDocument();
+    expect(screen.getByText('This appointment is cancelled.')).toBeInTheDocument();
+  });
+
+  test('says why an appointment already seen cannot be cancelled', () => {
+    renderDetails({ ...BOOKED_APPOINTMENT, status: 'fulfilled' });
+
+    expect(cancelButton()).not.toBeInTheDocument();
+    expect(screen.getByText("An appointment in 'fulfilled' status cannot be cancelled.")).toBeInTheDocument();
   });
 });

--- a/packages/react-scheduling/src/SchedulingWorkspace/AppointmentDetails/AppointmentDetails.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/AppointmentDetails/AppointmentDetails.tsx
@@ -29,7 +29,7 @@ const STATUS_COLORS: Record<Appointment['status'], string> = {
 
 export interface AppointmentDetailsProps {
   readonly appointment: WithId<Appointment>;
-  readonly onCancelled?: (appointment: WithId<Appointment>) => void;
+  readonly onCancelled?: (appointment: WithId<Appointment>) => void | Promise<void>;
   /** Overrides the value set the cancellation reason is coded against. */
   readonly cancellationReasonValueSet?: string;
 }
@@ -98,7 +98,11 @@ export function AppointmentDetails(props: AppointmentDetailsProps): JSX.Element 
         }
       }
 
-      onCancelled?.(cancelled);
+      try {
+        await onCancelled?.(cancelled);
+      } catch (error) {
+        console.error(error);
+      }
     } catch (err: unknown) {
       setCancelError(err);
     } finally {

--- a/packages/react-scheduling/src/SchedulingWorkspace/AppointmentDetails/AppointmentDetails.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/AppointmentDetails/AppointmentDetails.tsx
@@ -3,14 +3,8 @@
 import { Alert, Badge, Button, Divider, Stack, Text } from '@mantine/core';
 import type { WithId } from '@medplum/core';
 import { formatCodeableConcept, isDefined, normalizeErrorString, resolveId } from '@medplum/core';
-import type {
-  Appointment,
-  AppointmentParticipant,
-  Parameters,
-  Reference,
-  ValueSetExpansionContains,
-} from '@medplum/fhirtypes';
-import { ReferenceDisplay, ValueSetAutocomplete } from '@medplum/react';
+import type { Appointment, AppointmentParticipant, CodeableConcept, Parameters, Reference } from '@medplum/fhirtypes';
+import { CodeableConceptInput, ReferenceDisplay } from '@medplum/react';
 import { useMedplum } from '@medplum/react-hooks';
 import type { JSX, ReactNode } from 'react';
 import { Fragment, useCallback, useState } from 'react';
@@ -18,7 +12,7 @@ import { formatDayHeading, formatZonedTime } from '../../AppointmentFinder/Appoi
 import { APPOINTMENT_CANCELLATION_REASON_VALUE_SET } from '../../constants';
 
 /** The statuses `Appointment/:id/$cancel` accepts. It refuses any other with a 400. */
-const CANCELABLE_STATUSES: readonly Appointment['status'][] = ['pending', 'booked'];
+const CANCELABLE_STATUSES: ReadonlySet<Appointment['status']> = new Set(['pending', 'booked']);
 
 const STATUS_COLORS: Record<Appointment['status'], string> = {
   proposed: 'yellow',
@@ -65,7 +59,7 @@ export function AppointmentDetails(props: AppointmentDetailsProps): JSX.Element 
   const otherActors = getOtherActors(appointment);
   const [cancelling, setCancelling] = useState(false);
   const [cancelError, setCancelError] = useState<unknown>();
-  const [reason, setReason] = useState<ValueSetExpansionContains>();
+  const [reason, setReason] = useState<CodeableConcept>();
 
   const cancel = useCallback(async (): Promise<void> => {
     if (!reason) {
@@ -81,9 +75,7 @@ export function AppointmentDetails(props: AppointmentDetailsProps): JSX.Element 
           parameter: [
             {
               name: 'cancelationReason',
-              valueCodeableConcept: {
-                coding: [{ system: reason.system, code: reason.code, display: reason.display }],
-              },
+              valueCodeableConcept: reason,
             },
           ],
         } satisfies Parameters
@@ -141,23 +133,20 @@ export function AppointmentDetails(props: AppointmentDetailsProps): JSX.Element 
           {normalizeErrorString(cancelError)}
         </Alert>
       )}
-      {CANCELABLE_STATUSES.includes(appointment.status) ? (
+      {CANCELABLE_STATUSES.has(appointment.status) ? (
         <>
-          {/*
-           * Coded against the value set rather than against a list kept here, and not
-           * `creatable`: a reason typed in by hand would be written as a code no
-           * terminology knows.
-           */}
-          <ValueSetAutocomplete
+          <CodeableConceptInput
+            name="cancelationReason"
+            path="Appointment.cancelationReason"
             binding={cancellationReasonValueSet ?? APPOINTMENT_CANCELLATION_REASON_VALUE_SET}
             label="Cancellation reason"
             placeholder="Search reasons"
             maxValues={1}
             creatable={false}
+            withHelpText={false}
             required
-            onChange={(reasons) => setReason(reasons[0])}
+            onChange={setReason}
           />
-          {/* Nothing is cancelled without a reason for it. */}
           <Button color="red" variant="light" loading={cancelling} disabled={!reason} onClick={cancel}>
             Cancel Appointment
           </Button>

--- a/packages/react-scheduling/src/SchedulingWorkspace/AppointmentDetails/AppointmentDetails.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/AppointmentDetails/AppointmentDetails.tsx
@@ -1,13 +1,24 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Badge, Stack, Text } from '@mantine/core';
+import { Alert, Badge, Button, Divider, Stack, Text } from '@mantine/core';
 import type { WithId } from '@medplum/core';
-import { formatCodeableConcept, isDefined } from '@medplum/core';
-import type { Appointment, AppointmentParticipant, Reference } from '@medplum/fhirtypes';
-import { ReferenceDisplay } from '@medplum/react';
+import { formatCodeableConcept, isDefined, normalizeErrorString, resolveId } from '@medplum/core';
+import type {
+  Appointment,
+  AppointmentParticipant,
+  Parameters,
+  Reference,
+  ValueSetExpansionContains,
+} from '@medplum/fhirtypes';
+import { ReferenceDisplay, ValueSetAutocomplete } from '@medplum/react';
+import { useMedplum } from '@medplum/react-hooks';
 import type { JSX, ReactNode } from 'react';
-import { Fragment } from 'react';
+import { Fragment, useCallback, useState } from 'react';
 import { formatDayHeading, formatZonedTime } from '../../AppointmentFinder/AppointmentFinder.times';
+import { APPOINTMENT_CANCELLATION_REASON_VALUE_SET } from '../../constants';
+
+/** The statuses `Appointment/:id/$cancel` accepts. It refuses any other with a 400. */
+const CANCELABLE_STATUSES: readonly Appointment['status'][] = ['pending', 'booked'];
 
 const STATUS_COLORS: Record<Appointment['status'], string> = {
   proposed: 'yellow',
@@ -48,9 +59,60 @@ export interface AppointmentDetailsProps {
  * @returns The details component
  */
 export function AppointmentDetails(props: AppointmentDetailsProps): JSX.Element {
-  const { appointment } = props;
+  const { appointment, onCancelled, cancellationReasonValueSet } = props;
+  const medplum = useMedplum();
   const patient = getPatientParticipant(appointment)?.actor;
   const otherActors = getOtherActors(appointment);
+  const [cancelling, setCancelling] = useState(false);
+  const [cancelError, setCancelError] = useState<unknown>();
+  const [reason, setReason] = useState<ValueSetExpansionContains>();
+
+  const cancel = useCallback(async (): Promise<void> => {
+    if (!reason) {
+      return;
+    }
+    setCancelling(true);
+    setCancelError(undefined);
+    try {
+      const cancelled = await medplum.post<WithId<Appointment>>(
+        medplum.fhirUrl('Appointment', appointment.id, '$cancel'),
+        {
+          resourceType: 'Parameters',
+          parameter: [
+            {
+              name: 'cancelationReason',
+              valueCodeableConcept: {
+                coding: [{ system: reason.system, code: reason.code, display: reason.display }],
+              },
+            },
+          ],
+        } satisfies Parameters
+      );
+
+      // `$cancel` is a custom operation, so the MedplumClient cannot tell what it changed.
+      // Announce changes to the Appointment so other UI can reflect this update.
+      medplum.notifyResourceModified({
+        resourceType: 'Appointment',
+        operation: 'update',
+        id: cancelled.id,
+        resource: cancelled,
+      });
+      // The operation deleted the Slots the appointment was holding. Read off the
+      // appointment as it stood before.
+      for (const slot of appointment.slot ?? []) {
+        const id = resolveId(slot);
+        if (id) {
+          medplum.notifyResourceModified({ resourceType: 'Slot', operation: 'delete', id });
+        }
+      }
+
+      onCancelled?.(cancelled);
+    } catch (err: unknown) {
+      setCancelError(err);
+    } finally {
+      setCancelling(false);
+    }
+  }, [appointment, medplum, onCancelled, reason]);
 
   return (
     <Stack gap="sm">
@@ -72,6 +134,41 @@ export function AppointmentDetails(props: AppointmentDetailsProps): JSX.Element 
         }
       />
       <Detail label="Notes" value={appointment.comment ?? appointment.description} />
+      <Divider />
+      <Detail label="Cancellation reason" value={formatCodeableConcept(appointment.cancelationReason) || undefined} />
+      {cancelError !== undefined && (
+        <Alert color="red" title="Could not cancel this appointment">
+          {normalizeErrorString(cancelError)}
+        </Alert>
+      )}
+      {CANCELABLE_STATUSES.includes(appointment.status) ? (
+        <>
+          {/*
+           * Coded against the value set rather than against a list kept here, and not
+           * `creatable`: a reason typed in by hand would be written as a code no
+           * terminology knows.
+           */}
+          <ValueSetAutocomplete
+            binding={cancellationReasonValueSet ?? APPOINTMENT_CANCELLATION_REASON_VALUE_SET}
+            label="Cancellation reason"
+            placeholder="Search reasons"
+            maxValues={1}
+            creatable={false}
+            required
+            onChange={(reasons) => setReason(reasons[0])}
+          />
+          {/* Nothing is cancelled without a reason for it. */}
+          <Button color="red" variant="light" loading={cancelling} disabled={!reason} onClick={cancel}>
+            Cancel Appointment
+          </Button>
+        </>
+      ) : (
+        <Text size="sm" c="dimmed">
+          {appointment.status === 'cancelled'
+            ? 'This appointment is cancelled.'
+            : `An appointment in '${appointment.status}' status cannot be cancelled.`}
+        </Text>
+      )}
     </Stack>
   );
 }

--- a/packages/react-scheduling/src/SchedulingWorkspace/AppointmentDetails/AppointmentDetails.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/AppointmentDetails/AppointmentDetails.tsx
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Badge, Stack, Text } from '@mantine/core';
+import type { WithId } from '@medplum/core';
+import { formatCodeableConcept, isDefined } from '@medplum/core';
+import type { Appointment, AppointmentParticipant, Reference } from '@medplum/fhirtypes';
+import { ReferenceDisplay } from '@medplum/react';
+import type { JSX, ReactNode } from 'react';
+import { Fragment } from 'react';
+import { formatDayHeading, formatZonedTime } from '../../AppointmentFinder/AppointmentFinder.times';
+
+const STATUS_COLORS: Record<Appointment['status'], string> = {
+  proposed: 'yellow',
+  pending: 'yellow',
+  booked: 'blue',
+  arrived: 'blue',
+  fulfilled: 'blue',
+  cancelled: 'red',
+  noshow: 'red',
+  'entered-in-error': 'red',
+  'checked-in': 'blue',
+  waitlist: 'gray',
+};
+
+export interface AppointmentDetailsProps {
+  readonly appointment: WithId<Appointment>;
+  readonly onCancelled?: (appointment: WithId<Appointment>) => void;
+  /** Overrides the value set the cancellation reason is coded against. */
+  readonly cancellationReasonValueSet?: string;
+}
+
+/**
+ * Shows a detail view of a single appointment
+ *
+ * Cancelling posts `Appointment/:id/$cancel`, which sets the appointment status
+ * and releases every time it was holding, then announces both so views reading
+ * them refresh.
+ *
+ * A reason has to be chosen before anything can be cancelled. The operation takes one
+ * optionally; asking for it while the appointment is in front of whoever is calling it
+ * off is the only moment it is known.
+ *
+ * @param props - The React props
+ * @param props.appointment - The Appointment resource to detail
+ * @param props.onCancelled - A callback that can be invoked after a successful $cancel
+ * @param props.cancellationReasonValueSet - The value set to offer cancellation reasons from,
+ * in place of the default binding
+ * @returns The details component
+ */
+export function AppointmentDetails(props: AppointmentDetailsProps): JSX.Element {
+  const { appointment } = props;
+  const patient = getPatientParticipant(appointment)?.actor;
+  const otherActors = getOtherActors(appointment);
+
+  return (
+    <Stack gap="sm">
+      <Badge color={STATUS_COLORS[appointment.status]}>{appointment.status}</Badge>
+      <Detail label="Patient" value={patient && <ReferenceDisplay link={false} value={patient} />} />
+      <Detail label="When" value={formatWhen(appointment)} />
+      <Detail label="Service" value={formatService(appointment)} />
+      <Detail
+        label="With"
+        value={
+          otherActors.length > 0
+            ? otherActors.map((actor, index) => (
+                <Fragment key={actor.reference ?? `actor-${index}`}>
+                  {index > 0 && ', '}
+                  <ReferenceDisplay value={actor} link={false} />
+                </Fragment>
+              ))
+            : undefined
+        }
+      />
+      <Detail label="Notes" value={appointment.comment ?? appointment.description} />
+    </Stack>
+  );
+}
+
+interface DetailProps {
+  readonly label: string;
+  /** Left out entirely when there is nothing on file for it. */
+  readonly value?: ReactNode;
+}
+
+/**
+ * One labelled line of what is on file, or nothing at all when it is not.
+ * @param props - The React props.
+ * @returns The line, or null.
+ */
+function Detail(props: DetailProps): JSX.Element | null {
+  if (!props.value) {
+    return null;
+  }
+  return (
+    <Stack gap={0}>
+      <Text size="xs" c="dimmed">
+        {props.label}
+      </Text>
+      <Text size="sm">{props.value}</Text>
+    </Stack>
+  );
+}
+
+function getPatientParticipant(appointment: Appointment): AppointmentParticipant | undefined {
+  return appointment.participant.find((participant) => participant.actor?.reference?.startsWith('Patient/'));
+}
+
+/**
+ * Everyone and everything the visit is held on besides the patient.
+ * @param appointment - The appointment being described.
+ * @returns Their references, in the order the appointment lists them.
+ */
+function getOtherActors(appointment: Appointment): Reference[] {
+  const patient = getPatientParticipant(appointment);
+  return appointment.participant
+    .filter((participant) => participant !== patient)
+    .map((participant) => participant.actor)
+    .filter(isDefined);
+}
+
+/**
+ * Says when the visit is, as far as it is known.
+ * @param appointment - The appointment being described.
+ * @returns The day and the times, or undefined for an appointment holding no time.
+ */
+function formatWhen(appointment: Appointment): string | undefined {
+  if (!appointment.start) {
+    return undefined;
+  }
+  const start = new Date(appointment.start);
+  const times = [formatZonedTime(start), appointment.end && formatZonedTime(new Date(appointment.end))]
+    .filter(Boolean)
+    .join(' – ');
+  return `${formatDayHeading(start)} · ${times}`;
+}
+
+/**
+ * Names what the visit is for, preferring the service over the kind of visit.
+ * @param appointment - The appointment being described.
+ * @returns The service or appointment type, or undefined when neither is on file.
+ */
+function formatService(appointment: Appointment): string | undefined {
+  const service = (appointment.serviceType ?? []).map(formatCodeableConcept).filter(Boolean).join(', ');
+  return service || formatCodeableConcept(appointment.appointmentType) || undefined;
+}

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.appointment.test.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.appointment.test.tsx
@@ -5,7 +5,7 @@ import { createReference } from '@medplum/core';
 import type { Appointment } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { APPOINTMENT_CANCELLATION_REASON_VALUE_SET } from '../constants';
+import { APPOINTMENT_CANCELLATION_REASON_CODE_SYSTEM, APPOINTMENT_CANCELLATION_REASON_VALUE_SET } from '../constants';
 import { installCancelStub } from '../stories/mockCancel';
 import { installValueSetStub } from '../stories/mockValueSet';
 import { DrRiveraPractitioner, SchedulingFixtures } from '../stories/scheduling';
@@ -127,6 +127,17 @@ describe('SchedulingWorkspace appointment details', () => {
     await waitFor(async () => {
       const stored = await medplum.readResource('Appointment', APPOINTMENT.id);
       expect(stored.status).toBe('cancelled');
+      // The operation is handed the reason as a coding out of the value set, which is
+      // what it writes to the appointment.
+      expect(stored.cancelationReason).toStrictEqual({
+        coding: [
+          {
+            system: APPOINTMENT_CANCELLATION_REASON_CODE_SYSTEM,
+            code: 'pat-fb',
+            display: 'Patient: Feeling Better',
+          },
+        ],
+      });
     });
   });
 

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.appointment.test.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.appointment.test.tsx
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import { createReference } from '@medplum/core';
+import type { Appointment } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { DrRiveraPractitioner, SchedulingFixtures } from '../stories/scheduling';
+import { renderWithMedplum, screen, userEvent, waitFor, within } from '../test-utils/render';
+import { SchedulingWorkspace } from './SchedulingWorkspace';
+
+// The calendar opens on today, so the visit is dated into the week on screen rather than
+// into a fixed one the grid would have to be paged to.
+const TODAY_AT_TEN = new Date(new Date().setHours(10, 0, 0, 0));
+
+/**
+ * A visit on Dr. Rivera's calendar alone.
+ */
+const APPOINTMENT: WithId<Appointment> = {
+  resourceType: 'Appointment',
+  id: 'appt-rivera-imaging',
+  status: 'booked',
+  start: TODAY_AT_TEN.toISOString(),
+  end: new Date(TODAY_AT_TEN.getTime() + 30 * 60 * 1000).toISOString(),
+  serviceType: [{ text: 'Ultrasound Imaging' }],
+  participant: [
+    { status: 'accepted', actor: { reference: 'Patient/pt-cooper', display: 'Miles Cooper' } },
+    { status: 'accepted', actor: createReference(DrRiveraPractitioner) },
+  ],
+};
+
+let medplum: MockClient;
+
+beforeEach(async () => {
+  medplum = new MockClient();
+  for (const resource of [...SchedulingFixtures, APPOINTMENT]) {
+    await medplum.createResource(resource);
+  }
+});
+
+/**
+ * The visit as the calendar draws it, once the workspace has loaded it.
+ * @returns The event element.
+ */
+async function appointmentEvent(): Promise<HTMLElement> {
+  return waitFor(() => screen.getByText('Miles Cooper'));
+}
+
+/** Clicks the visit on the calendar, the way a user opens its details. */
+async function clickAppointment(): Promise<void> {
+  await userEvent.click(await appointmentEvent());
+}
+
+/**
+ * The details, as far as they are open.
+ * @returns The dialog they are shown in, or null while they are closed.
+ */
+function details(): HTMLElement | null {
+  return screen.queryByRole('dialog');
+}
+
+describe('SchedulingWorkspace appointment details', () => {
+  test('shows no details until an appointment is clicked', async () => {
+    renderWithMedplum(<SchedulingWorkspace />, medplum);
+
+    await appointmentEvent();
+
+    expect(details()).not.toBeInTheDocument();
+  });
+
+  test('clicking an appointment opens its details', async () => {
+    renderWithMedplum(<SchedulingWorkspace />, medplum);
+
+    await clickAppointment();
+
+    const open = within(details() as HTMLElement);
+    expect(open.getByText('Miles Cooper')).toBeInTheDocument();
+    expect(open.getByText('booked')).toBeInTheDocument();
+    expect(open.getByText('Ultrasound Imaging')).toBeInTheDocument();
+  });
+
+  test('closing the details leaves the appointment on the calendar', async () => {
+    renderWithMedplum(<SchedulingWorkspace />, medplum);
+
+    await clickAppointment();
+    await userEvent.click(screen.getByRole('button', { name: 'Close appointment details' }));
+
+    await waitFor(() => expect(details()).not.toBeInTheDocument());
+    expect(await appointmentEvent()).toBeInTheDocument();
+  });
+
+  test('clicking an appointment does not start a booking', async () => {
+    renderWithMedplum(<SchedulingWorkspace />, medplum);
+
+    await clickAppointment();
+
+    // An event click is not a selection gesture on the grid behind it.
+    expect(screen.queryByRole('heading', { name: /book appointment/i })).not.toBeInTheDocument();
+  });
+});

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.appointment.test.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.appointment.test.tsx
@@ -4,7 +4,10 @@ import type { WithId } from '@medplum/core';
 import { createReference } from '@medplum/core';
 import type { Appointment } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
-import { beforeEach, describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { APPOINTMENT_CANCELLATION_REASON_VALUE_SET } from '../constants';
+import { installCancelStub } from '../stories/mockCancel';
+import { installValueSetStub } from '../stories/mockValueSet';
 import { DrRiveraPractitioner, SchedulingFixtures } from '../stories/scheduling';
 import { renderWithMedplum, screen, userEvent, waitFor, within } from '../test-utils/render';
 import { SchedulingWorkspace } from './SchedulingWorkspace';
@@ -30,12 +33,20 @@ const APPOINTMENT: WithId<Appointment> = {
 };
 
 let medplum: MockClient;
+let restoreCancel: () => void;
+let restoreValueSet: () => void;
 
 beforeEach(async () => {
   medplum = new MockClient();
   for (const resource of [...SchedulingFixtures, APPOINTMENT]) {
     await medplum.createResource(resource);
   }
+  restoreCancel = installCancelStub(medplum);
+  restoreValueSet = installValueSetStub(medplum);
+  return () => {
+    restoreCancel();
+    restoreValueSet();
+  };
 });
 
 /**
@@ -57,6 +68,23 @@ async function clickAppointment(): Promise<void> {
  */
 function details(): HTMLElement | null {
   return screen.queryByRole('dialog');
+}
+
+function cancelButton(): HTMLElement | null {
+  return screen.queryByRole('button', { name: 'Cancel Appointment' });
+}
+
+/**
+ * Chooses a reason for the cancellation, which nothing can be cancelled without.
+ *
+ * Typed rather than picked off the open list: the field asks the server for ten matches at
+ * a time, so a reason far down the code system is only offered once it is searched for.
+ *
+ * @param label - The reason to choose, as the expansion displays it.
+ */
+async function chooseReason(label = 'Patient: Feeling Better'): Promise<void> {
+  await userEvent.type(screen.getByPlaceholderText('Search reasons'), label);
+  await userEvent.click(await screen.findByRole('option', { name: label }));
 }
 
 describe('SchedulingWorkspace appointment details', () => {
@@ -87,6 +115,99 @@ describe('SchedulingWorkspace appointment details', () => {
 
     await waitFor(() => expect(details()).not.toBeInTheDocument());
     expect(await appointmentEvent()).toBeInTheDocument();
+  });
+
+  test('cancelling from the details runs the appointment through $cancel', async () => {
+    renderWithMedplum(<SchedulingWorkspace />, medplum);
+
+    await clickAppointment();
+    await chooseReason();
+    await userEvent.click(cancelButton() as HTMLElement);
+
+    await waitFor(async () => {
+      const stored = await medplum.readResource('Appointment', APPOINTMENT.id);
+      expect(stored.status).toBe('cancelled');
+    });
+  });
+
+  test('cancelling redraws the details and the calendar from what came back', async () => {
+    // Answered the way a server answers: the appointment comes back cancelled and the
+    // client is told nothing else. The cancel stub would instead cancel *through* the
+    // client, whose own write announces itself — and that would refresh both views here
+    // whether or not the details announced anything, which is the thing under test.
+    vi.spyOn(medplum, 'post').mockResolvedValue({ ...APPOINTMENT, status: 'cancelled' });
+    const { container } = renderWithMedplum(<SchedulingWorkspace />, medplum);
+
+    await clickAppointment();
+    expect(container.querySelector('.appointment.booked')).toBeInTheDocument();
+
+    await chooseReason();
+    await userEvent.click(cancelButton() as HTMLElement);
+
+    // The details stay open on what is now a cancelled visit, with nothing left to press.
+    await waitFor(() => expect(within(details() as HTMLElement).getByText('cancelled')).toBeInTheDocument());
+    expect(cancelButton()).not.toBeInTheDocument();
+    expect(within(details() as HTMLElement).getByText('This appointment is cancelled.')).toBeInTheDocument();
+
+    // And the grid is drawn again from the same announcement, without re-fetching.
+    await waitFor(() => expect(container.querySelector('.appointment.cancelled')).toBeInTheDocument());
+    expect(container.querySelector('.appointment.booked')).not.toBeInTheDocument();
+  });
+
+  test('a refusal does not outlive the details it was raised in', async () => {
+    vi.spyOn(medplum, 'post').mockRejectedValue(new Error('Appointment cannot be canceled'));
+    renderWithMedplum(<SchedulingWorkspace />, medplum);
+
+    await clickAppointment();
+    await chooseReason();
+    await userEvent.click(cancelButton() as HTMLElement);
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Close appointment details' }));
+    await waitFor(() => expect(details()).not.toBeInTheDocument());
+    await clickAppointment();
+
+    // Closed is unmounted, so what the details say now is only about the appointment
+    // being opened — and the reason chosen for the cancellation that failed is gone with
+    // it, leaving nothing to cancel against.
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(cancelButton()).toBeDisabled();
+  });
+
+  test('cancellation reasons come from the default binding', async () => {
+    const expand = vi.spyOn(medplum, 'valueSetExpand');
+    renderWithMedplum(<SchedulingWorkspace />, medplum);
+
+    await clickAppointment();
+    await chooseReason();
+
+    expect(expand).toHaveBeenCalledWith(
+      expect.objectContaining({ url: APPOINTMENT_CANCELLATION_REASON_VALUE_SET }),
+      expect.anything()
+    );
+  });
+
+  test('a supplied value set is what cancellation reasons are searched in', async () => {
+    const expand = vi.spyOn(medplum, 'valueSetExpand');
+    renderWithMedplum(
+      <SchedulingWorkspace appointmentCancellationReasonValueSet="http://example.com/ValueSet/our-reasons" />,
+      medplum
+    );
+
+    await clickAppointment();
+    await userEvent.type(screen.getByPlaceholderText('Search reasons'), 'Ran');
+
+    await waitFor(() =>
+      expect(expand).toHaveBeenCalledWith(
+        expect.objectContaining({ url: 'http://example.com/ValueSet/our-reasons' }),
+        expect.anything()
+      )
+    );
+    // And the binding it replaced is not asked for at all.
+    expect(expand).not.toHaveBeenCalledWith(
+      expect.objectContaining({ url: APPOINTMENT_CANCELLATION_REASON_VALUE_SET }),
+      expect.anything()
+    );
   });
 
   test('clicking an appointment does not start a booking', async () => {

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.stories.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.stories.tsx
@@ -5,7 +5,14 @@ import type { Appointment } from '@medplum/fhirtypes';
 import type { Meta } from '@storybook/react';
 import { IconCalendarCheck } from '@tabler/icons-react';
 import type { JSX } from 'react';
-import { withBookStub, withFindStub, withFixtures, withMockedDate } from '../stories/decorators';
+import {
+  withBookStub,
+  withCancelStub,
+  withFindStub,
+  withFixtures,
+  withMockedDate,
+  withValueSetStub,
+} from '../stories/decorators';
 import { CalendarWeekFixtures, inViewerTimezone, PatientFixtures, SchedulingFixtures } from '../stories/scheduling';
 import { SchedulingWorkspace } from './SchedulingWorkspace';
 
@@ -20,7 +27,7 @@ const LOCAL_FIXTURES = inViewerTimezone(ELSEWHERE_FIXTURES);
 export default {
   title: 'Medplum/SchedulingWorkspace',
   component: SchedulingWorkspace,
-  decorators: [withBookStub(), withFindStub(), withMockedDate],
+  decorators: [withBookStub(), withCancelStub(), withValueSetStub(), withFindStub(), withMockedDate],
   parameters: {
     // Default seeding includes a lot of cluttering Slot resources for Dr. Alice Smith; skip it.
     skipDefaultSeeding: true,
@@ -51,7 +58,12 @@ export default {
  * clears the answers; clicking again inside the day already open leaves them alone.
  *
  * Clicking a booked appointment instead — the Tuesday and Wednesday imaging visits, or
- * anything booked from the form — opens its details over the calendar.
+ * anything booked from the form — opens its details over the calendar. A reason has to be
+ * searched for and picked before anything can be called off; "Cancel Appointment" then
+ * runs the visit through `Appointment/:id/$cancel`: the drawer comes back describing a
+ * cancelled appointment, showing the reason and with no button left on it, and the event
+ * behind it is drawn as cancelled without a reload, because the cancellation announces
+ * what it wrote the way booking does.
  *
  * Everything here is kept on your own clock, so no time names a zone and nothing is
  * said under the calendar. `From A Different Timezone` is the same clinic scheduled

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.stories.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.stories.tsx
@@ -50,6 +50,9 @@ export default {
  * Clicking a different day with the form part-filled re-opens it on the new day and
  * clears the answers; clicking again inside the day already open leaves them alone.
  *
+ * Clicking a booked appointment instead — the Tuesday and Wednesday imaging visits, or
+ * anything booked from the form — opens its details over the calendar.
+ *
  * Everything here is kept on your own clock, so no time names a zone and nothing is
  * said under the calendar. `From A Different Timezone` is the same clinic scheduled
  * somewhere else.

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.tsx
@@ -46,6 +46,11 @@ const NONE_DESELECTED: DeselectedIdsByActorType = {
 export interface SchedulingWorkspaceProps {
   readonly className?: string;
   readonly onBooked?: (booking: AppointmentBooking) => void | Promise<void>;
+  /**
+   * Overrides the value set the appointment detail view offers cancellation reasons
+   * from, for a host coding them against its own terminology.
+   */
+  readonly appointmentCancellationReasonValueSet?: string;
 }
 
 /**
@@ -59,7 +64,8 @@ export interface SchedulingWorkspaceProps {
  *   new appointment on the calendar beside it — a host supplies no data for any of it.
  *   What was written is reported through `onBooked`, for a host that wants to say so.
  * - Shows what is booked: clicking an appointment opens {@link AppointmentDetails} in a
- *   drawer over the calendar.
+ *   drawer over the calendar, describing the visit and offering to cancel it. Cancelling
+ *   is what takes the time back off the calendar, again without a host supplying anything.
  * - Highlights the time last chosen, wherever it was chosen: the click that opened the
  *   pane, then whatever the form's time search settles on, and nothing while the form
  *   holds no time. The calendar is never moved to reach it — a highlight off the week
@@ -69,7 +75,7 @@ export interface SchedulingWorkspaceProps {
  * @returns A React Node with the coordinated Calendars panel + calendar UI in it
  */
 export function SchedulingWorkspace(props: SchedulingWorkspaceProps): JSX.Element {
-  const { onBooked } = props;
+  const { onBooked, appointmentCancellationReasonValueSet } = props;
   const medplum = useMedplum();
   const theme = useMantineTheme();
 
@@ -260,7 +266,12 @@ export function SchedulingWorkspace(props: SchedulingWorkspaceProps): JSX.Elemen
         title="Appointment details"
         closeButtonProps={{ 'aria-label': 'Close appointment details' }}
       >
-        {openAppointment && <AppointmentDetails appointment={openAppointment} />}
+        {openAppointment && (
+          <AppointmentDetails
+            appointment={openAppointment}
+            cancellationReasonValueSet={appointmentCancellationReasonValueSet}
+          />
+        )}
       </Drawer>
       {bookingSelection && (
         <div className={cx(classes.bookingPane, { [classes.bookingPaneWide]: timeFinderOpen })}>

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.tsx
@@ -46,6 +46,7 @@ const NONE_DESELECTED: DeselectedIdsByActorType = {
 export interface SchedulingWorkspaceProps {
   readonly className?: string;
   readonly onBooked?: (booking: AppointmentBooking) => void | Promise<void>;
+  readonly onCancelled?: (appointment: WithId<Appointment>) => void | Promise<void>;
   /**
    * Overrides the value set the appointment detail view offers cancellation reasons
    * from, for a host coding them against its own terminology.
@@ -95,7 +96,6 @@ export function SchedulingWorkspace(props: SchedulingWorkspaceProps): JSX.Elemen
   // What the calendar highlights
   const [highlight, setHighlight] = useState<DateTimeRange>();
   const [timeFinderOpen, setTimeFinderOpen] = useState(false);
-
 
   // Finds all bookable Schedules, with one search per bookable actor type.
   useEffect(() => {
@@ -270,6 +270,7 @@ export function SchedulingWorkspace(props: SchedulingWorkspaceProps): JSX.Elemen
           <AppointmentDetails
             appointment={openAppointment}
             cancellationReasonValueSet={appointmentCancellationReasonValueSet}
+            onCancelled={props.onCancelled}
           />
         )}
       </Drawer>

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Alert, CloseButton, Group, Title, useMantineTheme } from '@mantine/core';
+import { Alert, CloseButton, Drawer, Group, Title, useMantineTheme } from '@mantine/core';
+import type { WithId } from '@medplum/core';
 import {
   getExtensionValue,
   getReferenceString,
@@ -24,6 +25,7 @@ import { useSchedulingResources } from '../hooks/useSchedulingResources';
 import type { MultiCalendarSource } from '../MultiCalendar/MultiCalendar';
 import { MultiCalendar } from '../MultiCalendar/MultiCalendar';
 import type { DateTimeRange } from '../types';
+import { AppointmentDetails } from './AppointmentDetails/AppointmentDetails';
 import type { CalendarsPanelItem } from './CalendarsPanel/CalendarsPanel';
 import { CalendarsPanel } from './CalendarsPanel/CalendarsPanel';
 import { CalendarTimezoneNotice } from './CalendarTimezoneNotice';
@@ -56,6 +58,8 @@ export interface SchedulingWorkspaceProps {
  *   The form writes the booking and announces what it wrote, which is what puts the
  *   new appointment on the calendar beside it — a host supplies no data for any of it.
  *   What was written is reported through `onBooked`, for a host that wants to say so.
+ * - Shows what is booked: clicking an appointment opens {@link AppointmentDetails} in a
+ *   drawer over the calendar.
  * - Highlights the time last chosen, wherever it was chosen: the click that opened the
  *   pane, then whatever the form's time search settles on, and nothing while the form
  *   holds no time. The calendar is never moved to reach it — a highlight off the week
@@ -78,11 +82,14 @@ export function SchedulingWorkspace(props: SchedulingWorkspaceProps): JSX.Elemen
 
   const [range, setRange] = useState<DateTimeRange>();
 
-  // What was clicked
+  // What was selected
   const [bookingSelection, setBookingSelection] = useState<DateTimeRange>();
+  const [selectedAppointmentId, setSelectedAppointmentId] = useState<string>();
+
   // What the calendar highlights
   const [highlight, setHighlight] = useState<DateTimeRange>();
   const [timeFinderOpen, setTimeFinderOpen] = useState(false);
+
 
   // Finds all bookable Schedules, with one search per bookable actor type.
   useEffect(() => {
@@ -187,6 +194,21 @@ export function SchedulingWorkspace(props: SchedulingWorkspaceProps): JSX.Elemen
     [closeBooking, onBooked]
   );
 
+  const selectAppointment = useCallback((appointment: Appointment): void => {
+    if (appointment.id) {
+      setSelectedAppointmentId(appointment.id);
+    }
+  }, []);
+
+  const closeAppointment = useCallback((): void => setSelectedAppointmentId(undefined), []);
+
+  const openAppointment = useMemo((): WithId<Appointment> | undefined => {
+    if (selectedAppointmentId) {
+      return (appointments ?? []).find((a) => a.id === selectedAppointmentId);
+    }
+    return undefined;
+  }, [appointments, selectedAppointmentId]);
+
   const toItem = (candidate: ScheduleCandidate, selected: boolean): CalendarsPanelItem => {
     const color = colorByScheduleId.get(candidate.schedule.id);
     if (!color) {
@@ -226,10 +248,20 @@ export function SchedulingWorkspace(props: SchedulingWorkspaceProps): JSX.Elemen
           onRangeChange={setRange}
           loading={resourcesLoading}
           onSelectInterval={startBooking}
+          onSelectAppointment={selectAppointment}
           selection={highlight}
         />
         <CalendarTimezoneNotice className={classes.timezoneNotice} timezones={timezones} anyUnknown={anyUnknown} />
       </div>
+      <Drawer
+        opened={openAppointment !== undefined}
+        onClose={closeAppointment}
+        position="right"
+        title="Appointment details"
+        closeButtonProps={{ 'aria-label': 'Close appointment details' }}
+      >
+        {openAppointment && <AppointmentDetails appointment={openAppointment} />}
+      </Drawer>
       {bookingSelection && (
         <div className={cx(classes.bookingPane, { [classes.bookingPaneWide]: timeFinderOpen })}>
           <Group justify="space-between" wrap="nowrap" mb="sm">

--- a/packages/react-scheduling/src/constants.ts
+++ b/packages/react-scheduling/src/constants.ts
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { HTTP_HL7_ORG, HTTP_TERMINOLOGY_HL7_ORG } from '@medplum/core';
+
+// Note that these are used by the `Appointment.cancelationReason` field (one
+// "L" in that field name in R4).
+export const APPOINTMENT_CANCELLATION_REASON_VALUE_SET =
+  HTTP_HL7_ORG + '/fhir/ValueSet/appointment-cancellation-reason';
+export const APPOINTMENT_CANCELLATION_REASON_CODE_SYSTEM =
+  HTTP_TERMINOLOGY_HL7_ORG + '/CodeSystem/appointment-cancellation-reason';

--- a/packages/react-scheduling/src/stories/WithCancelStub.tsx
+++ b/packages/react-scheduling/src/stories/WithCancelStub.tsx
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { useMedplum } from '@medplum/react-hooks';
+import type { JSX, ReactNode } from 'react';
+import { useEffect, useState } from 'react';
+import { installCancelStub } from './mockCancel';
+
+export interface WithCancelStubProps {
+  readonly children: ReactNode;
+}
+
+/**
+ * Teaches the ambient Storybook client to answer `Appointment/[id]/$cancel`.
+ *
+ * Installed before the children render, so a cancellation cannot reach the unpatched
+ * client and fail for want of an operation.
+ *
+ * @param props - The React props.
+ * @returns The children, once the stub is in place.
+ */
+export function WithCancelStub(props: WithCancelStubProps): JSX.Element | null {
+  const medplum = useMedplum();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const restore = installCancelStub(medplum);
+    setReady(true);
+    return () => {
+      setReady(false);
+      restore();
+    };
+  }, [medplum]);
+
+  return ready ? <>{props.children}</> : null;
+}

--- a/packages/react-scheduling/src/stories/WithValueSetStub.tsx
+++ b/packages/react-scheduling/src/stories/WithValueSetStub.tsx
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { useMedplum } from '@medplum/react-hooks';
+import type { JSX, ReactNode } from 'react';
+import { useEffect, useState } from 'react';
+import { installValueSetStub } from './mockValueSet';
+
+export interface WithValueSetStubProps {
+  readonly children: ReactNode;
+}
+
+/**
+ * Teaches the ambient Storybook client to expand the value sets these components bind to.
+ *
+ * Installed before the children render, so a bound field cannot probe the unpatched
+ * client and take its example codes for the terminology.
+ *
+ * @param props - The React props.
+ * @returns The children, once the stub is in place.
+ */
+export function WithValueSetStub(props: WithValueSetStubProps): JSX.Element | null {
+  const medplum = useMedplum();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const restore = installValueSetStub(medplum);
+    setReady(true);
+    return () => {
+      setReady(false);
+      restore();
+    };
+  }, [medplum]);
+
+  return ready ? <>{props.children}</> : null;
+}

--- a/packages/react-scheduling/src/stories/decorators.tsx
+++ b/packages/react-scheduling/src/stories/decorators.tsx
@@ -4,8 +4,10 @@ import type { Resource } from '@medplum/fhirtypes';
 import type { Decorator } from '@storybook/react';
 import { MockDateWrapper } from './MockDateWrapper';
 import { WithBookStub } from './WithBookStub';
+import { WithCancelStub } from './WithCancelStub';
 import { WithFindStub } from './WithFindStub';
 import { WithFixtures } from './WithFixtures';
+import { WithValueSetStub } from './WithValueSetStub';
 
 // Freezes the system clock so date/time-dependent stories are deterministic.
 export const withMockedDate: Decorator = (Story) => (
@@ -51,4 +53,26 @@ export const withBookStub = (): Decorator => (Story) => (
   <WithBookStub>
     <Story />
   </WithBookStub>
+);
+
+/**
+ * Answers `Appointment/[id]/$cancel` by cancelling what it names, which MockClient
+ * cannot.
+ * @returns The decorator.
+ */
+export const withCancelStub = (): Decorator => (Story) => (
+  <WithCancelStub>
+    <Story />
+  </WithCancelStub>
+);
+
+/**
+ * Expands the value sets these components bind to, which MockClient answers with
+ * example codes.
+ * @returns The decorator.
+ */
+export const withValueSetStub = (): Decorator => (Story) => (
+  <WithValueSetStub>
+    <Story />
+  </WithValueSetStub>
 );

--- a/packages/react-scheduling/src/stories/mockCancel.ts
+++ b/packages/react-scheduling/src/stories/mockCancel.ts
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { MedplumClient, MedplumRequestOptions } from '@medplum/core';
+import { badRequest, OperationOutcomeError, resolveId } from '@medplum/core';
+import type { Appointment, CodeableConcept, Parameters } from '@medplum/fhirtypes';
+
+/**
+ * Answers `Appointment/[id]/$cancel` against the stored resources.
+ *
+ * `MockClient` has no scheduling operations, so a story or test that cancels has to
+ * stand in for the server. It does what the operation does: refuses a status the
+ * operation refuses, sets the appointment to `cancelled`, records the `cancelationReason`
+ * it was given, and deletes every Slot it was holding.
+ *
+ * @param medplum - The client to patch. Other requests are passed through.
+ * @returns A function restoring the client's own `post`.
+ */
+export function installCancelStub(medplum: MedplumClient): () => void {
+  const original = medplum.post.bind(medplum);
+
+  medplum.post = async function stubbedPost<T>(
+    url: string | URL,
+    body?: unknown,
+    contentType?: string,
+    options?: MedplumRequestOptions
+  ): Promise<T> {
+    const asString = url.toString();
+    const match = /Appointment\/([^/]+)\/(?:%24|\$)cancel$/.exec(asString);
+    if (!match) {
+      return original(url, body, contentType, options);
+    }
+    return cancelAppointment(medplum, match[1], readReason(body)) as Promise<T>;
+  } as MedplumClient['post'];
+
+  return () => {
+    medplum.post = original;
+  };
+}
+
+/**
+ * Reads the reason out of the request, as the operation's input parameters carry it.
+ * @param body - What was posted to `$cancel`.
+ * @returns The reason, or undefined when the caller sent none.
+ */
+function readReason(body: unknown): CodeableConcept | undefined {
+  const parameters = body as Parameters | undefined;
+  return parameters?.parameter?.find((parameter) => parameter.name === 'cancelationReason')?.valueCodeableConcept;
+}
+
+async function cancelAppointment(
+  medplum: MedplumClient,
+  id: string,
+  cancelationReason: CodeableConcept | undefined
+): Promise<Appointment> {
+  const appointment = await medplum.readResource('Appointment', id);
+  if (appointment.status !== 'pending' && appointment.status !== 'booked') {
+    throw new OperationOutcomeError(badRequest(`Appointment cannot be canceled in '${appointment.status}' status`));
+  }
+
+  const cancelled = await medplum.updateResource<Appointment>({
+    ...appointment,
+    status: 'cancelled',
+    cancelationReason: cancelationReason ?? appointment.cancelationReason,
+  });
+  for (const slot of appointment.slot ?? []) {
+    const slotId = resolveId(slot);
+    if (slotId) {
+      await medplum.deleteResource('Slot', slotId);
+    }
+  }
+  return cancelled;
+}

--- a/packages/react-scheduling/src/stories/mockValueSet.ts
+++ b/packages/react-scheduling/src/stories/mockValueSet.ts
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { MedplumClient, MedplumRequestOptions, ValueSetExpandParams } from '@medplum/core';
+import type { ValueSet, ValueSetExpansionContains } from '@medplum/fhirtypes';
+import { APPOINTMENT_CANCELLATION_REASON_CODE_SYSTEM, APPOINTMENT_CANCELLATION_REASON_VALUE_SET } from '../constants';
+
+/** The FHIR R4 `appointment-cancellation-reason` CodeSystem, as a real server would expand it. */
+const CANCELLATION_REASONS: readonly ValueSetExpansionContains[] = [
+  { code: 'pat', display: 'Patient' },
+  { code: 'pat-crs', display: 'Patient: Canceled via automated reminder system' },
+  { code: 'pat-cpp', display: 'Patient: Canceled via Patient Portal' },
+  { code: 'pat-dec', display: 'Patient: Deceased' },
+  { code: 'pat-fb', display: 'Patient: Feeling Better' },
+  { code: 'pat-lt', display: 'Patient: Lack of Transportation' },
+  { code: 'pat-mt', display: 'Patient: Member Terminated' },
+  { code: 'pat-mv', display: 'Patient: Moved' },
+  { code: 'pat-preg', display: 'Patient: Pregnant' },
+  { code: 'pat-swl', display: 'Patient: Scheduled from Wait List' },
+  { code: 'pat-ucp', display: 'Patient: Unhappy/Changed Provider' },
+  { code: 'prov', display: 'Provider' },
+  { code: 'prov-pers', display: 'Provider: Personal' },
+  { code: 'prov-dch', display: 'Provider: Discharged' },
+  { code: 'prov-edu', display: 'Provider: Edu/Meeting' },
+  { code: 'prov-hosp', display: 'Provider: Hospitalized' },
+  { code: 'prov-labs', display: 'Provider: Labs Out of Acceptable Range' },
+  { code: 'prov-mri', display: 'Provider: MRI Screening Form Marked Do Not Proceed' },
+  { code: 'prov-onc', display: 'Provider: Oncology Treatment Plan Changes' },
+  { code: 'maint', display: 'Equipment Maintenance/Repair' },
+  { code: 'meds-inc', display: 'Prep/Med Incomplete' },
+  { code: 'other', display: 'Other' },
+  { code: 'oth-cms', display: 'Other: CMS Therapy Cap Service Not Authorized' },
+  { code: 'oth-err', display: 'Other: Error' },
+  { code: 'oth-fin', display: 'Other: Financial' },
+  { code: 'oth-iv', display: 'Other: Improper IV Access/Infiltrate IV' },
+  { code: 'oth-int', display: 'Other: No Interpreter Available' },
+  { code: 'oth-mu', display: 'Other: Prep/Med/Results Unavailable' },
+  { code: 'oth-room', display: 'Other: Room/Resource Maintenance' },
+  { code: 'oth-oerr', display: 'Other: Schedule Order Error' },
+  { code: 'oth-swie', display: 'Other: Silent Walk In Error' },
+  { code: 'oth-weath', display: 'Other: Weather' },
+].map((concept) => ({ ...concept, system: APPOINTMENT_CANCELLATION_REASON_CODE_SYSTEM }));
+
+/** The value sets this stub knows how to expand, by URL. */
+const EXPANSIONS: Record<string, readonly ValueSetExpansionContains[]> = {
+  [APPOINTMENT_CANCELLATION_REASON_VALUE_SET]: CANCELLATION_REASONS,
+};
+
+/**
+ * Expands the value sets the scheduling components are bound to.
+ *
+ * `MockClient` answers every `ValueSet/$expand` with the same three example codes, so a
+ * story or test driving a value-set-bound field would offer "Test Display" where a server
+ * offers real terminology. This answers the ones the components ask for the way a server
+ * with R4 terminology loaded does, honouring `filter` and `count` as an expansion must:
+ * the field searches as the user types, and only shows what it asked for.
+ *
+ * @param medplum - The client to patch. Other value sets are passed through.
+ * @returns A function restoring the client's own `valueSetExpand`.
+ */
+export function installValueSetStub(medplum: MedplumClient): () => void {
+  const original = medplum.valueSetExpand.bind(medplum);
+
+  medplum.valueSetExpand = async function stubbedExpand(
+    params: ValueSetExpandParams,
+    options?: MedplumRequestOptions
+  ): Promise<ValueSet> {
+    const concepts = params.url ? EXPANSIONS[params.url] : undefined;
+    if (!concepts) {
+      return original(params, options);
+    }
+
+    const filter = (params.filter ?? '').toLowerCase();
+    const matches = concepts.filter(
+      (concept) =>
+        !filter ||
+        (concept.display ?? '').toLowerCase().includes(filter) ||
+        (concept.code ?? '').toLowerCase().includes(filter)
+    );
+
+    return {
+      resourceType: 'ValueSet',
+      status: 'active',
+      url: params.url,
+      expansion: {
+        // Fixed rather than "now": a story pinned to a mocked clock has no business
+        // reading the wall clock, and nothing here depends on the value.
+        timestamp: '2020-05-04T00:00:00.000Z',
+        contains: matches.slice(0, params.count ?? 10),
+      },
+    };
+  } as MedplumClient['valueSetExpand'];
+
+  return () => {
+    medplum.valueSetExpand = original;
+  };
+}


### PR DESCRIPTION
When selecting an appointment from the calendar, we open a Drawer and show the appointment details inside of it.

This includes a button that can be used to cancel the appointment. Cancellation reason comes from the AppointmentCancellationReason value set (https://hl7.org/fhir/R4/valueset-appointment-cancellation-reason.html), but may be overridden with a custom value set by an embedding application.

In the future, more controls will be added to this pane allowing operations like Rescheduling and Reassigning to another provider/room/device.

Furthers https://github.com/medplum/medplum/issues/10140.

https://github.com/user-attachments/assets/3a1551cf-84c5-4ad1-b054-4f7ec970a72d