### PR TITLE
Add radiology dictation demo

### DIFF
--- a/examples/medplum-radiology-demo/.env.defaults
+++ b/examples/medplum-radiology-demo/.env.defaults
@@ -1,0 +1,4 @@
+MEDPLUM_BASE_URL=https://api.medplum.com/ # Or http://localhost:8103/ for localhost
+MEDPLUM_CLIENT_ID= # Optional
+GOOGLE_CLIENT_ID=921088377005-3j1sa10vr6hj86jgmdfh2l53v3mp7lfi.apps.googleusercontent.com # Optional
+RECAPTCHA_SITE_KEY=6LfFd_8gAAAAAOCVrZQ_aF2CN5b7s91NEYIu5GxL # Optional

--- a/examples/medplum-radiology-demo/.gitignore
+++ b/examples/medplum-radiology-demo/.gitignore
@@ -1,0 +1,25 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+package-lock.json
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/examples/medplum-radiology-demo/README.md
+++ b/examples/medplum-radiology-demo/README.md
@@ -1,0 +1,42 @@
+# Medplum Radiology Demo
+
+A radiologist reading worklist built on Medplum primitives: pick a study from the worklist, dictate a
+`DiagnosticReport` with voice input, and resume the draft later.
+
+## What it shows
+
+- **Worklist** — `Task` resources tagged with the `https://medplum.com/radiology-dictation` identifier, listed in a
+  pane that stays mounted while you switch between reports.
+- **Report creator** — voice-to-text dictation via the `useWhisper` hook from `@medplum/react`, alongside the patient
+  chart (`PatientSummary`) for the selected study.
+- **Resumable drafts** — opening a Task creates a blank `DiagnosticReport` identified by that Task, so reopening it
+  later picks the same draft back up. Nothing else is written until you save, so switching studies discards unsaved
+  dictation.
+- **FHIRcast** — a small panel to connect to a topic and follow `ImagingStudy-open`, `ImagingStudy-close`, and
+  `syncerror` events. While connected, selecting a worklist item publishes the context change too: the outgoing study
+  is closed before the incoming one is opened, so subscribers such as a PACS viewer follow along.
+
+Voice input requires the `ai-realtime` feature on your Medplum project.
+
+## Getting started
+
+```sh
+npm install
+npm run dev
+```
+
+Set `MEDPLUM_BASE_URL` in `.env` (copied from `.env.defaults` on first run).
+
+## Seeding the worklist
+
+Create a reading task from a patient and an imaging study:
+
+```sh
+export MEDPLUM_BASE_URL=http://localhost:8103/
+export MEDPLUM_CLIENT_ID=<client-id>
+export MEDPLUM_CLIENT_SECRET=<client-secret>
+
+npm run generate-task -- Patient/123 ImagingStudy/456
+```
+
+The new `Task` shows up in the worklist immediately.

--- a/examples/medplum-radiology-demo/index.html
+++ b/examples/medplum-radiology-demo/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Medplum Radiology Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/medplum-radiology-demo/package.json
+++ b/examples/medplum-radiology-demo/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "medplum-radiology-demo",
+  "version": "5.1.35",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc && vite build",
+    "dev": "vite",
+    "generate-task": "tsx scripts/generate-diag-report-task.ts",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "preview": "vite preview"
+  },
+  "prettier": {
+    "plugins": [
+      "prettier-plugin-organize-imports"
+    ],
+    "printWidth": 120,
+    "singleQuote": true,
+    "trailingComma": "es5"
+  },
+  "devDependencies": {
+    "@mantine/core": "8.3.18",
+    "@mantine/hooks": "8.3.18",
+    "@mantine/notifications": "8.3.18",
+    "@medplum/core": "5.1.35",
+    "@medplum/eslint-config": "5.1.35",
+    "@medplum/fhirtypes": "5.1.35",
+    "@medplum/react": "5.1.35",
+    "@tabler/icons-react": "3.46.0",
+    "@types/node": "22.20.1",
+    "@types/react": "19.2.18",
+    "@types/react-dom": "19.2.4",
+    "@vitejs/plugin-react": "6.0.5",
+    "postcss": "8.5.26",
+    "postcss-preset-mantine": "1.18.0",
+    "postcss-simple-vars": "7.0.1",
+    "prettier-plugin-organize-imports": "4.3.0",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
+    "react-router": "8.3.0",
+    "tsx": "4.20.6",
+    "typescript": "6.0.3",
+    "vite": "8.2.1"
+  },
+  "packageManager": "npm@10.9.9",
+  "engines": {
+    "node": "^22.18.0 || >=24.2.0"
+  }
+}

--- a/examples/medplum-radiology-demo/postcss.config.mjs
+++ b/examples/medplum-radiology-demo/postcss.config.mjs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import mantinePreset from 'postcss-preset-mantine';
+import simpleVars from 'postcss-simple-vars';
+
+const config = {
+  plugins: [
+    mantinePreset(),
+    simpleVars({
+      variables: {
+        'mantine-breakpoint-xs': '36em',
+        'mantine-breakpoint-sm': '48em',
+        'mantine-breakpoint-md': '62em',
+        'mantine-breakpoint-lg': '75em',
+        'mantine-breakpoint-xl': '88em',
+      },
+    }),
+  ],
+};
+
+export default config;

--- a/examples/medplum-radiology-demo/scripts/generate-diag-report-task.ts
+++ b/examples/medplum-radiology-demo/scripts/generate-diag-report-task.ts
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Seeds a radiology worklist Task:
+//   npm run generate-task -- Patient/123 ImagingStudy/456
+//
+// Auth comes from the environment: MEDPLUM_BASE_URL, MEDPLUM_CLIENT_ID, MEDPLUM_CLIENT_SECRET.
+import { MedplumClient } from '@medplum/core';
+import type { ImagingStudy, Patient, Reference, Task } from '@medplum/fhirtypes';
+
+const RADIOLOGY_SYSTEM = 'https://medplum.com/radiology-dictation';
+const RADIOLOGY_TASK_CODE = 'read-imaging-study';
+
+function parseReference<T extends Patient | ImagingStudy>(arg: string | undefined, resourceType: string): Reference<T> {
+  if (!arg?.startsWith(`${resourceType}/`) || arg.split('/').length !== 2) {
+    throw new Error(`Expected a ${resourceType} reference such as "${resourceType}/123", got "${arg ?? ''}"`);
+  }
+  return { reference: arg };
+}
+
+async function main(): Promise<void> {
+  const [patientArg, imagingStudyArg] = process.argv.slice(2);
+  const patient = parseReference<Patient>(patientArg, 'Patient');
+  const imagingStudy = parseReference<ImagingStudy>(imagingStudyArg, 'ImagingStudy');
+
+  const baseUrl = process.env.MEDPLUM_BASE_URL;
+  const clientId = process.env.MEDPLUM_CLIENT_ID;
+  const clientSecret = process.env.MEDPLUM_CLIENT_SECRET;
+  if (!clientId || !clientSecret || !baseUrl) {
+    throw new Error('Set MEDPLUM_BASE_URL, MEDPLUM_CLIENT_ID and MEDPLUM_CLIENT_SECRET');
+  }
+
+  const medplum = new MedplumClient({ baseUrl });
+  await medplum.startClientLogin(clientId, clientSecret);
+
+  // Read both references so a typo fails here rather than showing an empty row in the worklist.
+  const [patientResource, study] = await Promise.all([
+    medplum.readReference(patient),
+    medplum.readReference(imagingStudy),
+  ]);
+
+  const task = await medplum.createResource<Task>({
+    resourceType: 'Task',
+    status: 'ready',
+    intent: 'order',
+    identifier: [{ system: RADIOLOGY_SYSTEM, value: RADIOLOGY_TASK_CODE }],
+    code: { text: study.description ?? 'Radiology read' },
+    description: `Dictate report for ${study.description ?? imagingStudy.reference}`,
+    for: { reference: `Patient/${patientResource.id}` },
+    input: [
+      {
+        type: { text: 'ImagingStudy' },
+        valueReference: { reference: `ImagingStudy/${study.id}` },
+      },
+    ],
+  });
+
+  console.log(`Created Task/${task.id} for ${patient.reference} / ${imagingStudy.reference}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/medplum-radiology-demo/src/App.tsx
+++ b/examples/medplum-radiology-demo/src/App.tsx
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { AppShell, ErrorBoundary, Loading, Logo, useMedplum, useMedplumProfile } from '@medplum/react';
+import { IconRadioactive } from '@tabler/icons-react';
+import type { JSX } from 'react';
+import { Suspense } from 'react';
+import { Navigate, Route, Routes } from 'react-router';
+import { LandingPage } from './pages/LandingPage';
+import { SignInPage } from './pages/SignInPage';
+import { RadiologyPage } from './radiology/RadiologyPage';
+
+export function App(): JSX.Element | null {
+  const medplum = useMedplum();
+  const profile = useMedplumProfile();
+
+  if (medplum.isLoading()) {
+    return null;
+  }
+
+  return (
+    <AppShell
+      logo={<Logo size={24} />}
+      menus={
+        profile
+          ? [{ title: 'Worklists', links: [{ icon: <IconRadioactive />, label: 'Radiology', href: '/Radiology' }] }]
+          : undefined
+      }
+    >
+      <ErrorBoundary>
+        <Suspense fallback={<Loading />}>
+          <Routes>
+            {profile ? (
+              <>
+                <Route path="/Radiology" element={<RadiologyPage />} />
+                <Route path="/Radiology/:taskId" element={<RadiologyPage />} />
+                <Route path="/signin" element={<SignInPage />} />
+                <Route path="*" element={<Navigate to="/Radiology" replace />} />
+              </>
+            ) : (
+              <>
+                <Route path="/signin" element={<SignInPage />} />
+                <Route path="*" element={<LandingPage />} />
+              </>
+            )}
+          </Routes>
+        </Suspense>
+      </ErrorBoundary>
+    </AppShell>
+  );
+}

--- a/examples/medplum-radiology-demo/src/main.tsx
+++ b/examples/medplum-radiology-demo/src/main.tsx
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { MantineProvider, createTheme } from '@mantine/core';
+import '@mantine/core/styles.css';
+import { Notifications } from '@mantine/notifications';
+import '@mantine/notifications/styles.css';
+import { MedplumClient } from '@medplum/core';
+import { MedplumProvider } from '@medplum/react';
+import '@medplum/react/styles.css';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { RouterProvider, createBrowserRouter } from 'react-router';
+import { App } from './App';
+
+const medplum = new MedplumClient({
+  onUnauthenticated: () => (window.location.href = '/'),
+  baseUrl: import.meta.env.MEDPLUM_BASE_URL,
+  cacheTime: 60000,
+  autoBatchTime: 100,
+});
+
+const theme = createTheme({
+  fontSizes: {
+    xs: '0.6875rem',
+    sm: '0.875rem',
+    md: '0.875rem',
+    lg: '1.0rem',
+    xl: '1.125rem',
+  },
+});
+
+const router = createBrowserRouter([{ path: '*', element: <App /> }]);
+
+const navigate = (path: string): Promise<void> => router.navigate(path);
+
+const container = document.getElementById('root') as HTMLDivElement;
+const root = createRoot(container);
+root.render(
+  <StrictMode>
+    <MedplumProvider medplum={medplum} navigate={navigate}>
+      <MantineProvider theme={theme}>
+        <Notifications position="bottom-right" />
+        <RouterProvider router={router} />
+      </MantineProvider>
+    </MedplumProvider>
+  </StrictMode>
+);

--- a/examples/medplum-radiology-demo/src/pages/LandingPage.tsx
+++ b/examples/medplum-radiology-demo/src/pages/LandingPage.tsx
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Anchor, Button, Stack, Text, Title } from '@mantine/core';
+import { Document } from '@medplum/react';
+import type { JSX } from 'react';
+import { Link } from 'react-router';
+
+export function LandingPage(): JSX.Element {
+  return (
+    <Document width={500}>
+      <Stack align="center">
+        <Title order={2}>Radiology Reading Worklist</Title>
+        <Text>
+          This example demonstrates a radiologist worklist: pick a study, dictate a DiagnosticReport with voice input,
+          and resume the draft later. If you haven't already,{' '}
+          <Anchor href="https://app.medplum.com/register">register</Anchor> for a Medplum project, then sign in below.
+        </Text>
+        <Button component={Link} to="/signin">
+          Sign in
+        </Button>
+      </Stack>
+    </Document>
+  );
+}

--- a/examples/medplum-radiology-demo/src/pages/SignInPage.tsx
+++ b/examples/medplum-radiology-demo/src/pages/SignInPage.tsx
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Title } from '@mantine/core';
+import { Logo, SignInForm } from '@medplum/react';
+import type { JSX } from 'react';
+import { useNavigate } from 'react-router';
+
+export function SignInPage(): JSX.Element {
+  const navigate = useNavigate();
+  return (
+    <SignInForm
+      googleClientId={import.meta.env.GOOGLE_CLIENT_ID}
+      clientId={import.meta.env.MEDPLUM_CLIENT_ID}
+      onSuccess={() => navigate('/Radiology')?.catch(console.error)}
+    >
+      <Logo size={32} />
+      <Title>Sign in to Medplum</Title>
+    </SignInForm>
+  );
+}

--- a/examples/medplum-radiology-demo/src/radiology/FhircastPanel.tsx
+++ b/examples/medplum-radiology-demo/src/radiology/FhircastPanel.tsx
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Badge, Button, Group, Paper, TextInput } from '@mantine/core';
+import type { FhircastConnection, FhircastEventName, FhircastMessagePayload } from '@medplum/core';
+import { useMedplum } from '@medplum/react';
+import type { JSX } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { showErrorNotification } from '../utils/notifications';
+
+// Heartbeats are deliberately absent: the hub sends them regardless of the subscription, and the
+// client swallows them rather than dispatching a message, so naming one here only fails validation.
+const RADIOLOGY_EVENTS: FhircastEventName[] = ['ImagingStudy-open', 'ImagingStudy-close', 'syncerror'];
+
+type Status = 'disconnected' | 'connecting' | 'connected';
+
+export interface FhircastPanelProps {
+  readonly onMessage?: (message: FhircastMessagePayload) => void;
+  /** Called with the topic once connected, and with `undefined` when the user disconnects. */
+  readonly onConnectedTopicChange?: (topic: string | undefined) => void;
+}
+
+export function FhircastPanel({ onMessage, onConnectedTopicChange }: FhircastPanelProps): JSX.Element {
+  const medplum = useMedplum();
+  const [topic, setTopic] = useState('');
+  const [status, setStatus] = useState<Status>('disconnected');
+  const connectionRef = useRef<FhircastConnection>(undefined);
+  const onMessageRef = useRef(onMessage);
+  const onConnectedTopicChangeRef = useRef(onConnectedTopicChange);
+
+  useEffect(() => {
+    onMessageRef.current = onMessage;
+    onConnectedTopicChangeRef.current = onConnectedTopicChange;
+  }, [onMessage, onConnectedTopicChange]);
+
+  useEffect(() => {
+    return () => connectionRef.current?.disconnect();
+  }, []);
+
+  const disconnect = (): void => {
+    connectionRef.current?.disconnect();
+    connectionRef.current = undefined;
+    setStatus('disconnected');
+    onConnectedTopicChangeRef.current?.(undefined);
+  };
+
+  const connect = (): void => {
+    setStatus('connecting');
+    medplum
+      .fhircastSubscribe(topic.trim(), RADIOLOGY_EVENTS)
+      .then((subRequest) => {
+        const connection = medplum.fhircastConnect(subRequest);
+        connection.addEventListener('connect', () => {
+          setStatus('connected');
+          onConnectedTopicChangeRef.current?.(subRequest.topic);
+        });
+        // The connection retries on its own, so a drop is a status to show rather than a teardown.
+        connection.addEventListener('disconnect', () => setStatus('connecting'));
+        connection.addEventListener('message', (event) => onMessageRef.current?.(event.payload));
+        connectionRef.current = connection;
+      })
+      .catch((err) => {
+        setStatus('disconnected');
+        showErrorNotification(err);
+      });
+  };
+
+  const isConnected = status !== 'disconnected';
+  const badgeColor = { connected: 'green', connecting: 'yellow', disconnected: 'gray' }[status];
+
+  return (
+    <Paper withBorder p="xs">
+      <Group gap="xs" wrap="nowrap">
+        <TextInput
+          size="xs"
+          placeholder="FHIRcast topic"
+          aria-label="FHIRcast topic"
+          value={topic}
+          disabled={isConnected}
+          onChange={(e) => setTopic(e.currentTarget.value)}
+        />
+        <Button
+          size="xs"
+          variant="light"
+          disabled={!isConnected && !topic.trim()}
+          onClick={isConnected ? disconnect : connect}
+        >
+          {isConnected ? 'Disconnect' : 'Connect'}
+        </Button>
+        <Badge size="sm" color={badgeColor} variant="light">
+          {status}
+        </Badge>
+      </Group>
+    </Paper>
+  );
+}

--- a/examples/medplum-radiology-demo/src/radiology/RadiologyPage.module.css
+++ b/examples/medplum-radiology-demo/src/radiology/RadiologyPage.module.css
@@ -1,0 +1,38 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - var(--app-shell-header-height, 0));
+  overflow: hidden;
+}
+
+.body {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  flex: 1;
+  min-height: 0;
+}
+
+.worklist {
+  width: 280px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--mantine-color-gray-3);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.report {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.chart {
+  width: 320px;
+  flex-shrink: 0;
+  border-left: 1px solid var(--mantine-color-gray-3);
+  overflow-y: auto;
+}

--- a/examples/medplum-radiology-demo/src/radiology/RadiologyPage.tsx
+++ b/examples/medplum-radiology-demo/src/radiology/RadiologyPage.tsx
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Box, Text } from '@mantine/core';
+import type { DiagnosticReport, ImagingStudy, Patient, Reference, Task } from '@medplum/fhirtypes';
+import { Loading, PatientSummary, useMedplum, useResource } from '@medplum/react';
+import type { JSX } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import { showErrorNotification } from '../utils/notifications';
+import { FhircastPanel } from './FhircastPanel';
+import { getOrCreateDraftReport, getTaskImagingStudy, publishStudyChange } from './radiology-utils';
+import classes from './RadiologyPage.module.css';
+import { RadiologyWorklist } from './RadiologyWorklist';
+import { ReportCreator } from './ReportCreator';
+
+export function RadiologyPage(): JSX.Element {
+  const { taskId } = useParams();
+  const navigate = useNavigate();
+  const medplum = useMedplum();
+  const task = useResource<Task>(taskId ? { reference: `Task/${taskId}` } : undefined);
+  const [draft, setDraft] = useState<{ taskId: string; report: DiagnosticReport }>();
+  const [connectedTopic, setConnectedTopic] = useState<string>();
+
+  const patient = task?.for as Reference<Patient> | undefined;
+  const study = useResource<ImagingStudy>(task ? getTaskImagingStudy(task) : undefined);
+
+  useEffect(() => {
+    if (!task?.id || !patient) {
+      return;
+    }
+    const openedTaskId = task.id;
+    getOrCreateDraftReport(medplum, task, patient)
+      .then((report) => setDraft({ taskId: openedTaskId, report }))
+      .catch(showErrorNotification);
+  }, [medplum, task, patient]);
+
+  // Only show a draft that belongs to the Task in the URL, so a slow load never renders the
+  // previous radiologist's report against the newly selected study.
+  const report = draft && draft.taskId === taskId ? draft.report : undefined;
+
+  // The study the topic currently has open. Tracked in a ref because it is the published context
+  // rather than rendered state, and the close event needs the study that is being replaced.
+  const openStudyRef = useRef<ImagingStudy>(undefined);
+
+  useEffect(() => {
+    // Disconnecting drops our claim on the topic; a later reconnect re-opens from scratch.
+    if (!connectedTopic) {
+      openStudyRef.current = undefined;
+      return;
+    }
+    const previous = openStudyRef.current;
+    if (previous?.id === study?.id) {
+      return;
+    }
+    openStudyRef.current = study;
+    publishStudyChange(medplum, connectedTopic, previous, study).catch(showErrorNotification);
+  }, [medplum, connectedTopic, study]);
+
+  const onSelect = (next: Task): void => {
+    navigate(`/Radiology/${next.id}`)?.catch(console.error);
+  };
+
+  const onConnectedTopicChange = useCallback((topic: string | undefined): void => setConnectedTopic(topic), []);
+
+  return (
+    <div className={classes.container}>
+      <Box p="xs">
+        <FhircastPanel onConnectedTopicChange={onConnectedTopicChange} />
+      </Box>
+      <div className={classes.body}>
+        <div className={classes.worklist}>
+          <RadiologyWorklist selectedTaskId={taskId} onSelect={onSelect} />
+        </div>
+        <div className={classes.report}>
+          {!taskId && (
+            <Text p="md" c="dimmed">
+              Select a study from the worklist to start a report.
+            </Text>
+          )}
+          {taskId && (!task || !report) && <Loading />}
+          {/* Keyed on the draft so switching worklist items remounts with a clean, unsaved editor. */}
+          {task && report && <ReportCreator key={report.id} task={task} report={report} />}
+        </div>
+        {patient && (
+          <div className={classes.chart}>
+            <PatientSummary patient={patient} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/examples/medplum-radiology-demo/src/radiology/RadiologyWorklist.tsx
+++ b/examples/medplum-radiology-demo/src/radiology/RadiologyWorklist.tsx
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { NavLink, ScrollArea, Stack, Text } from '@mantine/core';
+import type { Task } from '@medplum/fhirtypes';
+import { ResourceName, useSearchResources } from '@medplum/react';
+import type { JSX } from 'react';
+import { RADIOLOGY_WORKLIST_QUERY } from './radiology-utils';
+
+export interface RadiologyWorklistProps {
+  readonly selectedTaskId?: string;
+  readonly onSelect: (task: Task) => void;
+}
+
+export function RadiologyWorklist({ selectedTaskId, onSelect }: RadiologyWorklistProps): JSX.Element {
+  const [tasks] = useSearchResources('Task', RADIOLOGY_WORKLIST_QUERY);
+
+  if (tasks?.length === 0) {
+    return (
+      <Text p="md" c="dimmed" size="sm">
+        No studies to read.
+      </Text>
+    );
+  }
+
+  return (
+    <ScrollArea>
+      <Stack gap={0} p="xs">
+        {tasks?.map((task) => (
+          <NavLink
+            key={task.id}
+            active={task.id === selectedTaskId}
+            onClick={() => onSelect(task)}
+            label={task.for ? <ResourceName value={task.for} /> : 'Unknown patient'}
+            description={task.code?.text ?? task.description}
+          />
+        ))}
+      </Stack>
+    </ScrollArea>
+  );
+}

--- a/examples/medplum-radiology-demo/src/radiology/ReportCreator.tsx
+++ b/examples/medplum-radiology-demo/src/radiology/ReportCreator.tsx
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { ActionIcon, Badge, Button, Group, Stack, Text, Textarea, Title, Tooltip } from '@mantine/core';
+import type { DiagnosticReport, Task } from '@medplum/fhirtypes';
+import { Loading, useMedplum, useWhisper } from '@medplum/react';
+import { IconMicrophone, IconPlayerStopFilled } from '@tabler/icons-react';
+import type { JSX } from 'react';
+import { useState } from 'react';
+import { showErrorNotification } from '../utils/notifications';
+
+export interface ReportCreatorProps {
+  readonly task: Task;
+  readonly report: DiagnosticReport;
+}
+
+export function ReportCreator({ task, report }: ReportCreatorProps): JSX.Element {
+  const medplum = useMedplum();
+  const isVoiceEnabled = medplum.getProject()?.features?.includes('ai-realtime') ?? false;
+  const [text, setText] = useState(report.conclusion ?? '');
+  const [saving, setSaving] = useState(false);
+
+  const { start, stop, status, isListening } = useWhisper({
+    model: 'gpt-4o-transcribe',
+    onTranscript: (transcript) => {
+      const trimmed = transcript.trim();
+      if (!trimmed) {
+        return;
+      }
+      setText((previous) => (previous.trim() ? `${previous.trim()} ${trimmed}` : trimmed));
+    },
+  });
+
+  // `stop()` leaves the socket warm and parks the hook at 'idle', which is also its resting state
+  // before the first `start()`. So the button has to track the states where audio is actually being
+  // captured or set up — never the absence of a terminal state.
+  const isConnecting = status === 'requesting_microphone' || status === 'connecting' || status === 'connected';
+  const isActive = isConnecting || isListening;
+
+  const save = (status: DiagnosticReport['status']): void => {
+    setSaving(true);
+    medplum
+      .updateResource<DiagnosticReport>({ ...report, status, conclusion: text })
+      .catch(showErrorNotification)
+      .finally(() => setSaving(false));
+  };
+
+  if (!report.id) {
+    return <Loading />;
+  }
+
+  return (
+    <Stack p="md" gap="sm" style={{ flex: 1, minHeight: 0 }}>
+      <Group justify="space-between">
+        <div>
+          <Title order={4}>{task.code?.text ?? 'Radiology report'}</Title>
+          <Text size="xs" c="dimmed">
+            {task.description}
+          </Text>
+        </div>
+        <Badge variant="light" color={report.status === 'final' ? 'green' : 'gray'}>
+          {report.status}
+        </Badge>
+      </Group>
+
+      <Group gap="xs">
+        <Tooltip
+          label={isVoiceEnabled ? 'Dictate findings' : 'Voice input is not enabled. Add the "ai-realtime" feature.'}
+        >
+          <ActionIcon
+            variant={isActive ? 'filled' : 'light'}
+            color={isActive ? 'red' : 'blue'}
+            disabled={!isVoiceEnabled}
+            aria-label={isActive ? 'Stop dictation' : 'Start dictation'}
+            onClick={() => (isActive ? stop() : start().catch(showErrorNotification))}
+          >
+            {isActive ? <IconPlayerStopFilled size={16} /> : <IconMicrophone size={16} />}
+          </ActionIcon>
+        </Tooltip>
+        {isActive && (
+          <Text size="xs" c="dimmed">
+            {isListening ? 'Listening…' : 'Connecting…'}
+          </Text>
+        )}
+      </Group>
+
+      <Textarea
+        aria-label="Report findings"
+        placeholder="Dictate or type the findings…"
+        value={text}
+        onChange={(e) => setText(e.currentTarget.value)}
+        autosize
+        minRows={12}
+        styles={{ wrapper: { flex: 1 } }}
+      />
+
+      <Group>
+        <Button variant="default" loading={saving} onClick={() => save('preliminary')}>
+          Save draft
+        </Button>
+        <Button loading={saving} disabled={!text.trim()} onClick={() => save('final')}>
+          Sign report
+        </Button>
+      </Group>
+    </Stack>
+  );
+}

--- a/examples/medplum-radiology-demo/src/radiology/radiology-utils.ts
+++ b/examples/medplum-radiology-demo/src/radiology/radiology-utils.ts
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { MedplumClient } from '@medplum/core';
+import { getReferenceString } from '@medplum/core';
+import type { DiagnosticReport, ImagingStudy, Patient, Reference, Task } from '@medplum/fhirtypes';
+
+/** Marks the Tasks and DiagnosticReports that belong to the radiology dictation worklist. */
+export const RADIOLOGY_SYSTEM = 'https://medplum.com/radiology-dictation';
+
+/** Task.code used by `generate-diag-report-task`, and the filter the worklist searches on. */
+export const RADIOLOGY_TASK_CODE = 'read-imaging-study';
+
+export const RADIOLOGY_WORKLIST_QUERY = `identifier=${RADIOLOGY_SYSTEM}|${RADIOLOGY_TASK_CODE}&status:not=completed,cancelled&_sort=-_lastUpdated&_count=50`;
+
+/**
+ * The draft report is keyed to its Task, so reopening the Task resumes the same draft.
+ * @param task - The worklist Task.
+ * @returns The identifier value for the Task's draft report.
+ */
+export function draftIdentifierValue(task: Task): string {
+  return `${RADIOLOGY_TASK_CODE}/${task.id}`;
+}
+
+/**
+ * @param task - The worklist Task.
+ * @returns The ImagingStudy the Task was created for, if any.
+ */
+export function getTaskImagingStudy(task: Task): Reference<ImagingStudy> | undefined {
+  const input = task.input?.find((i) => i.valueReference?.reference?.startsWith('ImagingStudy/'));
+  return input?.valueReference as Reference<ImagingStudy> | undefined;
+}
+
+/**
+ * Returns the existing draft for a Task, or creates a blank one. The blank draft is the only thing
+ * written on open — dictation edits stay local until the radiologist saves, so switching worklist
+ * items never persists a half-finished report.
+ * @param medplum - The Medplum client.
+ * @param task - The worklist Task being opened.
+ * @param patient - The subject of the report.
+ * @returns The resumable draft DiagnosticReport.
+ */
+export async function getOrCreateDraftReport(
+  medplum: MedplumClient,
+  task: Task,
+  patient: Reference<Patient>
+): Promise<DiagnosticReport> {
+  const identifier = draftIdentifierValue(task);
+  const existing = await medplum.searchOne('DiagnosticReport', { identifier: `${RADIOLOGY_SYSTEM}|${identifier}` });
+  if (existing) {
+    return existing;
+  }
+  const imagingStudy = getTaskImagingStudy(task);
+  return medplum.createResource<DiagnosticReport>({
+    resourceType: 'DiagnosticReport',
+    identifier: [{ system: RADIOLOGY_SYSTEM, value: identifier }],
+    status: 'registered',
+    code: task.code ?? { text: 'Radiology report' },
+    subject: patient,
+    basedOn: [{ reference: getReferenceString(task) }],
+    ...(imagingStudy ? { imagingStudy: [imagingStudy] } : {}),
+  });
+}
+
+/**
+ * Announces a change of study on the FHIRcast topic: the study leaving the viewport is closed before
+ * the new one opens, so subscribers never see two studies open at once.
+ *
+ * The full ImagingStudy is published rather than a stub, since subscribers key off details such as
+ * the accession number that a bare id would not carry.
+ * @param medplum - The Medplum client.
+ * @param topic - The connected FHIRcast topic.
+ * @param previous - The study currently open, if any.
+ * @param next - The study being opened, if any.
+ */
+export async function publishStudyChange(
+  medplum: MedplumClient,
+  topic: string,
+  previous: ImagingStudy | undefined,
+  next: ImagingStudy | undefined
+): Promise<void> {
+  if (previous) {
+    await medplum.fhircastPublish(topic, 'ImagingStudy-close', { key: 'study', resource: previous });
+  }
+  if (next) {
+    await medplum.fhircastPublish(topic, 'ImagingStudy-open', { key: 'study', resource: next });
+  }
+}

--- a/examples/medplum-radiology-demo/src/utils/notifications.ts
+++ b/examples/medplum-radiology-demo/src/utils/notifications.ts
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { notifications } from '@mantine/notifications';
+import { normalizeErrorString } from '@medplum/core';
+import { IconCircleOff } from '@tabler/icons-react';
+import React from 'react';
+
+export const showErrorNotification = (err: unknown): void => {
+  notifications.show({
+    color: 'red',
+    icon: React.createElement(IconCircleOff),
+    title: 'Error',
+    message: normalizeErrorString(err),
+  });
+};

--- a/examples/medplum-radiology-demo/src/vite-env.d.ts
+++ b/examples/medplum-radiology-demo/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+/// <reference types="vite/client" />

--- a/examples/medplum-radiology-demo/tsconfig.json
+++ b/examples/medplum-radiology-demo/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "types": ["vite/client"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "exclude": ["dist"]
+}

--- a/examples/medplum-radiology-demo/vercel.json
+++ b/examples/medplum-radiology-demo/vercel.json
@@ -1,0 +1,5 @@
+{
+  "installCommand": "npm install",
+  "buildCommand": "npm run build",
+  "routes": [{ "src": "/[^.]+", "dest": "/", "status": 200 }]
+}

--- a/examples/medplum-radiology-demo/vite.config.ts
+++ b/examples/medplum-radiology-demo/vite.config.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import react from '@vitejs/plugin-react';
+import dns from 'dns';
+import { copyFileSync, existsSync } from 'fs';
+import path from 'path';
+import { defineConfig } from 'vite';
+
+dns.setDefaultResultOrder('verbatim');
+
+if (!existsSync(path.join(__dirname, '.env'))) {
+  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+}
+
+dns.setDefaultResultOrder('verbatim');
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  envPrefix: ['MEDPLUM_', 'GOOGLE_', 'RECAPTCHA_'],
+  plugins: [react()],
+  server: {
+    host: 'localhost',
+    port: 3000,
+  },
+});


### PR DESCRIPTION
A radiologist reading worklist built on Medplum primitives, added under `examples/medplum-radiology-demo`.

## What it shows

- **Worklist** — `Task` resources tagged with the `https://medplum.com/radiology-dictation` identifier, listed in a pane that stays mounted while switching between reports.
- **Report creator** — voice-to-text dictation via the `useWhisper` hook from `@medplum/react`, alongside `PatientSummary` for the selected study.
- **Resumable drafts** — opening a Task creates a blank `DiagnosticReport` identified by that Task, so reopening it later picks up the same draft. Nothing else is written until save, so switching studies discards unsaved dictation.
- **FHIRcast** — a panel to connect to a topic and follow `ImagingStudy-open`, `ImagingStudy-close`, and `syncerror` events. While connected, selecting a worklist item publishes the context change: the outgoing study is closed before the incoming one is opened, so subscribers such as a PACS viewer follow along.
- **Seeding script** — `npm run generate-task -- Patient/123 ImagingStudy/456` creates a reading Task via client credentials.

Voice input requires the `ai-realtime` feature on the Medplum project.

## Test plan

- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npx prettier --check` — clean
- `npm run build` — succeeds

Draft for now; opening for early review of the structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)