### PR TITLE
fix(server): block deletion of resources referenced by ProjectMembership (#8312)

### DIFF
--- a/packages/server/src/fhir/precommit.test.ts
+++ b/packages/server/src/fhir/precommit.test.ts
@@ -12,7 +12,7 @@ import { globalLogger } from '../logger';
 import { createTestProject, withTestContext } from '../test.setup';
 import { createBot } from './operations/botinit';
 import { deployBot } from './operations/deploy';
-import type { Repository } from './repo';
+import { Repository } from './repo';
 
 describe('FHIR Repo', () => {
   let project: WithId<Project>;
@@ -171,18 +171,38 @@ describe('FHIR Repo', () => {
     });
 
     test('Checks ProjectMembership.profile', async () => {
-      await expect(repo.deleteResource('Practitioner', profile.id)).resolves.toBeUndefined();
+      await expect(repo.deleteResource('Practitioner', profile.id)).rejects.toThrow(
+        `Cannot delete Practitioner/${profile.id}: referenced by ProjectMembership/`
+      );
       expect(logSpy).toHaveBeenCalledWith('Deleting resource referenced by ProjectMembership', expect.any(Error));
+      // The delete is blocked, so the resource should still exist
+      await expect(repo.readResource('Practitioner', profile.id)).resolves.toMatchObject({ id: profile.id });
     });
 
     test('Checks ProjectMembership.access.policy', async () => {
-      await expect(repo.deleteResource('AccessPolicy', accessPolicy.id)).resolves.toBeUndefined();
+      await expect(repo.deleteResource('AccessPolicy', accessPolicy.id)).rejects.toThrow(
+        `Cannot delete AccessPolicy/${accessPolicy.id}: referenced by ProjectMembership/`
+      );
       expect(logSpy).toHaveBeenCalledWith('Deleting resource referenced by ProjectMembership', expect.any(Error));
+      // The delete is blocked, so the resource should still exist
+      await expect(repo.readResource('AccessPolicy', accessPolicy.id)).resolves.toMatchObject({ id: accessPolicy.id });
     });
 
     test('Does not check ProjectMembership.userConfiguration', async () => {
       await expect(repo.deleteResource('UserConfiguration', userConfig.id)).resolves.toBeUndefined();
       expect(logSpy).toHaveBeenCalledTimes(0);
+    });
+
+    test('Super admin can delete referenced resources', async () => {
+      // Super admins bypass the critical reference check by design
+      const superAdminRepo = new Repository({
+        extendedMode: true,
+        superAdmin: true,
+        author: createReference(profile),
+      });
+
+      await expect(superAdminRepo.deleteResource('AccessPolicy', accessPolicy.id)).resolves.toBeUndefined();
+      expect(logSpy).not.toHaveBeenCalledWith('Deleting resource referenced by ProjectMembership', expect.any(Error));
     });
   });
 });

--- a/packages/server/src/fhir/precommit.ts
+++ b/packages/server/src/fhir/precommit.ts
@@ -54,6 +54,7 @@ export async function preCommitValidation<T extends Resource>(
       await checkReferencesForDelete(repo, resource);
     } catch (err) {
       logger.warn('Deleting resource referenced by ProjectMembership', err as Error);
+      throw err;
     }
   }
 


### PR DESCRIPTION
Fixes #8312

## Description
Deleting a resource that is still referenced by a ProjectMembership previously succeeded silently:
`preCommitValidation` caught the `OperationOutcomeError` from `checkReferencesForDelete` and only logged
a warning (the "log only for now" first pass from #7913, as discussed in #8312). This PR converts the
check into an actual block:

- The error is now re-thrown, so `Repository.deleteResource` fails with `400 Bad Request`
  (`Cannot delete AccessPolicy/...: referenced by ProjectMembership/...`) before any data is modified.
- Super admins keep their existing bypass (`isSuperAdmin()`).

## Testing
- Updated `precommit.test.ts`: `Checks ProjectMembership.profile` and `Checks ProjectMembership.access.policy`
  now expect a rejection, the warning log, and that the resource still exists.
- Added `Super admin can delete referenced resources` covering the `isSuperAdmin()` bypass.
- `npx vitest run src/fhir/precommit.test.ts` — 6/6 passed; eslint clean.
- Manually verified in the web app: deleting a referenced AccessPolicy as a project admin shows the error
  toast and the resource remains; deletion works normally for non-referenced policies.
