### PR TITLE
feat(react): support custom user menu items

### DIFF
--- a/packages/react/src/AppShell/AppShell.test.tsx
+++ b/packages/react/src/AppShell/AppShell.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
+import type { ReactNode } from 'react';
 import { Logo } from '../Logo/Logo';
 import { act, fireEvent, render, screen, selectAutocompleteOption } from '../test-utils/render';
 import type { AppShellAnnouncement } from './AnnouncementBanners';
@@ -10,7 +11,11 @@ import { AppShell } from './AppShell';
 const medplum = new MockClient();
 const navigateMock = vi.fn();
 
-async function setup(layoutVersion: 'v1' | 'v2' = 'v1', announcements?: AppShellAnnouncement[]): Promise<void> {
+async function setup(
+  layoutVersion: 'v1' | 'v2' = 'v1',
+  announcements?: AppShellAnnouncement[],
+  userMenuItems?: ReactNode
+): Promise<void> {
   // Reset localStorage before each test
   localStorage.clear();
 
@@ -22,6 +27,7 @@ async function setup(layoutVersion: 'v1' | 'v2' = 'v1', announcements?: AppShell
           version="test.version"
           layoutVersion={layoutVersion}
           announcements={announcements}
+          userMenuItems={userMenuItems}
           menus={[
             {
               title: 'Menu 1',
@@ -65,6 +71,16 @@ describe('AppShell v1', () => {
     await setup();
 
     expect(screen.getByText('Your application here')).toBeInTheDocument();
+  });
+
+  test('Renders consumer user menu items', async () => {
+    await setup('v1', undefined, <div>Custom user menu item</div>);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('User menu'));
+    });
+
+    expect(await screen.findByText('Custom user menu item')).toBeInTheDocument();
   });
 
   test('Toggle sidebar', async () => {
@@ -141,6 +157,16 @@ describe('AppShell v2', () => {
     await setup('v2');
 
     expect(screen.getByText('Your application here')).toBeInTheDocument();
+  });
+
+  test('Renders consumer user menu items in v2', async () => {
+    await setup('v2', undefined, <div>Custom user menu item</div>);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('User menu'));
+    });
+
+    expect(await screen.findByText('Custom user menu item')).toBeInTheDocument();
   });
 
   test('Toggle sidebar v2 via logo', async () => {

--- a/packages/react/src/AppShell/AppShell.tsx
+++ b/packages/react/src/AppShell/AppShell.tsx
@@ -38,6 +38,7 @@ export interface AppShellProps {
   readonly showLayoutVersionToggle?: boolean;
   readonly spotlightPatientsOnly?: boolean;
   readonly spotlightActions?: SpotlightLinkAction[];
+  readonly userMenuItems?: ReactNode;
 }
 
 export function AppShell(props: AppShellProps): JSX.Element {
@@ -130,6 +131,7 @@ export function AppShell(props: AppShellProps): JSX.Element {
         userMenuEnabled={true}
         version={props.version}
         showLayoutVersionToggle={props.showLayoutVersionToggle}
+        userMenuItems={props.userMenuItems}
       />
     ) : undefined;
   } else {
@@ -155,6 +157,7 @@ export function AppShell(props: AppShellProps): JSX.Element {
         notifications={props.notifications}
         announcements={visibleAnnouncements}
         onDismissAnnouncement={dismissAnnouncement}
+        userMenuItems={props.userMenuItems}
       />
     );
     navbarComponent =
@@ -169,6 +172,7 @@ export function AppShell(props: AppShellProps): JSX.Element {
           resourceTypeSearchDisabled={props.resourceTypeSearchDisabled}
           patientsOnly={props.spotlightPatientsOnly}
           spotlightActions={props.spotlightActions}
+          userMenuItems={props.userMenuItems}
         />
       ) : undefined;
   }

--- a/packages/react/src/AppShell/Header.test.tsx
+++ b/packages/react/src/AppShell/Header.test.tsx
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { AppShell as MantineAppShell } from '@mantine/core';
+import { AppShell as MantineAppShell, Menu } from '@mantine/core';
 import { locationUtils } from '@medplum/core';
 import { MockClient, TestProject } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
+import type { ReactNode } from 'react';
 import { Logo } from '../Logo/Logo';
 import { act, fireEvent, render, screen } from '../test-utils/render';
 import { Header } from './Header';
@@ -12,12 +13,17 @@ const medplum = new MockClient();
 const navigateMock = vi.fn();
 const closeMock = vi.fn();
 
-async function setup(client?: MockClient): Promise<void> {
+async function setup(client?: MockClient, userMenuItems?: ReactNode): Promise<void> {
   await act(async () => {
     render(
       <MedplumProvider medplum={client ?? medplum} navigate={navigateMock}>
         <MantineAppShell>
-          <Header logo={<Logo size={24} />} version="test.version" navbarToggle={closeMock} />
+          <Header
+            logo={<Logo size={24} />}
+            version="test.version"
+            navbarToggle={closeMock}
+            userMenuItems={userMenuItems}
+          />
         </MantineAppShell>
       </MedplumProvider>
     );
@@ -99,6 +105,16 @@ describe('Header', () => {
     await act(async () => {
       fireEvent.click(menuButton);
     });
+  });
+
+  test('Renders consumer user menu items without replacing built-in items', async () => {
+    await setup(undefined, <Menu.Item>Custom user menu item</Menu.Item>);
+
+    await openMenu();
+
+    expect(screen.getByText('Custom user menu item')).toBeInTheDocument();
+    expect(screen.getByText('Account settings')).toBeInTheDocument();
+    expect(screen.getByText('Sign out')).toBeInTheDocument();
   });
 
   test('Switch profile', async () => {

--- a/packages/react/src/AppShell/Header.tsx
+++ b/packages/react/src/AppShell/Header.tsx
@@ -25,6 +25,7 @@ export interface HeaderProps {
   readonly notifications?: ReactNode;
   readonly announcements?: AppShellAnnouncement[];
   readonly onDismissAnnouncement?: (announcement: AppShellAnnouncement) => void;
+  readonly userMenuItems?: ReactNode;
 }
 
 export function Header(props: HeaderProps): JSX.Element {
@@ -85,7 +86,7 @@ export function Header(props: HeaderProps): JSX.Element {
                 </UnstyledButton>
               </Menu.Target>
               <Menu.Dropdown className={headerDropdownClasses.dropdown}>
-                <HeaderDropdown version={props.version} />
+                <HeaderDropdown version={props.version} userMenuItems={props.userMenuItems} />
               </Menu.Dropdown>
             </Menu>
           </Group>

--- a/packages/react/src/AppShell/HeaderDropdown.tsx
+++ b/packages/react/src/AppShell/HeaderDropdown.tsx
@@ -17,7 +17,7 @@ import {
   IconTable,
 } from '@tabler/icons-react';
 import cx from 'clsx';
-import type { JSX } from 'react';
+import type { JSX, ReactNode } from 'react';
 import { useState } from 'react';
 import { ProjectLoginOption } from '../auth/ProjectLoginOption';
 import { getAppName } from '../utils/app';
@@ -64,6 +64,7 @@ function getLoginKey(login: LoginState): string {
 export interface HeaderDropdownProps {
   readonly version?: string;
   readonly showLayoutVersionToggle?: boolean;
+  readonly userMenuItems?: ReactNode;
 }
 
 export function HeaderDropdown(props: HeaderDropdownProps): JSX.Element {
@@ -110,6 +111,12 @@ export function HeaderDropdown(props: HeaderDropdownProps): JSX.Element {
               </Box>
             </Menu.Item>
           ))}
+        </>
+      )}
+      {props.userMenuItems && (
+        <>
+          <HeaderDropdownDivider />
+          {props.userMenuItems}
         </>
       )}
       <HeaderDropdownDivider />

--- a/packages/react/src/AppShell/Navbar.test.tsx
+++ b/packages/react/src/AppShell/Navbar.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { AppShell as MantineAppShell } from '@mantine/core';
+import { AppShell as MantineAppShell, Menu } from '@mantine/core';
 import type { WithId } from '@medplum/core';
 import type { Communication, UserConfiguration } from '@medplum/fhirtypes';
 import { MockClient, TestProject } from '@medplum/mock';
@@ -167,6 +167,35 @@ describe('Navbar', () => {
     });
 
     expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+  });
+
+  test('Renders consumer user menu items without replacing built-in items', async () => {
+    const initialUrl = new URL('/', 'http://localhost');
+    await act(async () => {
+      render(
+        <MedplumProvider medplum={medplum} navigate={navigateMock}>
+          <MantineAppShell>
+            <Navbar
+              logo={<div>Logo</div>}
+              pathname={initialUrl.pathname}
+              searchParams={initialUrl.searchParams}
+              navbarToggle={toggleMock}
+              closeNavbar={closeMock}
+              userMenuEnabled={true}
+              userMenuItems={<Menu.Item>Custom user menu item</Menu.Item>}
+            />
+          </MantineAppShell>
+        </MedplumProvider>
+      );
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('User menu'));
+    });
+
+    expect(await screen.findByText('Custom user menu item')).toBeInTheDocument();
+    expect(await screen.findByText('Account settings')).toBeInTheDocument();
+    expect(await screen.findByText('Sign out')).toBeInTheDocument();
   });
 
   test('Highlighted link', async () => {

--- a/packages/react/src/AppShell/Navbar.tsx
+++ b/packages/react/src/AppShell/Navbar.tsx
@@ -67,6 +67,7 @@ export interface NavbarProps {
   readonly opened?: boolean;
   readonly version?: string;
   readonly showLayoutVersionToggle?: boolean;
+  readonly userMenuItems?: ReactNode;
 }
 
 export function Navbar(props: NavbarProps): JSX.Element {
@@ -245,7 +246,11 @@ export function Navbar(props: NavbarProps): JSX.Element {
                 </UnstyledButton>
               </Menu.Target>
               <Menu.Dropdown className={headerDropdownClasses.dropdown}>
-                <HeaderDropdown version={props.version} showLayoutVersionToggle={props.showLayoutVersionToggle} />
+                <HeaderDropdown
+                  version={props.version}
+                  showLayoutVersionToggle={props.showLayoutVersionToggle}
+                  userMenuItems={props.userMenuItems}
+                />
               </Menu.Dropdown>
             </Menu>
           </MantineAppShell.Section>


### PR DESCRIPTION
## Summary

- add an optional `userMenuItems` extension point to `AppShell`, `Header`, and `Navbar`
- render consumer content inside the existing username dropdown in both layout versions
- preserve the built-in project, account, appearance, and sign-out items

## Verification

- `npm run lint`
- `npm run build`
- `npm test`: 1,384/1,386 passed under unsupported local Node 26; the two shared-storage collisions passed 10/10 when rerun in isolation with an isolated local-storage file

Fixes #10466