### PR TITLE
Handle compose.include.valueSet in ValueSet/$validate-code

### DIFF
--- a/packages/server/src/fhir/operations/valuesetvalidatecode.test.ts
+++ b/packages/server/src/fhir/operations/valuesetvalidatecode.test.ts
@@ -446,6 +446,99 @@ describe('ValueSet validate-code', () => {
     ]);
   });
 
+  test('Validates code via include.valueSet', async () => {
+    const system = 'http://example.com/system-' + randomUUID();
+    const csRes = await request(app)
+      .post('/fhir/R4/CodeSystem')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'CodeSystem',
+        url: system,
+        status: 'active',
+        content: 'complete',
+        concept: [{ code: 'TARGET', display: 'Target' }],
+      } satisfies CodeSystem);
+    expect(csRes).toHaveStatus(201);
+
+    const innerRes = await request(app)
+      .post('/fhir/R4/ValueSet')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'ValueSet',
+        url: 'http://example.com/inner-vs-' + randomUUID(),
+        status: 'active',
+        compose: { include: [{ system, concept: [{ code: 'TARGET' }] }] },
+      } satisfies ValueSet);
+    expect(innerRes).toHaveStatus(201);
+
+    const outerRes = await request(app)
+      .post('/fhir/R4/ValueSet')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'ValueSet',
+        url: 'http://example.com/outer-vs-' + randomUUID(),
+        status: 'active',
+        // No system: this include pulls in the other ValueSet
+        compose: { include: [{ valueSet: [(innerRes.body as ValueSet).url as string] }] },
+      } satisfies ValueSet);
+    expect(outerRes).toHaveStatus(201);
+
+    const validateRes = await request(app)
+      .post(`/fhir/R4/ValueSet/$validate-code`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'url', valueUri: (outerRes.body as ValueSet).url },
+          { name: 'coding', valueCoding: { system, code: 'TARGET' } },
+        ],
+      });
+    expect(validateRes).toHaveStatus(200);
+    expect(validateRes.body.parameter).toContainExactly([
+      { name: 'result', valueBoolean: true },
+      { name: 'display', valueString: 'Target' },
+    ]);
+  });
+
+  test('Terminates when ValueSets include each other', async () => {
+    const urlA = 'http://example.com/cycle-a-' + randomUUID();
+    const urlB = 'http://example.com/cycle-b-' + randomUUID();
+    for (const [url, other] of [
+      [urlA, urlB],
+      [urlB, urlA],
+    ]) {
+      const res = await request(app)
+        .post('/fhir/R4/ValueSet')
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .send({
+          resourceType: 'ValueSet',
+          url,
+          status: 'active',
+          compose: { include: [{ valueSet: [other] }] },
+        } satisfies ValueSet);
+      expect(res).toHaveStatus(201);
+    }
+
+    const validateRes = await request(app)
+      .post(`/fhir/R4/ValueSet/$validate-code`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'url', valueUri: urlA },
+          { name: 'coding', valueCoding: { system, code: 'NOPE' } },
+        ],
+      });
+    expect(validateRes).toHaveStatus(200);
+    expect(validateRes.body.parameter).toContainExactly([{ name: 'result', valueBoolean: false }]);
+  });
+
   test('Falls back to validating system URL when CodeSystem unavailable', async () => {
     const system = 'http://example.com/other-codes-' + randomUUID();
     const res = await request(app)

--- a/packages/server/src/fhir/operations/valuesetvalidatecode.ts
+++ b/packages/server/src/fhir/operations/valuesetvalidatecode.ts
@@ -80,14 +80,15 @@ export async function valueSetValidateOperation(req: FhirRequest): Promise<FhirR
 export async function validateCodingInValueSet(
   repo: Repository,
   valueSet: ValueSet,
-  codings: Coding[]
+  codings: Coding[],
+  seen = new Set<string>()
 ): Promise<Coding | undefined> {
   let found: Coding | undefined;
   if (valueSet.expansion && !valueSet.expansion.parameter) {
     found = valueSet.expansion.contains?.find((e) => codings.some((c) => e.system === c.system && e.code === c.code));
   } else if (valueSet.compose) {
     for (const include of valueSet.compose.include) {
-      found = await findIncludedCode(repo, include, ...codings);
+      found = await findIncludedCode(repo, include, seen, ...codings);
       if (found) {
         break;
       }
@@ -105,8 +106,25 @@ export async function validateCodingInValueSet(
 async function findIncludedCode(
   repo: Repository,
   include: ValueSetComposeInclude,
+  seen: Set<string>,
   ...codings: Coding[]
 ): Promise<Coding | undefined> {
+  // An include may reference other ValueSets instead of a system, as computeExpansion() allows;
+  // `seen` stops a cycle of ValueSets including each other
+  if (include.valueSet) {
+    for (const url of include.valueSet) {
+      if (seen.has(url)) {
+        continue;
+      }
+      seen.add(url);
+      const included = await findTerminologyResource<ValueSet>(repo, 'ValueSet', url);
+      const found = await validateCodingInValueSet(repo, included, codings, seen);
+      if (found) {
+        return found;
+      }
+    }
+    return undefined;
+  }
   if (!include.system) {
     throw new OperationOutcomeError(
       badRequest('Missing system URL for ValueSet include', 'ValueSet.compose.include.system')


### PR DESCRIPTION
Fixes #9514. findIncludedCode threw "Missing system URL" for include.valueSet, on $validate-code and on writes whose binding uses one; it now recurses like computeExpansion, with a seen set so mutually including ValueSets terminate.
