### PR TITLE
[Scheduling] Handle missing actor timezones more gracefully

### DIFF
--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentActorSelect.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentActorSelect.tsx
@@ -70,7 +70,6 @@ export function AppointmentActorSelect(props: AppointmentActorSelectProps): JSX.
       name={actorType}
       label={label}
       required={required}
-      description={required ? undefined : `Optional. Leave empty to search without holding a ${noun}.`}
       placeholder={`Search ${noun}s`}
       error={error}
       disabled={disabled}

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.test.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.test.ts
@@ -6,8 +6,6 @@ import {
   endOfMonth,
   enumerateDateRange,
   filterByTimeOfDay,
-  formatDateRange,
-  formatDayLabel,
   formatTimezoneLabel,
   formatZonedTime,
   getActorGroupKey,
@@ -235,34 +233,6 @@ describe('enumerateDateRange', () => {
   test('Stops at the limit rather than running a year out', () => {
     const days = enumerateDateRange({ start: new Date(2026, 6, 1), end: new Date(2027, 6, 1) }, 5);
     expect(days).toHaveLength(5);
-  });
-});
-
-describe('formatDateRange', () => {
-  test('Says which days are being searched', () => {
-    expect(formatDateRange({ start: new Date(2026, 6, 27), end: new Date(2026, 6, 27) })).toBe('Monday, July 27');
-    expect(formatDateRange({ start: new Date(2026, 6, 27), end: new Date(2026, 6, 30) })).toBe(
-      'Monday, July 27 – Thursday, July 30'
-    );
-    expect(formatDateRange({ start: new Date(2026, 6, 27) })).toBe('From Monday, July 27');
-    expect(formatDateRange({ end: new Date(2026, 6, 30) })).toBe('Through Thursday, July 30');
-  });
-
-  test('Says nothing when neither end was asked for', () => {
-    expect(formatDateRange({})).toBeUndefined();
-  });
-
-  test('Names the days however the caller asks them to be named', () => {
-    expect(formatDateRange({ start: new Date(2026, 6, 27), end: new Date(2026, 6, 30) }, formatDayLabel)).toBe(
-      'July 27 – July 30'
-    );
-    expect(formatDateRange({ start: new Date(2026, 6, 27) }, formatDayLabel)).toBe('From July 27');
-  });
-});
-
-describe('formatDayLabel', () => {
-  test('Names a day without its weekday', () => {
-    expect(formatDayLabel(new Date(2026, 6, 27))).toBe('July 27');
   });
 });
 

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.ts
@@ -130,15 +130,6 @@ export function formatDayHeading(date: Date): string {
 }
 
 /**
- * Names a calendar day without its weekday (e.g. "July 27").
- * @param date - Local midnight of the day.
- * @returns The formatted day.
- */
-export function formatDayLabel(date: Date): string {
-  return new Intl.DateTimeFormat(undefined, { month: 'long', day: 'numeric' }).format(date);
-}
-
-/**
  * Returns how far a timezone is from UTC at a given instant.
  * @param instant - The instant to read the offset at.
  * @param timezone - IANA timezone identifier.
@@ -428,21 +419,6 @@ export function endOfDay(date: Date): Date {
   return result;
 }
 
-/**
- * Returns whether two instants fall on the same local day.
- * @param left - The first instant.
- * @param right - The second, or undefined when there is nothing to compare.
- * @returns True when both fall on the same local day.
- */
-export function isSameDay(left: Date, right: Date | undefined): boolean {
-  return (
-    !!right &&
-    left.getFullYear() === right.getFullYear() &&
-    left.getMonth() === right.getMonth() &&
-    left.getDate() === right.getDate()
-  );
-}
-
 export function addDays(date: Date, days: number): Date {
   const result = new Date(date);
   result.setDate(result.getDate() + days);
@@ -536,27 +512,4 @@ export function getFindWindowError(range: DateRange): string | undefined {
  */
 export function getDayCount(start: Date, end: Date): number {
   return Math.ceil((end.getTime() - start.getTime()) / MS_PER_DAY);
-}
-
-/**
- * Says in words which days a search covers.
- * @param range - The days asked for.
- * @param formatDay - How to name one day. Defaults to naming it with its weekday.
- * @returns The range as a phrase, or undefined when both ends are open.
- */
-export function formatDateRange(
-  range: DateRange,
-  formatDay: (date: Date) => string = formatDayHeading
-): string | undefined {
-  const { start, end } = range;
-  if (start && end) {
-    return isSameDay(start, end) ? formatDay(start) : `${formatDay(start)} – ${formatDay(end)}`;
-  }
-  if (start) {
-    return `From ${formatDay(start)}`;
-  }
-  if (end) {
-    return `Through ${formatDay(end)}`;
-  }
-  return undefined;
 }

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.test.tsx
@@ -280,15 +280,12 @@ describe('AppointmentProposalForm', () => {
       expect(within(listbox).getByText('Uro Associates - Satellite')).toBeInTheDocument();
     });
 
-    test('Narrows the visit types to the chosen site, and says which site', async () => {
+    test('Narrows the visit types to the chosen site', async () => {
       setup(medplum);
       await chooseSite('Satellite', 'Uro Associates - Satellite');
 
       await typeInAutocomplete(field(/visit type/i), 'Ultrasound');
 
-      expect(
-        screen.getByText('Showing visit types offered at Uro Associates - Satellite, plus those not tied to a site.')
-      ).toBeInTheDocument();
       // Imaging names the main clinic, and only a visit type naming this site exactly
       // is offered at it.
       expect(await screen.findByText('Nothing found')).toBeInTheDocument();
@@ -625,17 +622,6 @@ describe('AppointmentProposalForm', () => {
 
       // A proposal carries the Slots it was found for, and the search has moved on.
       expect(chosenTimeField()).toBeNull();
-    });
-
-    test('Names the days being searched, without the weekdays their headings carry', async () => {
-      setup(medplum);
-      await openFinder();
-
-      expect(screen.getByText(/^August 17 · drag or shift-click/)).toBeInTheDocument();
-
-      await dragDays('17', '21');
-
-      expect(await screen.findByText(/August 17 – August 21 · drag or shift-click/)).toBeInTheDocument();
     });
   });
 

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
@@ -27,7 +27,7 @@ import { AppointmentDayTimes } from './AppointmentDayTimes';
 import classes from './AppointmentFinder.module.css';
 import type { ActorSelections, ScheduleCandidate } from './AppointmentFinder.schedules';
 import { getActorCombinations, getSelectedCandidates, getSelectionError } from './AppointmentFinder.schedules';
-import { formatDateRange, formatDayLabel, getDurationMinutes, isViewerTimezone } from './AppointmentFinder.times';
+import { getDurationMinutes, isViewerTimezone } from './AppointmentFinder.times';
 import { AppointmentOptionRow } from './AppointmentOptionRow';
 import { AppointmentServiceSelect } from './AppointmentServiceSelect';
 import { isServiceKeptAtLocation } from './AppointmentServiceSelect.utils';
@@ -44,11 +44,6 @@ const PATIENT_SEARCH_CRITERIA = { _count: '25', _sort: 'name,birthdate' };
 
 // No month-wide scan exists, so every day is offered and the search answers.
 const NO_MARKED_DATES: Date[] = [];
-
-// Shown beneath the calendar, since dragging or shift-clicking leaves no visible mark.
-const DAY_GESTURE_HINT = 'drag or shift-click to search more days';
-
-const HINT_SEPARATOR = ' · ';
 
 export interface AppointmentProposalFormProps {
   /** Pre-fills where the visit is, for a host that already knows. */
@@ -331,9 +326,6 @@ export function AppointmentProposalForm(props: AppointmentProposalFormProps): JS
               onClick={daySearch.chooseDayRange}
               onSelectRange={daySearch.chooseDayRange}
             />
-            <Text size="xs" c="dimmed">
-              {getSearchedDaysHint(daySearch.selectedDayRange)}
-            </Text>
             {daySearch.windowError && <Alert color="yellow">{daySearch.windowError}</Alert>}
           </Stack>
         )}
@@ -599,15 +591,6 @@ function toRange(appointment: Appointment | undefined): DateTimeRange | undefine
     return undefined;
   }
   return { start: new Date(appointment.start), end: new Date(appointment.end) };
-}
-
-/**
- * The line under the calendar: which days are being searched, and how to ask for others.
- * @param range - The days being searched.
- * @returns The line to show beneath the calendar.
- */
-function getSearchedDaysHint(range: DateTimeRange): string {
-  return [formatDateRange(range, formatDayLabel), DAY_GESTURE_HINT].filter(isDefined).join(HINT_SEPARATOR);
 }
 
 /**

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.test.tsx
@@ -146,12 +146,11 @@ describe('AppointmentServiceSelect', () => {
       ['Ultrasound', '25', 'name'],
       ['Ultrasound', '25', 'name'],
     ]);
-    expect(screen.getByText(/Showing visit types offered at/)).toBeInTheDocument();
     searchResources.mockRestore();
   });
 
-  // A caller holding a reference should not have to read the Location first: narrowing
-  // needs only the reference string, and the site is fetched to name it.
+  // A caller holding a reference should not have to read the Location first:
+  // narrowing needs only the reference string.
   test('Narrows the services to a location given as a reference', async () => {
     const searchResources = vi.spyOn(medplum, 'searchResources');
     setup({ location: { reference: 'Location/main-clinic' } });
@@ -159,9 +158,6 @@ describe('AppointmentServiceSelect', () => {
     await typeInAutocomplete(searchBox(), 'Ultrasound');
 
     expect(serviceSearches(searchResources)[0].get('location')).toBe('Location/main-clinic');
-    expect(
-      await screen.findByText(`Showing visit types offered at ${MainClinic.name}, plus those not tied to a site.`)
-    ).toBeInTheDocument();
     searchResources.mockRestore();
   });
 

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.tsx
@@ -5,7 +5,7 @@ import { formatCodeableConcept, getDisplayString, getReferenceString, hasSchedul
 import type { HealthcareService, Location, Reference } from '@medplum/fhirtypes';
 import type { AsyncAutocompleteOption } from '@medplum/react';
 import { AsyncAutocomplete } from '@medplum/react';
-import { useMedplum, useResource } from '@medplum/react-hooks';
+import { useMedplum } from '@medplum/react-hooks';
 import type { JSX } from 'react';
 import { useCallback } from 'react';
 import { AppointmentOptionRow } from './AppointmentOptionRow';
@@ -48,7 +48,6 @@ export function AppointmentServiceSelect(props: AppointmentServiceSelectProps): 
   const medplum = useMedplum();
 
   const locationReference = location && getReferenceString(location);
-  const locationResource = useResource(location);
 
   const loadOptions = useCallback(
     async (input: string, signal: AbortSignal): Promise<WithId<HealthcareService>[]> => {
@@ -84,11 +83,6 @@ export function AppointmentServiceSelect(props: AppointmentServiceSelectProps): 
       name="service"
       label={label}
       placeholder="Search visit types"
-      description={
-        locationResource
-          ? `Showing visit types offered at ${getDisplayString(locationResource)}, plus those not tied to a site.`
-          : undefined
-      }
       required
       maxValues={1}
       error={error}

--- a/packages/react-scheduling/src/SchedulingWorkspace/CalendarTimezoneNotice.test.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/CalendarTimezoneNotice.test.tsx
@@ -31,6 +31,20 @@ describe('CalendarTimezoneNotice', () => {
     expect(screen.getByTestId('calendar-timezone-notice')).toHaveTextContent('Calendar shown in your local time (PT).');
   });
 
+  test('Warns when a calendar’s own zone could not be read', () => {
+    // The actor carrying the zone may be one the caller has no access to. An unread zone
+    // is warned about like one known to differ, so the times are never quietly read as local.
+    render(<CalendarTimezoneNotice timezones={[]} anyUnknown viewerTimezone={PACIFIC} />);
+
+    expect(screen.getByTestId('calendar-timezone-notice')).toHaveTextContent('Calendar shown in your local time (PT).');
+  });
+
+  test('Warns when one calendar is on the viewer’s clock and another’s zone is unread', () => {
+    render(<CalendarTimezoneNotice timezones={[PACIFIC]} anyUnknown viewerTimezone={PACIFIC} />);
+
+    expect(screen.getByTestId('calendar-timezone-notice')).toHaveTextContent('Calendar shown in your local time (PT).');
+  });
+
   test('Warns for a zone that shares the viewer’s clock for part of the year', () => {
     // Arizona reads as Pacific all summer, but the notice still warns, so what it says does not
     // change under the reader twice a year.

--- a/packages/react-scheduling/src/SchedulingWorkspace/CalendarTimezoneNotice.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/CalendarTimezoneNotice.tsx
@@ -8,21 +8,24 @@ import { formatTimezoneLabel, isViewerTimezone } from '../AppointmentFinder/Appo
 export interface CalendarTimezoneNoticeProps {
   /** IANA timezones of the calendars on show whose timezone is known. Exclude any that are unknown. */
   readonly timezones: readonly string[];
+  /** Whether any calendar on show has a timezone that could not be read. */
+  readonly anyUnknown?: boolean;
   /** The viewer's own IANA timezone. Defaults to the browser's. */
   readonly viewerTimezone?: string;
   readonly className?: string;
 }
 
 /**
- * Warns when the calendar's contents are not all in the same timezone as the viewer's.
+ * Warns when the calendar's contents are not all known to be in the same timezone as the
+ * viewer's.
  * @param props - The React props.
  * @returns The notice, or nothing when every calendar is on the viewer's own clock.
  */
 export function CalendarTimezoneNotice(props: CalendarTimezoneNoticeProps): JSX.Element | null {
-  const { timezones, viewerTimezone, className } = props;
+  const { timezones, anyUnknown, viewerTimezone, className } = props;
 
   const elsewhere = timezones.some((timezone) => !isViewerTimezone(timezone, viewerTimezone));
-  if (!elsewhere) {
+  if (!elsewhere && !anyUnknown) {
     return null;
   }
 

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.tsx
@@ -7,7 +7,6 @@ import {
   isDefined,
   normalizeErrorString,
   SchedulingScheduleColorURI,
-  TimezoneExtensionURI,
 } from '@medplum/core';
 import type { Appointment, Slot } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
@@ -28,6 +27,7 @@ import type { DateTimeRange } from '../types';
 import type { CalendarsPanelItem } from './CalendarsPanel/CalendarsPanel';
 import { CalendarsPanel } from './CalendarsPanel/CalendarsPanel';
 import { CalendarTimezoneNotice } from './CalendarTimezoneNotice';
+import { getCalendarTimezones } from './SchedulingWorkspace.utils';
 import classes from './SchedulingWorkspace.module.css';
 
 type CandidatesByActorType = Readonly<Record<BookableActorType, ScheduleCandidate[]>>;
@@ -162,22 +162,7 @@ export function SchedulingWorkspace(props: SchedulingWorkspaceProps): JSX.Elemen
     });
   }, [activeCandidates, slots, appointments, colorByScheduleId]);
 
-  /*
-   * A calendar's zone is read off its actor alone. A Schedule can also carry a zone per
-   * service in its scheduling parameters, but nothing here names a service to pick between
-   * them, and while a Schedule holds a single actor the actor's own zone is the one those
-   * parameters are likely to agree with anyway.
-   */
-  const timezones = useMemo((): string[] => {
-    const zones: string[] = [];
-    for (const candidate of activeCandidates) {
-      const timezone = candidate.actorResource && getExtensionValue(candidate.actorResource, TimezoneExtensionURI);
-      if (typeof timezone === 'string') {
-        zones.push(timezone);
-      }
-    }
-    return zones;
-  }, [activeCandidates]);
+  const { timezones, anyUnknown } = useMemo(() => getCalendarTimezones(activeCandidates), [activeCandidates]);
 
   const startBooking = useCallback((interval: DateTimeRange): void => {
     setBookingSelection(interval);
@@ -243,7 +228,7 @@ export function SchedulingWorkspace(props: SchedulingWorkspaceProps): JSX.Elemen
           onSelectInterval={startBooking}
           selection={highlight}
         />
-        <CalendarTimezoneNotice className={classes.timezoneNotice} timezones={timezones} />
+        <CalendarTimezoneNotice className={classes.timezoneNotice} timezones={timezones} anyUnknown={anyUnknown} />
       </div>
       {bookingSelection && (
         <div className={cx(classes.bookingPane, { [classes.bookingPaneWide]: timeFinderOpen })}>

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.tsx
@@ -27,8 +27,8 @@ import type { DateTimeRange } from '../types';
 import type { CalendarsPanelItem } from './CalendarsPanel/CalendarsPanel';
 import { CalendarsPanel } from './CalendarsPanel/CalendarsPanel';
 import { CalendarTimezoneNotice } from './CalendarTimezoneNotice';
-import { getCalendarTimezones } from './SchedulingWorkspace.utils';
 import classes from './SchedulingWorkspace.module.css';
+import { getCalendarTimezones } from './SchedulingWorkspace.utils';
 
 type CandidatesByActorType = Readonly<Record<BookableActorType, ScheduleCandidate[]>>;
 type DeselectedIdsByActorType = Readonly<Record<BookableActorType, ReadonlySet<string>>>;

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.utils.test.ts
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.utils.test.ts
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { TimezoneExtensionURI } from '@medplum/core';
+import type { Practitioner, Schedule } from '@medplum/fhirtypes';
+import type { WithId } from '@medplum/core';
+import type { ScheduleCandidate } from '../AppointmentFinder/AppointmentFinder.schedules';
+import { getCalendarTimezones } from './SchedulingWorkspace.utils';
+
+const EASTERN = 'America/New_York';
+
+const SCHEDULE: WithId<Schedule> = {
+  resourceType: 'Schedule',
+  id: 'dr-rivera-schedule',
+  actor: [{ reference: 'Practitioner/dr-rivera' }],
+};
+
+function candidateOf(timezone?: string, read = true): ScheduleCandidate {
+  if (!read) {
+    return { schedule: SCHEDULE, actorResource: undefined };
+  }
+  const actorResource: WithId<Practitioner> = {
+    resourceType: 'Practitioner',
+    id: 'dr-rivera',
+    extension: timezone ? [{ url: TimezoneExtensionURI, valueCode: timezone }] : undefined,
+  };
+  return { schedule: SCHEDULE, actorResource };
+}
+
+describe('getCalendarTimezones', () => {
+  test('Reads the zone off each actor that named one', () => {
+    expect(getCalendarTimezones([candidateOf(EASTERN)])).toStrictEqual({ timezones: [EASTERN], anyUnknown: false });
+  });
+
+  test('Passes over an actor that was read and named no zone', () => {
+    // Rooms and devices routinely carry no zone of their own, so this is the ordinary
+    // case rather than something to warn about.
+    expect(getCalendarTimezones([candidateOf()])).toStrictEqual({ timezones: [], anyUnknown: false });
+  });
+
+  test('Reports an actor that could not be read as unknown', () => {
+    // An access policy may allow reading a Schedule but not its actor. The zone is
+    // written on the actor, so it cannot be told, and the caller has to say so.
+    expect(getCalendarTimezones([candidateOf(undefined, false)])).toStrictEqual({
+      timezones: [],
+      anyUnknown: true,
+    });
+  });
+
+  test('Keeps the zones it could read alongside the ones it could not', () => {
+    const candidates = [candidateOf(EASTERN), candidateOf(undefined, false)];
+
+    expect(getCalendarTimezones(candidates)).toStrictEqual({ timezones: [EASTERN], anyUnknown: true });
+  });
+
+  test('Reads nothing off no calendars', () => {
+    expect(getCalendarTimezones([])).toStrictEqual({ timezones: [], anyUnknown: false });
+  });
+});

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.utils.test.ts
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.utils.test.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
 import { TimezoneExtensionURI } from '@medplum/core';
 import type { Practitioner, Schedule } from '@medplum/fhirtypes';
-import type { WithId } from '@medplum/core';
 import type { ScheduleCandidate } from '../AppointmentFinder/AppointmentFinder.schedules';
 import { getCalendarTimezones } from './SchedulingWorkspace.utils';
 

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.utils.ts
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.utils.ts
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { getExtensionValue, TimezoneExtensionURI } from '@medplum/core';
+import type { ScheduleCandidate } from '../AppointmentFinder/AppointmentFinder.schedules';
+
+/** The zones the calendars on show are kept in, and whether any of them is unknown. */
+export interface CalendarTimezones {
+  /** One entry per calendar whose zone could be read. */
+  readonly timezones: string[];
+  /** Whether any calendar's actor could not be read, leaving its zone untold. */
+  readonly anyUnknown: boolean;
+}
+
+/**
+ * Reads the zones the calendars on show are drawn for.
+ *
+ * A calendar's zone is read off its actor alone. A Schedule can also carry a zone per
+ * service in its scheduling parameters, but nothing here names a service to pick between
+ * them, and while a Schedule holds a single actor the actor's own zone is the one those
+ * parameters are likely to agree with anyway.
+ *
+ * An actor that could not be read is reported as unknown rather than passed over. A
+ * caller may be entitled to read a Schedule without being entitled to read its actor,
+ * and the grid is drawn either way, so saying nothing would let times kept elsewhere be
+ * read as the viewer's own. An actor that was read and simply names no zone is not that
+ * case, and is passed over as before.
+ *
+ * @param candidates - The calendars on show.
+ * @returns The zones that could be read, and whether any could not.
+ */
+export function getCalendarTimezones(candidates: readonly ScheduleCandidate[]): CalendarTimezones {
+  const timezones: string[] = [];
+  let anyUnknown = false;
+
+  for (const candidate of candidates) {
+    if (!candidate.actorResource) {
+      anyUnknown = true;
+      continue;
+    }
+    const timezone = getExtensionValue(candidate.actorResource, TimezoneExtensionURI);
+    if (typeof timezone === 'string') {
+      timezones.push(timezone);
+    }
+  }
+
+  return { timezones, anyUnknown };
+}

--- a/packages/server/src/fhir/operations/book.test.ts
+++ b/packages/server/src/fhir/operations/book.test.ts
@@ -2404,4 +2404,94 @@ describe('scheduling flow integration test', () => {
     // set `meta.author` to the creating Patient, which could leak PHI.
     expect(otherPatientResponse.body.entry[0].resource.meta).not.toHaveProperty('author');
   });
+
+  test('booking a slot as a patient who cannot read Schedule.actor', async () => {
+    // The same minimal policy as above, less the read on Practitioner. `$book` validates
+    // the proposed appointment through the same scheduling parameters `$find` does, so it
+    // used to fail here too even though the Schedule names a timezone of its own.
+    const practitioner = await systemRepo.createResource<Practitioner>({
+      resourceType: 'Practitioner',
+      meta: { project: project.project.id },
+      extension: [{ url: 'http://hl7.org/fhir/StructureDefinition/timezone', valueCode: 'America/New_York' }],
+    });
+
+    const schedule = await systemRepo.createResource<Schedule>({
+      resourceType: 'Schedule',
+      meta: { project: project.project.id },
+      actor: [createReference(practitioner)],
+      serviceType: toServiceTypeCodeableConcepts(service),
+      extension: [
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+          extension: [
+            { url: 'service', valueReference: createReference(service) },
+            // Deliberately not the actor's zone, so the times below can only have come
+            // from the Schedule.
+            { url: 'timezone', valueCode: 'America/Phoenix' },
+            threeDayAvailability,
+            { url: 'duration', valueDuration: { value: 60, unit: 'min' } },
+          ],
+        },
+      ],
+    });
+
+    const { accessToken, profile } = await addTestUser(project.project, {
+      resourceType: 'Patient',
+      accessPolicy: {
+        resourceType: 'AccessPolicy',
+        resource: [
+          { resourceType: 'HealthcareService', interaction: ['read'] },
+          { resourceType: 'Schedule', interaction: ['read'] },
+          { resourceType: 'Patient', criteria: 'Patient?_compartment=%patient', interaction: ['read'] },
+          { resourceType: 'Slot', interaction: ['create', 'search'] },
+          { resourceType: 'Appointment', interaction: ['create'], criteria: 'Appointment?_compartment=%patient' },
+        ],
+      } satisfies AccessPolicy,
+    });
+
+    const start = '2026-01-28T16:00:00Z'; // 09:00 America/Phoenix (UTC-7)
+    const end = '2026-01-28T17:00:00Z'; // 10:00 America/Phoenix
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$book')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'appointment',
+            resource: {
+              resourceType: 'Appointment',
+              start,
+              end,
+              status: 'proposed',
+              serviceType: toServiceTypeCodeableConcepts(service),
+              participant: [
+                { actor: createReference(profile), status: 'accepted' },
+                { actor: createReference(practitioner), status: 'accepted' },
+              ],
+              contained: [
+                {
+                  resourceType: 'Slot',
+                  schedule: createReference(schedule),
+                  start,
+                  end,
+                  status: 'busy',
+                  serviceType: [officeVisitConcept],
+                } satisfies Slot,
+              ],
+            } satisfies Appointment,
+          },
+        ],
+      });
+
+    expect(response).toHaveStatus(201);
+
+    const entries = ((response.body as Bundle).entry ?? []).map((entry) => entry.resource).filter(isDefined);
+    const appointments = entries.filter(isAppointment);
+    expect(appointments).toHaveLength(1);
+    expect(appointments[0]).toHaveProperty('status', 'booked');
+    expect(appointments[0]).toHaveProperty('start', start);
+    expect(appointments[0]).toHaveProperty('end', end);
+  });
 });

--- a/packages/server/src/fhir/operations/find.test.ts
+++ b/packages/server/src/fhir/operations/find.test.ts
@@ -9,6 +9,7 @@ import {
   toServiceTypeCodeableConcepts,
 } from '@medplum/core';
 import type {
+  AccessPolicy,
   Appointment,
   Bundle,
   Extension,
@@ -24,7 +25,7 @@ import supertest from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
 import type { SystemRepository } from '../../fhir/repo';
-import { createTestProject } from '../../test.setup';
+import { addTestUser, createTestProject } from '../../test.setup';
 import type { SchedulingParametersExtensionExtension } from './utils/scheduling-parameters';
 
 const app = express();
@@ -260,7 +261,7 @@ describe('Appointment/$find', () => {
     });
   }
 
-  function makeRequest(params: Record<string, string | string[]>): ReturnType<typeof request.get> {
+  function makeRequest(params: Record<string, string | string[]>, token = accessToken): ReturnType<typeof request.get> {
     const qs = new URLSearchParams();
     for (const [key, val] of Object.entries(params)) {
       if (Array.isArray(val)) {
@@ -272,7 +273,7 @@ describe('Appointment/$find', () => {
       }
     }
 
-    return request.get('/fhir/R4/Appointment/$find').set('Authorization', `Bearer ${accessToken}`).query(qs.toString());
+    return request.get('/fhir/R4/Appointment/$find').set('Authorization', `Bearer ${token}`).query(qs.toString());
   }
 
   test('finds appointments that are available on all referenced schedules', async () => {
@@ -1604,5 +1605,76 @@ describe('Appointment/$find', () => {
     expect(response).toHaveStatus(200);
     expect(response.body).toHaveProperty('entry');
     expect(response.body.entry).toHaveLength(4);
+  });
+
+  describe('when the caller cannot read Schedule.actor', () => {
+    // Grants everything `$find` needs of its own and nothing else. Notably absent is read
+    // on the Practitioner, Location, or Device named by `Schedule.actor`, which an access
+    // policy may legitimately withhold while still allowing schedules to be listed.
+    const scheduleOnlyPolicy: AccessPolicy = {
+      resourceType: 'AccessPolicy',
+      resource: [
+        { resourceType: 'Schedule', interaction: ['read'] },
+        { resourceType: 'HealthcareService', interaction: ['read'] },
+        { resourceType: 'Slot', interaction: ['read', 'search'] },
+      ],
+    };
+
+    const range = {
+      start: new Date('2026-03-16T00:00:00Z').toISOString(),
+      end: new Date('2026-03-17T00:00:00Z').toISOString(),
+    };
+
+    function startsOf(response: { body: Bundle<Appointment> }): (string | undefined)[] {
+      return (response.body.entry ?? []).map((entry) => entry.resource?.start);
+    }
+
+    test('finds the same times as a caller who can, when the Schedule names a timezone', async () => {
+      // The actor's zone is the lowest-priority layer, so a Schedule naming one of its own
+      // never consults the actor. The read that used to fail the operation was discarded.
+      const schedule = await makeSchedule(
+        [{ service: genericVisit, duration: 60, timezone: 'America/Phoenix', availability: monTueAvailability }],
+        { actor: [createReference(practitioner)] }
+      );
+      const { accessToken: restrictedToken } = await addTestUser(project, { accessPolicy: scheduleOnlyPolicy });
+
+      const params = {
+        ...range,
+        'service-type-reference': `HealthcareService/${genericVisit.id}`,
+        schedule: `Schedule/${schedule.id}`,
+      };
+      const asProjectAdmin = await makeRequest(params);
+      const asRestricted = await makeRequest(params, restrictedToken);
+
+      expect(asProjectAdmin).toHaveStatus(200);
+      expect(asRestricted).toHaveStatus(200);
+      expect(startsOf(asProjectAdmin).length).toBeGreaterThan(0);
+      expect(startsOf(asRestricted)).toEqual(startsOf(asProjectAdmin));
+    });
+
+    test('errors when no timezone is named higher up', async () => {
+      // `officeVisit` names no timezone and neither does this schedule, so the actor's own
+      // zone is the only one there is. It reads for the project admin and not for this
+      // caller, and the message says which of the two happened.
+      const schedule = await makeSchedule([{ service: officeVisit, duration: 60, availability: monTueAvailability }], {
+        actor: [createReference(practitioner)],
+      });
+      const { accessToken: restrictedToken } = await addTestUser(project, { accessPolicy: scheduleOnlyPolicy });
+
+      const params = {
+        ...range,
+        'service-type-reference': `HealthcareService/${officeVisit.id}`,
+        schedule: `Schedule/${schedule.id}`,
+      };
+
+      expect(await makeRequest(params)).toHaveStatus(200);
+
+      const asRestricted = await makeRequest(params, restrictedToken);
+      expect(asRestricted).toHaveStatus(400);
+      expect(asRestricted.body).toMatchObject({
+        resourceType: 'OperationOutcome',
+        issue: [{ details: { text: 'No timezone specified and schedule.actor could not be read' } }],
+      });
+    });
   });
 });

--- a/packages/server/src/fhir/operations/utils/scheduling.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.ts
@@ -506,17 +506,17 @@ export async function getSchedulingParametersGroup(
   const actors = await repo
     .readReferences(schedules.map((schedule) => schedule.actor[0]))
     .then((actors) => copyPaths(schedules, actors, { suffix: '.actor[0]' }));
-  assertAllLoaded(actors, 'Loading schedule.actor failed');
 
   const serviceParams = getHealthcareServiceSchedulingParameters(healthcareService);
 
   return new Map<WithPath<WithId<Schedule>>, LayeredDict<SchedulingParameters & { timezone: string }>>(
     schedules.map((schedule, idx) => {
       const actor = actors[idx];
+      const actorLoaded = isResource(actor);
 
       let parameters = getScheduleSchedulingParameters(schedule, healthcareService, serviceParams);
 
-      const timezone = getTimeZone(actor);
+      const timezone = actorLoaded ? getTimeZone(actor) : undefined;
       if (timezone) {
         // Tricky: `timezone` is defined to prefer scheduling-parameter
         // definitions coming from HealthcareService or Schedule extensions
@@ -529,7 +529,12 @@ export async function getSchedulingParametersGroup(
         schedule,
         parameters.refine((p): asserts p is SchedulingParameters & { timezone: string } => {
           if (p.timezone === undefined) {
-            throw new OperationOutcomeError(badRequest('No timezone specified', getPath(actor)));
+            throw new OperationOutcomeError(
+              badRequest(
+                actorLoaded ? 'No timezone specified' : 'No timezone specified and schedule.actor could not be read',
+                getPath(actor)
+              )
+            );
           }
         }),
       ];


### PR DESCRIPTION
## Don't throw a 400 if an actor's resource can't be loaded when we don't need it 
A user's access policy might prevent them from viewing an actor resource (`Practitioner`, `Device`, or `Location`) associated with a schedule. If that user calls `$find`, then a 400 will be thrown. 

We don't really need to be this strict; the server only loads the actor's resource to grab its timezone, which itself is a fallback behind the service and schedule. If a timezone is defined elsewhere, then we'd be throwing a 400 for not being able to obtain a resource that doesn't actually need to be read. 

This PR updates our server logic to only throw an error if the actor's resource can't be read _and_ there is not a timezone that we're able to obtain. 

## Show timezone notice when we don't know an actor's timezone 

Right now we show this notice under the calendar when the user views a schedule in a different timezone: 

<img width="278" height="118" alt="image" src="https://github.com/user-attachments/assets/4f701953-3da1-4f81-901f-13345ac4d875" />

If we're unable to read an actor's timezone, then we should show this. Better to have a false positive than a false negative. 

## Trim booking field helptext 

We have some unnecessarily verbose help text under certain fields (thanks Claude). Especially apparent when looking at this in a customer's sandbox with realistic resource data. This trims it up a bit to reduce visual clutter. Specifically: 
1. Under **Visit type**: "Showing visit types offered at {location}, plus those not tied to a site." 
2. Under **Room** and **Device**: "Optional. Leave empty to search without holding a room/device." 
3. Under the **calendar**: "August 17 – August 21 · drag or shift-click to search more days." 