### PR TITLE
Document Health Gorilla lab ordering iframe bot

### DIFF
--- a/packages/docs/docs/integration/health-gorilla/iframe.md
+++ b/packages/docs/docs/integration/health-gorilla/iframe.md
@@ -1,0 +1,102 @@
+---
+sidebar_position: 4
+---
+
+# Lab Ordering iFrame
+
+The `health-gorilla-iframe` bot lets your application launch Health Gorilla's hosted lab ordering interface for a Medplum patient. It returns an authenticated URL that you embed in an `<iframe>`; the bot itself does not render a user interface.
+
+Use this flow to let clinicians order through Health Gorilla's interface. To build your own ordering interface, see [Creating an Order Form in React](./sending-orders.md#creating-an-order-form-in-react).
+
+Health Gorilla's [Lab Network iFrame](https://developer.healthgorilla.com/docs/lab-network-iframe) supports order placement for a single patient and a single order. Results are handled separately through the [results integration](./receiving-results.md).
+
+## Prerequisites
+
+- A configured Health Gorilla labs integration, including an enabled Lab Network tenant, laboratory connections, and OAuth credentials with ordering scopes. [Contact the Medplum team](mailto:info+healthgorilla@medplum.com?subject=Health%20Gorilla%20Integration%20for%20Medplum) to enable the iframe bot and its operation for your project.
+- An existing Medplum `Patient` with `name[0].given`, `name[0].family`, `gender`, and a full `birthDate` in `YYYY-MM-DD` format. Partial birth dates are rejected.
+- A callback page in your application that Health Gorilla can return the user to after the order is completed or cancelled.
+
+The bot uses the existing Health Gorilla OAuth configuration and access token. No additional iframe-specific SSO secrets are required.
+
+## Request and response
+
+The bot accepts a JSON object with two required string fields:
+
+- `patientId`: The Medplum patient ID, without the `Patient/` prefix. This is not a Health Gorilla patient ID.
+- `callbackUrl`: The URL of your application's return page. Health Gorilla requires this value to create the ordering session.
+
+```json
+{
+  "patientId": "example-patient",
+  "callbackUrl": "https://app.example.com/labs/callback"
+}
+```
+
+The response is a JSON object containing `url`, the authenticated ordering URL. Use it as returned; the bot has already appended the Health Gorilla access token.
+
+### Invoke the operation
+
+Call the type-level `Patient/$health-gorilla-iframe` operation with the patient ID in the JSON body:
+
+```bash
+curl -X POST 'https://api.medplum.com/fhir/R4/Patient/$health-gorilla-iframe' \
+  -H 'Authorization: Bearer {medplum-access-token}' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "patientId": "example-patient",
+    "callbackUrl": "https://app.example.com/labs/callback"
+  }'
+```
+
+The request body is a plain JSON object, not a FHIR `Parameters` resource. The operation is registered on the `Patient` resource type; do not put the patient ID in the operation URL.
+
+### Execute the bot with the Medplum SDK
+
+You can also call the bot by its integration identifier using an authenticated `MedplumClient`:
+
+```typescript
+const { url }: { url: string } = await medplum.executeBot(
+  {
+    system: 'https://www.medplum.com/integrations/bot-identifier',
+    value: 'health-gorilla-labs/health-gorilla-iframe',
+  },
+  {
+    patientId: patient.id,
+    callbackUrl: new URL('/labs/callback', window.location.origin).toString(),
+  },
+  'application/json'
+);
+```
+
+After the request succeeds, render the returned URL in your application. For example, in React:
+
+```tsx
+<iframe title="Health Gorilla lab ordering" src={url} width="100%" height="800" />
+```
+
+Request a new ordering session when the user starts a new order or switches patients. Show a loading state while the bot runs and handle failures before rendering the iframe.
+
+:::caution[Authenticated URL]
+The returned URL contains a Health Gorilla OAuth access token. Keep it in memory for the ordering flow; do not log it, persist it in FHIR resources, or include it in analytics events.
+:::
+
+## Patient context
+
+The bot reads the patient from Medplum and sends the first name entry's given names and family name, gender, and birth date to Health Gorilla. It uses demographics for matching even when the Medplum patient already has a Health Gorilla identifier. Health Gorilla may create a new patient if those demographics do not match an existing record.
+
+The bot does not require a Health Gorilla patient identifier and does not write one back to Medplum. Launching an iframe therefore does not establish the identifier mapping needed for downstream result matching. Validate patient and order matching as part of your integration setup; see [Resolving Orders with Results](./receiving-results.md#resolving-orders-with-results).
+
+The bot passes `Patient.gender` through unchanged. Confirm Health Gorilla's handling of `other` and `unknown` with your integration contact before using those values in this flow.
+
+## Returning to your application and receiving results
+
+The `callbackUrl` is a browser return destination after the user completes or cancels ordering. It is separate from the webhook endpoint used by `receive-from-health-gorilla`. Reaching this page alone is not confirmation that an order was submitted.
+
+The iframe bot creates the ordering session and returns its URL. It does not create a Medplum `ServiceRequest`, download requisitions, or retrieve results. Keep the Health Gorilla webhook subscriptions configured through `setup-subscriptions`, and use [Receiving Results](./receiving-results.md) for structured results and PDFs. Use [Sync Resources from Health Gorilla](./sync-resources-from-health-gorilla.md) to recover missed results.
+
+## Troubleshooting
+
+- **`Missing patientId` or `Missing callbackUrl`**: Include both fields in the JSON request body.
+- **Patient is missing required fields**: Populate the first name entry's given and family names, gender, and full birth date before launching the session.
+- **Session creation fails**: Verify the existing Health Gorilla OAuth configuration, ordering scopes, and Lab Network setup. The bot surfaces HTTP and Health Gorilla session errors to the caller.
+- **Results do not match the expected patient or order**: Check the [result matching rules](./receiving-results.md#resolving-orders-with-results) and review `DetectedIssue` resources. The iframe launch does not sync patient identifiers or create a corresponding Medplum order.

--- a/packages/docs/docs/integration/health-gorilla/iframe.md
+++ b/packages/docs/docs/integration/health-gorilla/iframe.md
@@ -4,9 +4,11 @@ sidebar_position: 4
 
 # Lab Ordering iFrame
 
-The `health-gorilla-iframe` bot lets your application launch Health Gorilla's hosted lab ordering interface for a Medplum patient. It returns an authenticated URL that you embed in an `<iframe>`; the bot itself does not render a user interface.
+:::info[Choose one ordering interface]
+The iframe is an **optional alternative** to Medplum's [React order form components and `useHealthGorillaLabOrder` hook](./sending-orders.md#creating-an-order-form-in-react). Use either the hosted iframe or the Medplum form components and hook for your ordering workflow. You do not need both, and the iframe is not required for the Health Gorilla integration.
+:::
 
-Use this flow to let clinicians order through Health Gorilla's interface. To build your own ordering interface, see [Creating an Order Form in React](./sending-orders.md#creating-an-order-form-in-react).
+The `health-gorilla-iframe` bot lets your application launch Health Gorilla's hosted lab ordering interface for a Medplum patient. It returns an authenticated URL that you embed in an `<iframe>`; the bot itself does not render a user interface.
 
 Health Gorilla's [Lab Network iFrame](https://developer.healthgorilla.com/docs/lab-network-iframe) supports order placement for a single patient and a single order. Results are handled separately through the [results integration](./receiving-results.md).
 

--- a/packages/docs/docs/integration/health-gorilla/index.md
+++ b/packages/docs/docs/integration/health-gorilla/index.md
@@ -13,7 +13,7 @@ Need help? This is an advanced integration. [Contact our team](mailto:info+healt
 
 This guide provides an overview of Medplum's Health Gorilla labs integration and a list of recommendations for systemizing lab ordering.
 
-To embed Health Gorilla's hosted ordering interface in your application, use the [`health-gorilla-iframe` bot](./iframe.md). It returns an authenticated ordering URL for a Medplum patient. Results continue to arrive through the API integration.
+Choose one ordering interface for your workflow: build a form with Medplum's [React components and `useHealthGorillaLabOrder` hook](./sending-orders.md#creating-an-order-form-in-react), or embed Health Gorilla's hosted interface using the [`health-gorilla-iframe` bot](./iframe.md). The iframe is optional; you do not need both approaches. Results arrive through the API integration with either approach.
 
 For more information about the FHIR resources involved in the integration, see [Sending Orders](/docs/integration/health-gorilla/sending-orders) and [Receiving Results](/docs/integration/health-gorilla/receiving-results). To backfill or recover results that were not delivered by webhook, see [Sync Resources from Health Gorilla](/docs/integration/health-gorilla/sync-resources-from-health-gorilla). See our [Changelog](/docs/integration/health-gorilla/hg-changelog) for information about integration upgrades.
 

--- a/packages/docs/docs/integration/health-gorilla/index.md
+++ b/packages/docs/docs/integration/health-gorilla/index.md
@@ -13,6 +13,8 @@ Need help? This is an advanced integration. [Contact our team](mailto:info+healt
 
 This guide provides an overview of Medplum's Health Gorilla labs integration and a list of recommendations for systemizing lab ordering.
 
+To embed Health Gorilla's hosted ordering interface in your application, use the [`health-gorilla-iframe` bot](./iframe.md). It returns an authenticated ordering URL for a Medplum patient. Results continue to arrive through the API integration.
+
 For more information about the FHIR resources involved in the integration, see [Sending Orders](/docs/integration/health-gorilla/sending-orders) and [Receiving Results](/docs/integration/health-gorilla/receiving-results). To backfill or recover results that were not delivered by webhook, see [Sync Resources from Health Gorilla](/docs/integration/health-gorilla/sync-resources-from-health-gorilla). See our [Changelog](/docs/integration/health-gorilla/hg-changelog) for information about integration upgrades.
 
 ## Prerequisites
@@ -138,6 +140,8 @@ To avoid this and ensure results are properly matched to the correct patient:
 By doing this, the `receive-from-health-gorilla` bot will successfully match the incoming result's Placer/Accession number to the placeholder order, automatically linking the result to the correct patient and avoiding unsolicited reports.
 
 #### 3. Ordering from Medplum
+
+You can embed Health Gorilla's hosted ordering interface using the [Lab Ordering iFrame](./iframe.md) bot, or build a custom order form with Medplum's React components.
 
 In the final phase, you transition to placing lab orders directly from your Medplum application. To accelerate the development of the ordering interface, you can use the [`useHealthGorillaLabOrder` hook](./sending-orders.md#creating-an-order-form-in-react) from the `@medplum/health-gorilla-react` package. This headless UI hook helps manage the complex state required for creating an order, including searching and selecting lab tests, answering Ask on Entry (AOE) questions, and completing the order workflow.
 

--- a/packages/docs/docs/integration/health-gorilla/receiving-results.md
+++ b/packages/docs/docs/integration/health-gorilla/receiving-results.md
@@ -8,6 +8,8 @@ This guide explains how laboratory results are handled in the Medplum-Health Gor
 
 When Health Gorilla receives results from performing laboratories (Quest, Labcorp, regional labs, etc.), they are synchronized into your Medplum project as structured FHIR resources. The sections below describe the resulting data model and how results are matched to orders and patients.
 
+Orders placed through the [Lab Ordering iFrame](./iframe.md) also require this results integration. The iframe is for ordering only, and its browser callback does not deliver results. The iframe bot does not create Medplum orders or sync patient identifiers, so verify [order and patient matching](#resolving-orders-with-results) when setting up this flow.
+
 ## How results arrive in Medplum 
 
 There are two ways results and related resources get into your project:

--- a/packages/docs/docs/integration/health-gorilla/sending-orders.md
+++ b/packages/docs/docs/integration/health-gorilla/sending-orders.md
@@ -10,7 +10,9 @@ For a vendor-neutral overview of diagnostic ordering concepts and the FHIR data 
 
 This guide explains how laboratory orders work in the Medplum-Health Gorilla labs integration.
 
-The high-level workflow for sending laboratory & imaging orders is:
+To embed Health Gorilla's hosted ordering interface, see [Lab Ordering iFrame](./iframe.md). The `health-gorilla-iframe` bot returns a patient-specific ordering URL. The custom ordering workflow below uses Medplum FHIR resources and `send-to-health-gorilla` to submit orders.
+
+The high-level workflow for sending laboratory & imaging orders from a custom order form is:
 
 1. Present the provider with the appropriate lab order form (CPOE)
 2. Create the appropriate FHIR resources based on that information

--- a/packages/docs/docs/integration/health-gorilla/sending-orders.md
+++ b/packages/docs/docs/integration/health-gorilla/sending-orders.md
@@ -10,7 +10,7 @@ For a vendor-neutral overview of diagnostic ordering concepts and the FHIR data 
 
 This guide explains how laboratory orders work in the Medplum-Health Gorilla labs integration.
 
-To embed Health Gorilla's hosted ordering interface, see [Lab Ordering iFrame](./iframe.md). The `health-gorilla-iframe` bot returns a patient-specific ordering URL. The custom ordering workflow below uses Medplum FHIR resources and `send-to-health-gorilla` to submit orders.
+This guide covers building an order form with Medplum's React components and `useHealthGorillaLabOrder` hook, using Medplum FHIR resources and `send-to-health-gorilla` to submit orders. The [Lab Ordering iFrame](./iframe.md) is an optional alternative that embeds Health Gorilla's hosted interface. Choose either approach for your ordering workflow; the form components and hook do not require the iframe bot.
 
 The high-level workflow for sending laboratory & imaging orders from a custom order form is:
 


### PR DESCRIPTION
The public Health Gorilla docs describe custom API ordering but do not explain how to launch the hosted lab ordering interface. Add an iframe guide with prerequisites, the type-level operation and SDK examples, callback behavior, and troubleshooting, and link it from the overview, ordering, and results pages.

Clarify that the bot matches patients using demographics and returns an authenticated URL; it does not sync patient identifiers or create Medplum orders. Explain the separate results integration and token handling. Behavior was checked against the iframe bot, tests, and deployment configuration on Medplum EE main, and Health Gorilla's Lab Network iframe documentation.

Validation:
- Full Docusaurus build with link and anchor checks passed (`docusaurus build --no-minify`); warnings were confined to unrelated pages.
- SDK and React examples passed standalone TypeScript checks; the JSON example parsed successfully.
- Prettier check for the new guide and `git diff --check` passed.
- The repository-wide docs typecheck is blocked by the existing TypeScript `baseUrl` deprecation; suppressing that deprecation exposes existing theme/component errors outside these Markdown changes.
