### PR TITLE
fix(core): preserve FHIR lexer columns after newlines

### DIFF
--- a/packages/core/src/fhirlexer/tokenize.ts
+++ b/packages/core/src/fhirlexer/tokenize.ts
@@ -378,8 +378,9 @@ export class Tokenizer {
   }
 
   private advance(): void {
+    const char = this.curr();
     this.pos.index++;
-    if (this.curr() === '\n') {
+    if (char === '\n') {
       this.pos.line++;
       this.pos.column = 0;
     } else {

--- a/packages/core/src/fhirpath/tokenize.test.ts
+++ b/packages/core/src/fhirpath/tokenize.test.ts
@@ -83,6 +83,14 @@ describe('Tokenizer', () => {
     expect(tokenize('')).toStrictEqual([]);
   });
 
+  test('Tracks the position of tokens after a newline', () => {
+    expect(tokenize('Patient\n  .name')).toMatchObject([
+      { id: 'Symbol', value: 'Patient', line: 1, column: 0 },
+      { id: '.', value: '.', line: 2, column: 2 },
+      { id: 'Symbol', value: 'name', line: 2, column: 3 },
+    ]);
+  });
+
   describe('String escapes', () => {
     test('String escape sequence', () => {
       expect(tokenize("'\\\\\\/\\f\\r\\n\\t\\\"\\`\\'\\u002a'")).toMatchObject([


### PR DESCRIPTION
Fixes lexer position accounting used by FHIRPath and related parsers. advance() was testing the next character instead of the consumed character, which shifted the column for a token after a newline. Includes a multi-line regression test.

## Validation
- `node_modules/.bin/vitest run packages/core/src/fhirpath/tokenize.test.ts`: 36 passed
- `node_modules/.bin/eslint packages/core/src/fhirlexer/tokenize.ts packages/core/src/fhirpath/tokenize.test.ts`: passed
- `git diff --check`: passed