### PR TITLE
fix(core): reject unterminated FHIRPath literals

### DIFF
--- a/packages/core/src/fhirlexer/tokenize.ts
+++ b/packages/core/src/fhirlexer/tokenize.ts
@@ -149,6 +149,9 @@ export class Tokenizer {
   private consumeMultiLineComment(): Token {
     const start = this.pos.index;
     this.consumeWhile(() => this.curr() !== '*' || this.peek() !== '/');
+    if (!this.curr()) {
+      throw new Error('Unterminated multi-line comment');
+    }
     this.advance();
     this.advance();
     return this.buildToken('Comment', this.str.substring(start, this.pos.index));
@@ -167,6 +170,9 @@ export class Tokenizer {
     let char: string;
     while ((char = this.consumeChar(endChar))) {
       str += char;
+    }
+    if (!this.curr()) {
+      throw new Error('Unterminated string literal');
     }
     const result = this.buildToken(endChar === '`' ? 'Symbol' : 'String', str);
     this.advance();

--- a/packages/core/src/fhirpath/tokenize.test.ts
+++ b/packages/core/src/fhirpath/tokenize.test.ts
@@ -32,6 +32,13 @@ describe('Tokenizer', () => {
     ]);
   });
 
+  test.each([
+    ['string literal', "'unterminated"],
+    ['block comment', '/* unterminated'],
+  ])('Rejects an unterminated %s', (_name, input) => {
+    expect(() => tokenize(input)).toThrow('Unterminated');
+  });
+
   test('Simple string matching', () => {
     const matches = tokenize('  (  + ) /   ( *  ');
     expect(matches).toMatchObject([


### PR DESCRIPTION
Reject unterminated quoted strings and block comments in the shared FHIR lexer, with regression coverage for both malformed inputs.

## Validation
- `node_modules/.bin/vitest run packages/core/src/fhirpath/tokenize.test.ts`: 37 passed
- `node_modules/.bin/eslint packages/core/src/fhirlexer/tokenize.ts packages/core/src/fhirpath/tokenize.test.ts`: passed
- `git diff --check`: passed