### PR TITLE
fix(core): match versioned HealthcareService references in schedules

### DIFF
--- a/packages/core/src/scheduling.test.ts
+++ b/packages/core/src/scheduling.test.ts
@@ -262,6 +262,7 @@ describe('serviceType CodeableConcepts', () => {
     const serviceType = toServiceTypeCodeableConcepts(service);
 
     expect(serviceTypeIncludesService(serviceType, createReference(service))).toBe(true);
+    expect(serviceTypeIncludesService(serviceType, { reference: 'HealthcareService/service-1/_history/2' })).toBe(true);
     expect(serviceTypeIncludesService(serviceType, { reference: 'HealthcareService/service-2' })).toBe(false);
   });
 

--- a/packages/core/src/scheduling.ts
+++ b/packages/core/src/scheduling.ts
@@ -80,8 +80,12 @@ function isServiceReference(reference: Reference | undefined, serviceReference: 
   if (!reference?.reference) {
     return false;
   }
-  const [resourceType, id] = reference.reference.split('/');
-  return `${resourceType}/${id}` === serviceReference;
+  return getUnversionedServiceReference(reference.reference) === getUnversionedServiceReference(serviceReference);
+}
+
+function getUnversionedServiceReference(reference: string): string {
+  const [resourceType, id] = reference.split('/');
+  return resourceType && id ? `${resourceType}/${id}` : reference;
 }
 
 function matchesServiceSchedulingParameters(extension: Extension, serviceReference: string): boolean {
@@ -262,7 +266,7 @@ export function serviceTypeIncludesService(
   return serviceType.some((concept) => {
     const serviceReference = getExtensionValue(concept, ServiceTypeReferenceURI) as
       Reference<HealthcareService> | undefined;
-    return serviceReference?.reference === reference;
+    return isServiceReference(serviceReference, reference);
   });
 }
 


### PR DESCRIPTION
Normalize a FHIR reference version suffix when matching HealthcareService references embedded in Schedule serviceType concepts. The regression test keeps the unrelated-service check.

## Validation
- `node_modules/.bin/vitest run packages/core/src/scheduling.test.ts`: 18 passed
- `node_modules/.bin/eslint packages/core/src/scheduling.ts packages/core/src/scheduling.test.ts`: passed
- `git diff --check`: passed