### PR TITLE
fix(react): honor FHIR regex and entryFormat on questionnaire strings

### DIFF
--- a/examples/medplum-provider/src/pages/patient/IntakeFormPage.tsx
+++ b/examples/medplum-provider/src/pages/patient/IntakeFormPage.tsx
@@ -143,6 +143,17 @@ function extractValueSets(items: QuestionnaireItem[] | undefined, result: ValueS
   return result;
 }
 
+const phoneItemExtensions = [
+  {
+    url: 'http://hl7.org/fhir/StructureDefinition/regex',
+    valueString: '^\\+?[0-9\\(\\)\\-.\\s]{7,20}$',
+  },
+  {
+    url: 'http://hl7.org/fhir/StructureDefinition/entryFormat',
+    valueString: '(xxx) xxx-xxxx',
+  },
+];
+
 const defaultQuestionnaire: Questionnaire = {
   resourceType: 'Questionnaire',
   status: 'active',
@@ -202,6 +213,7 @@ const defaultQuestionnaire: Questionnaire = {
           linkId: 'phone',
           text: 'Phone',
           type: 'string',
+          extension: phoneItemExtensions,
         },
         {
           linkId: 'ssn',
@@ -261,6 +273,7 @@ const defaultQuestionnaire: Questionnaire = {
           linkId: 'emergency-contact-phone',
           text: 'Phone',
           type: 'string',
+          extension: phoneItemExtensions,
         },
       ],
     },

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -3363,4 +3363,84 @@ describe('QuestionnaireForm', () => {
       expect(onSubmit).not.toHaveBeenCalled();
     });
   });
+
+  describe('regex and entryFormat extensions', () => {
+    const phoneQuestionnaire: Questionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'active',
+      item: [
+        {
+          linkId: 'phone',
+          text: 'Phone',
+          type: QuestionnaireItemType.string,
+          extension: [
+            {
+              url: 'http://hl7.org/fhir/StructureDefinition/regex',
+              valueString: '^\\+?[0-9\\(\\)\\-.\\s]{7,20}$',
+            },
+            {
+              url: 'http://hl7.org/fhir/StructureDefinition/entryFormat',
+              valueString: '(xxx) xxx-xxxx',
+            },
+          ],
+        },
+      ],
+    };
+
+    test('Applies regex as a pattern attribute and entryFormat as a placeholder', async () => {
+      await setup({ questionnaire: phoneQuestionnaire, onSubmit: vi.fn() });
+
+      const input = screen.getByLabelText<HTMLInputElement>('Phone');
+      expect(input.pattern).toBe('^\\+?[0-9\\(\\)\\-.\\s]{7,20}$');
+      expect(input.placeholder).toBe('(xxx) xxx-xxxx');
+    });
+
+    test('Rejects a phone number containing letters', async () => {
+      const onSubmit = vi.fn();
+      await setup({ questionnaire: phoneQuestionnaire, onSubmit });
+
+      const input = screen.getByLabelText<HTMLInputElement>('Phone');
+      await act(async () => {
+        fireEvent.change(input, { target: { value: '123-A45-019D' } });
+      });
+
+      expect(input.validity.patternMismatch).toBe(true);
+      expect(input.checkValidity()).toBe(false);
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('Submit'));
+      });
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    test('Accepts a well-formed phone number', async () => {
+      const onSubmit = vi.fn();
+      await setup({ questionnaire: phoneQuestionnaire, onSubmit });
+
+      const input = screen.getByLabelText<HTMLInputElement>('Phone');
+      expect(input.pattern).toBe('^\\+?[0-9\\(\\)\\-.\\s]{7,20}$');
+
+      await act(async () => {
+        fireEvent.change(input, { target: { value: '(123) 445-0199' } });
+      });
+
+      expect(input.validity.patternMismatch).toBe(false);
+      expect(input.checkValidity()).toBe(true);
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('Submit'));
+      });
+      expect(onSubmit).toHaveBeenCalled();
+    });
+
+    test('Allows an empty optional phone field', async () => {
+      const onSubmit = vi.fn();
+      await setup({ questionnaire: phoneQuestionnaire, onSubmit });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('Submit'));
+      });
+      expect(onSubmit).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem.tsx
@@ -49,6 +49,9 @@ import { ValueSetAutocomplete } from '../ValueSetAutocomplete/ValueSetAutocomple
 const MAX_DISPLAYED_CHECKBOX_RADIO_VALUE_SET_OPTIONS = 30;
 const MAX_DISPLAYED_CHECKBOX_RADIO_EXPLICITOPTION_OPTIONS = 50;
 
+const REGEX_EXTENSION_URL = `${HTTP_HL7_ORG}/fhir/StructureDefinition/regex`;
+const ENTRY_FORMAT_EXTENSION_URL = `${HTTP_HL7_ORG}/fhir/StructureDefinition/entryFormat`;
+
 export interface QuestionnaireFormItemProps {
   readonly formState?: QuestionnaireFormLoadedState;
   readonly context?: QuestionnaireResponseItem[];
@@ -208,13 +211,18 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
       );
       break;
     case QuestionnaireItemType.string:
-    case QuestionnaireItemType.url:
+    case QuestionnaireItemType.url: {
+      const pattern = getExtension(item, REGEX_EXTENSION_URL)?.valueString;
+      const entryFormat = getExtension(item, ENTRY_FORMAT_EXTENSION_URL)?.valueString;
       formComponent = (
         <TextInput
           id={inputId}
           name={name}
           required={props.required ?? item.required}
           defaultValue={defaultValue?.value}
+          pattern={pattern}
+          placeholder={entryFormat}
+          title={entryFormat ? `Format: ${entryFormat}` : undefined}
           onChange={(e) => {
             const value = e.currentTarget.value;
             onChangeAnswer(value === '' ? [] : [{ valueString: value }]);
@@ -222,6 +230,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
         />
       );
       break;
+    }
     case QuestionnaireItemType.text:
       formComponent = (
         <Textarea


### PR DESCRIPTION
Fixes #8828

Related: #10232 (same approach, blocked on DCO)

### Summary

`QuestionnaireFormItem` maps FHIR `regex` / `entryFormat` extensions to native `pattern` / `placeholder` / `title` on string and url inputs, so constraint validation blocks submit. The form already uses that mechanism for `required`.

The provider New Patient intake form (`/onboarding`) stored phone values like `123-A45-019D` because Phone is a FHIR `string` item and those extensions were ignored. The default intake questionnaire applies a permissive phone pattern (optional `+`, then 7-20 digits or `()-. `) and a `(xxx) xxx-xxxx` entry format on Phone and Emergency Contact Phone, sharing one `phoneItemExtensions` array so the two items cannot drift.

### What I chose and the alternative

Wiring the extensions on `QuestionnaireFormItem` means other questionnaires can declare the same constraint. A provider-only hardcoded phone check (or `type="tel"`, which does not reject letters) would fix only New Patient. A stricter option is the 10-digit `isValidBillingPhone` rule already used in billing settings.

@maddyli on #8828: "This seems like an excellent approach, love the use of the FHIR extensions for QuestionnaireFormItem."

Happy to switch to a provider-only check, or to the stricter billing phone rule.

### Test plan

- [x] `packages/react` `QuestionnaireForm.test.tsx`: pattern/placeholder applied; `123-A45-019D` is `patternMismatch` and does not submit; `(123) 445-0199` submits; empty optional phone still submits
- [x] Same file + `AIRealTimeQuestionnaireForm.test.tsx`: 91/91 passed
- [ ] Manual: Provider app → New Patient → required fields + phone `123-A45-019D` → Submit blocked with a format tooltip
- [ ] Manual: same form with `(555) 555-5555` (or `555-5555`) creates the patient
- [ ] Manual: leave Phone blank; submit still succeeds (field is optional)
- [ ] Manual: Emergency Contact Phone with letters is blocked the same way
