### PR TITLE
fix(server): resolve custom operations by resource type, not code alone

### DIFF
--- a/packages/docs/docs/bots/custom-fhir-operations.md
+++ b/packages/docs/docs/bots/custom-fhir-operations.md
@@ -94,8 +94,9 @@ Create an `OperationDefinition` that describes your operation and links to your 
   "status": "active",
   "kind": "operation",
   "code": "my-custom-operation",
-  "system": true,
-  "type": false,
+  "resource": ["Patient"],
+  "system": false,
+  "type": true,
   "instance": false,
   "parameter": [
     {
@@ -121,6 +122,7 @@ Create an `OperationDefinition` that describes your operation and links to your 
 - Must include the `operationDefinition-implementation` extension
 - Extension must reference a Bot resource
 - Define appropriate input/output parameters
+- Set `resource` and the `system`, `type`, and `instance` flags to match how the operation is invoked (see [Operation Types](#operation-types))
 
 ### Step 4: Invoke Your Custom Operation
 
@@ -149,7 +151,11 @@ Custom operations support all standard FHIR operation types:
 - **Type-level operations**: `/fhir/R4/Patient/$my-operation`
 - **Instance-level operations**: `/fhir/R4/Patient/123/$my-operation`
 
-Configure the operation type using the `system`, `type`, and `instance` properties in your `OperationDefinition`.
+Configure the operation type using the `system`, `type`, and `instance` properties in your `OperationDefinition`, and list the resource types a type-level or instance-level operation applies to in `resource`.
+
+### Operation Codes
+
+Medplum resolves a request such as `POST /fhir/R4/HealthcareService/$lookup` by searching for `OperationDefinition` resources with the code `lookup`. The `OperationDefinition` resources from the FHIR specification (for example `CodeSystem/$lookup`) are visible in every project, so your custom operation may share its code with a specification operation, or with another custom operation on a different resource type. When several definitions share a code, Medplum only considers definitions that link to a Bot, and picks the one whose `resource` and level flags match the request. If two definitions match equally well, a definition in your own project takes precedence over one shared from another project.
 
 ## Input and Output Handling
 

--- a/packages/server/src/fhir/operations/custom.test.ts
+++ b/packages/server/src/fhir/operations/custom.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
 import { badRequest, ContentType, createReference } from '@medplum/core';
-import type { Bot, Patient } from '@medplum/fhirtypes';
+import type { Bot, BundleEntry, OperationDefinition, Patient } from '@medplum/fhirtypes';
 import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
@@ -736,5 +736,204 @@ describe('Custom operation', () => {
     expect(res.body.resourceType).toBe('Patient');
     expect(res.body.name).toMatchObject([{ family: 'FromBody' }]);
     expect(res.body.id).toBeUndefined();
+  });
+
+  test('Custom operation code that collides with a FHIR spec operation resolves to the bot', async () => {
+    // The spec CodeSystem/$lookup definition is visible in every project and has no bot implementation
+    const specRes = await request(app)
+      .get('/fhir/R4/OperationDefinition?code=lookup')
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(specRes).toHaveStatus(200);
+    const specEntries = specRes.body.entry as BundleEntry<OperationDefinition>[];
+    expect(specEntries.some((e) => e.resource?.resource?.includes('CodeSystem'))).toBe(true);
+
+    const res1 = await request(app)
+      .post('/fhir/R4/Bot')
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({ resourceType: 'Bot', name: 'Lookup Bot', runtimeVersion: 'vmcontext' });
+    expect(res1).toHaveStatus(201);
+    const bot = res1.body as WithId<Bot>;
+
+    const res2 = await request(app)
+      .post(`/fhir/R4/Bot/${bot.id}/$deploy`)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({ code: `exports.handler = async function () { return { result: 'healthcare-service-lookup' }; };` });
+    expect(res2).toHaveStatus(200);
+
+    const res3 = await request(app)
+      .post('/fhir/R4/OperationDefinition')
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        resourceType: 'OperationDefinition',
+        extension: [
+          {
+            url: 'https://medplum.com/fhir/StructureDefinition/operationDefinition-implementation',
+            valueReference: createReference(bot),
+          },
+        ],
+        name: 'healthcare-service-lookup',
+        status: 'active',
+        kind: 'operation',
+        code: 'lookup',
+        resource: ['HealthcareService'],
+        system: false,
+        type: true,
+        instance: false,
+        parameter: [{ use: 'out', name: 'result', type: 'string', min: 1, max: '1' }],
+      });
+    expect(res3).toHaveStatus(201);
+
+    const res4 = await request(app)
+      .post('/fhir/R4/HealthcareService/$lookup')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({});
+    expect(res4).toHaveStatus(200);
+    expect(res4.body).toMatchObject({
+      resourceType: 'Parameters',
+      parameter: [{ name: 'result', valueString: 'healthcare-service-lookup' }],
+    });
+  });
+
+  test('Custom operations with the same code on different resource types resolve to their own bots', async () => {
+    const bots: Record<string, WithId<Bot>> = {};
+    for (const resourceType of ['HealthcareService', 'Slot']) {
+      const res1 = await request(app)
+        .post('/fhir/R4/Bot')
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .send({ resourceType: 'Bot', name: `${resourceType} Shared Code Bot`, runtimeVersion: 'vmcontext' });
+      expect(res1).toHaveStatus(201);
+      const bot = res1.body as WithId<Bot>;
+      bots[resourceType] = bot;
+
+      const res2 = await request(app)
+        .post(`/fhir/R4/Bot/${bot.id}/$deploy`)
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .send({ code: `exports.handler = async function () { return { result: '${resourceType}' }; };` });
+      expect(res2).toHaveStatus(200);
+
+      const res3 = await request(app)
+        .post('/fhir/R4/OperationDefinition')
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .send({
+          resourceType: 'OperationDefinition',
+          extension: [
+            {
+              url: 'https://medplum.com/fhir/StructureDefinition/operationDefinition-implementation',
+              valueReference: createReference(bot),
+            },
+          ],
+          name: `${resourceType}-shared-code-operation`,
+          status: 'active',
+          kind: 'operation',
+          code: 'my-shared-code-operation',
+          resource: [resourceType],
+          system: false,
+          type: true,
+          instance: false,
+          parameter: [{ use: 'out', name: 'result', type: 'string', min: 1, max: '1' }],
+        });
+      expect(res3).toHaveStatus(201);
+    }
+
+    for (const resourceType of ['HealthcareService', 'Slot']) {
+      const res = await request(app)
+        .post(`/fhir/R4/${resourceType}/$my-shared-code-operation`)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .send({});
+      expect(res).toHaveStatus(200);
+      expect(res.body).toMatchObject({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'result', valueString: resourceType }],
+      });
+    }
+  });
+
+  test('System-level and type-level custom operations with the same code resolve by request level', async () => {
+    for (const level of ['system', 'type']) {
+      const res1 = await request(app)
+        .post('/fhir/R4/Bot')
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .send({ resourceType: 'Bot', name: `${level} Multi Level Bot`, runtimeVersion: 'vmcontext' });
+      expect(res1).toHaveStatus(201);
+      const bot = res1.body as WithId<Bot>;
+
+      const res2 = await request(app)
+        .post(`/fhir/R4/Bot/${bot.id}/$deploy`)
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .send({ code: `exports.handler = async function () { return { result: '${level}' }; };` });
+      expect(res2).toHaveStatus(200);
+
+      const res3 = await request(app)
+        .post('/fhir/R4/OperationDefinition')
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .send({
+          resourceType: 'OperationDefinition',
+          extension: [
+            {
+              url: 'https://medplum.com/fhir/StructureDefinition/operationDefinition-implementation',
+              valueReference: createReference(bot),
+            },
+          ],
+          name: `${level}-multi-level-operation`,
+          status: 'active',
+          kind: 'operation',
+          code: 'my-multi-level-operation',
+          resource: level === 'type' ? ['Patient'] : undefined,
+          system: level === 'system',
+          type: level === 'type',
+          instance: false,
+          parameter: [{ use: 'out', name: 'result', type: 'string', min: 1, max: '1' }],
+        });
+      expect(res3).toHaveStatus(201);
+    }
+
+    const systemRes = await request(app)
+      .post('/fhir/R4/$my-multi-level-operation')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({});
+    expect(systemRes).toHaveStatus(200);
+    expect(systemRes.body).toMatchObject({
+      resourceType: 'Parameters',
+      parameter: [{ name: 'result', valueString: 'system' }],
+    });
+
+    const typeRes = await request(app)
+      .post('/fhir/R4/Patient/$my-multi-level-operation')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({});
+    expect(typeRes).toHaveStatus(200);
+    expect(typeRes.body).toMatchObject({
+      resourceType: 'Parameters',
+      parameter: [{ name: 'result', valueString: 'type' }],
+    });
+  });
+
+  test('FHIR spec operation without a bot implementation still returns 404', async () => {
+    const specRes = await request(app)
+      .get('/fhir/R4/OperationDefinition?code=translate')
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(specRes).toHaveStatus(200);
+    const specEntries = specRes.body.entry as BundleEntry<OperationDefinition>[];
+    expect(specEntries.some((e) => e.resource?.resource?.includes('ConceptMap'))).toBe(true);
+
+    const res = await request(app)
+      .post('/fhir/R4/HealthcareService/$translate')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({});
+    expect(res).toHaveStatus(404);
   });
 });

--- a/packages/server/src/fhir/operations/custom.ts
+++ b/packages/server/src/fhir/operations/custom.ts
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
 import {
   allOk,
   badRequest,
@@ -17,18 +18,37 @@ import { getAuthenticatedContext } from '../../context';
 import type { Repository } from '../repo';
 import { buildOutputParameters } from './utils/parameters';
 
+const IMPLEMENTATION_EXTENSION_URL = 'https://medplum.com/fhir/StructureDefinition/operationDefinition-implementation';
+
+const MAX_OPERATION_DEFINITIONS = 100;
+const RESOURCE_MATCH_SCORE = 4;
+const LEVEL_MATCH_SCORE = 2;
+const PROJECT_MATCH_SCORE = 1;
+
+type RequestTarget =
+  | { level: 'system' }
+  | { level: 'type'; resourceType: string }
+  | { level: 'instance'; resourceType: string; resourceId: string };
+
+interface CustomOperation {
+  operation: WithId<OperationDefinition>;
+  botReference: Reference<Bot>;
+  score: number;
+}
+
 export async function tryCustomOperation(req: FhirRequest, repo: Repository): Promise<FhirResponse | undefined> {
   // Parse the URL to find the operation code
   const parts = req.url.split('/');
-  const operationPart = parts.find((part) => part.startsWith('$'));
-  if (!operationPart) {
+  const operationIndex = parts.findIndex((part) => part.startsWith('$'));
+  if (operationIndex === -1) {
     // No operation found
     return undefined;
   }
 
-  // Search for the OperationDefinition resource
-  const operationCode = operationPart.substring(1); // Remove the '$' prefix
-  const operation = await repo.searchOne<OperationDefinition>({
+  // The FHIR spec OperationDefinitions are shared with every project, so a custom operation can share its code
+  // with a spec operation on another resource type (e.g. HealthcareService/$lookup and CodeSystem/$lookup).
+  const operationCode = parts[operationIndex].substring(1); // Remove the '$' prefix
+  const operations = await repo.searchResources<OperationDefinition>({
     resourceType: 'OperationDefinition',
     filters: [
       {
@@ -37,33 +57,20 @@ export async function tryCustomOperation(req: FhirRequest, repo: Repository): Pr
         value: operationCode,
       },
     ],
+    count: MAX_OPERATION_DEFINITIONS,
   });
-  if (!operation) {
-    // No operation definition found
+
+  const target = getRequestTarget(parts, operationIndex);
+  const customOperation = selectCustomOperation(operations, target, repo.currentProject()?.id);
+  if (!customOperation) {
     return undefined;
   }
 
-  // Check if the operation is a custom operation
-  const extension = getExtension(
-    operation,
-    'https://medplum.com/fhir/StructureDefinition/operationDefinition-implementation'
-  );
-  if (!extension) {
-    // No implementation extension found
-    return undefined;
-  }
-
-  // Check if the extension is a Bot reference
-  const botReference = extension.valueReference;
-  if (!botReference?.reference?.startsWith('Bot/')) {
-    // Not a Bot reference
-    return undefined;
-  }
-
+  const { operation, botReference } = customOperation;
   const ctx = getAuthenticatedContext();
 
   // First read the bot as the user to verify access
-  const userBot = await repo.readReference<Bot>(botReference as Reference<Bot>);
+  const userBot = await repo.readReference<Bot>(botReference);
 
   // Then read the bot as system user to load extended metadata
   const systemRepo = repo.getSystemRepo();
@@ -72,12 +79,9 @@ export async function tryCustomOperation(req: FhirRequest, repo: Repository): Pr
   // Determine the input for the bot
   // For instance-level operations (e.g., /Patient/123/$my-operation), read the resource and use it as input
   // For system-level or type-level operations, use the request body (POST) or query string (GET)
-  const operationIndex = parts.indexOf(operationPart);
   let input: any;
-  if (operation.instance && operationIndex >= 3 && parts[operationIndex - 2] && parts[operationIndex - 1]) {
-    const resourceType = parts[operationIndex - 2] as ResourceType;
-    const resourceId = parts[operationIndex - 1];
-    input = await repo.readResource(resourceType, resourceId);
+  if (operation.instance && target.level === 'instance') {
+    input = await repo.readResource(target.resourceType as ResourceType, target.resourceId);
   } else {
     input = req.method === 'POST' ? req.body : req.query;
   }
@@ -113,4 +117,89 @@ export async function tryCustomOperation(req: FhirRequest, repo: Repository): Pr
   } catch (err) {
     return [normalizeOperationOutcome(err)];
   }
+}
+
+/**
+ * Determines the level and resource type of the operation request from the URL parts,
+ * e.g. ['', 'Patient', '123', '$op'] is instance-level, ['', 'Patient', '$op'] is type-level and ['', '$op'] is system-level.
+ * @param parts - The request URL split by '/'.
+ * @param operationIndex - The index of the '$operation' part.
+ * @returns The request target.
+ */
+function getRequestTarget(parts: string[], operationIndex: number): RequestTarget {
+  if (operationIndex >= 3 && parts[operationIndex - 2] && parts[operationIndex - 1]) {
+    return { level: 'instance', resourceType: parts[operationIndex - 2], resourceId: parts[operationIndex - 1] };
+  }
+  if (operationIndex >= 2 && parts[operationIndex - 1]) {
+    return { level: 'type', resourceType: parts[operationIndex - 1] };
+  }
+  return { level: 'system' };
+}
+
+/**
+ * Selects the Bot-implemented OperationDefinition that best matches the request level and resource type,
+ * preferring definitions in the current project over definitions shared from other projects.
+ * @param operations - The OperationDefinitions with the requested code.
+ * @param target - The request target.
+ * @param projectId - The current project ID.
+ * @returns The custom operation to execute, or undefined if none of the definitions is implemented by a Bot.
+ */
+function selectCustomOperation(
+  operations: WithId<OperationDefinition>[],
+  target: RequestTarget,
+  projectId: string | undefined
+): CustomOperation | undefined {
+  let best: CustomOperation | undefined;
+  for (const operation of operations) {
+    const botReference = getBotReference(operation);
+    if (!botReference) {
+      continue;
+    }
+    const score = getMatchScore(operation, target, projectId);
+    if (!best || score > best.score) {
+      best = { operation, botReference, score };
+    }
+  }
+  return best;
+}
+
+/**
+ * Returns the Bot reference from the implementation extension of an OperationDefinition.
+ * @param operation - The OperationDefinition.
+ * @returns The Bot reference, or undefined if the definition does not have a Bot implementation.
+ */
+function getBotReference(operation: OperationDefinition): Reference<Bot> | undefined {
+  const botReference = getExtension(operation, IMPLEMENTATION_EXTENSION_URL)?.valueReference;
+  if (!botReference?.reference?.startsWith('Bot/')) {
+    return undefined;
+  }
+  return botReference as Reference<Bot>;
+}
+
+/**
+ * Scores how well an OperationDefinition matches the request.
+ * A definition that does not match the request level or resource type is still a candidate,
+ * so a lone definition keeps working when invoked at a different level than declared.
+ * @param operation - The OperationDefinition.
+ * @param target - The request target.
+ * @param projectId - The current project ID.
+ * @returns The match score; higher is better.
+ */
+function getMatchScore(operation: OperationDefinition, target: RequestTarget, projectId: string | undefined): number {
+  let score = 0;
+  if (target.level === 'system') {
+    if (operation.system) {
+      score += RESOURCE_MATCH_SCORE;
+    }
+  } else if (target.level === 'type' ? operation.type : operation.instance) {
+    if (operation.resource?.includes(target.resourceType as ResourceType)) {
+      score += RESOURCE_MATCH_SCORE;
+    } else if (!operation.resource?.length) {
+      score += LEVEL_MATCH_SCORE;
+    }
+  }
+  if (projectId && operation.meta?.project === projectId) {
+    score += PROJECT_MATCH_SCORE;
+  }
+  return score;
 }


### PR DESCRIPTION
Fixes #10492

## Summary

A Bot-backed custom operation whose code matches a FHIR spec operation on another resource type (for example `HealthcareService/$lookup` vs `CodeSystem/$lookup`, or `Slot/$find` vs `List/$find`) returns 404. This PR resolves the operation by resource type and level instead of taking the first `OperationDefinition` with that code.

## Root cause

`tryCustomOperation` used `searchOne` on `OperationDefinition?code=<op>` and took the first hit. Since #9653 (released in 5.1.23) the R4 project exports the spec `OperationDefinition`s to every project. They were inserted before any project's own definitions, so an unsorted search returns the spec definition first. It carries no `operationDefinition-implementation` extension, so the resolver bails out and the client gets 404 (`not-found`).

Reproduced on 5.1.37: `GET OperationDefinition?code=lookup` returns the spec `CodeSystem/$lookup` first, then the project's `HealthcareService/$lookup`; `POST HealthcareService/$lookup` returns 404.

## Fix

- Search all definitions with the code (`searchResources`, capped at 100) instead of `searchOne`.
- Ignore definitions without a Bot implementation extension (the spec definitions).
- Pick the definition whose `resource` and `system`/`type`/`instance` flags match the request URL. Definitions in the current project win over shared ones on ties.
- A lone Bot-backed definition still resolves even if its flags do not match the URL, preserving existing behaviour for `system: true` definitions invoked at type level (which the existing tests, the docs example, and `$submit` dispatch rely on).

Instance-level input loading, `Parameters` passthrough, and error handling are unchanged.

## Tests

New tests in `packages/server/src/fhir/operations/custom.test.ts`:

- a custom operation whose code collides with the spec `CodeSystem/$lookup` resolves to the bot
- two custom operations with the same code on `HealthcareService` and `Slot` each resolve to their own bot
- a system-level and a type-level definition with the same code resolve by request level
- a code with only a spec definition (`HealthcareService/$translate`) still returns 404

The three positive tests fail on `main` and pass with this change. Docs updated with a note on how operation codes are resolved.
