### PR TITLE
fix(ci): exclude test files from server coverage

### DIFF
--- a/packages/server/vite.config.ts
+++ b/packages/server/vite.config.ts
@@ -68,6 +68,7 @@ export default defineConfig({
       reportsDirectory: 'coverage',
       include: ['src/**/*.ts'],
       exclude: [
+        'src/**/*.test.ts',
         'src/__mocks__/**',
         'src/migrations/migrate-main.ts',
         'src/migrations/schema/**',


### PR DESCRIPTION
## Problem

Coveralls dropped from **92.2% to 60.8%** on 2026-09-09, and has stayed there.

Covered lines barely moved. Relevant lines nearly doubled, and almost all of the new ones are uncovered:

| | covered lines | relevant lines | % |
|---|---|---|---|
| before (`9e2f3296d`) | 43,791 | 46,286 | 92.22% |
| after (`ab912e5c1`) | 43,806 | 83,256 | 60.94% |

Branch coverage only fell to 84% while line coverage halved — the signature of files with many statements and almost no branches. Test files.

## Cause

#10318 moved `test:seed` from a CLI file filter to a dedicated config:

```diff
-"test:seed": "vitest run src/seed.test.ts --testTimeout=400000"
+"test:seed": "vitest run --config vite.seed.config.ts --testTimeout=400000"
```

`vite.seed.config.ts` spreads `baseConfig.test`, inheriting `coverage.include: ['src/**/*.ts']`, and moves file selection into `test.include`. That flips a flag in `@vitest/coverage-v8/dist/provider.js:53`:

```js
// Include untested files when all tests were run (not a single file re-run)
if (this.options.include != null && (allTestsRun || !this.options.cleanOnRerun)) {
```

- **Before:** a CLI filename filter meant `allTestsRun === false`, so the untested-file pass was skipped.
- **After:** no CLI filter, so `allTestsRun === true`. Vitest globs `coverage.include`, subtracts the one file that ran, and emits a 0% entry for everything else — including all 265 `src/**/*.test.ts` files, which nothing excluded.

Those entries reach Coveralls because the blob reporter stores the **generated coverage map**, not raw v8 data (`vitest/dist/chunks/index.UpGiHP7g.js:2022`), and `--merge-reports` simply unions maps (`coverage.DM_a_rWm.js:953`). So `scripts/test.sh`'s `cp … blob-seed.json … blob-server-seed.json` carries all ~37k phantom lines into `coverage/lcov.info`, which is the only file the Coveralls step uploads.

Visible in CI logs — count of `*.test.ts` rows in the coverage tables:

```
before: 0
after:  264   (all in the test:seed report)
```

and the seed summary went `16.75%` → `5.62%`, now listing `app.test.ts 0% (20-418)`, `database-migration.test.ts 0% (4-995)`, etc.

## Fix

Add `src/**/*.test.ts` to `coverage.exclude`. Test files shouldn't be measured anyway, and this stops the seed run's untested-file glob from reaching them.

## Verification

Replaying vitest's own resolution path (`getUntestedFilesByRoot` + `isIncluded`, same `tinyglobby`/`picomatch` options) with the seed run's `testedFiles = ['src/seed.test.ts']`:

```
BEFORE fix: untested=572  of which *.test.ts=265
AFTER  fix: untested=307  of which *.test.ts=0
```

- `prettier --check` and `eslint` clean.
- `tsc --noEmit` on `packages/server` unchanged from baseline.
- The main server run is unaffected — it already reported no test files (88.47% before #10318, 88.56% after).

I did not run the full merge locally (needs the whole suite plus Postgres and Redis), so the restored number is unconfirmed until CI reports here.

## Follow-up worth considering

`scripts/test.sh` guards against a *missing* server blob but not a *degraded* one, which is why this landed as a silent 32-point drop instead of a failure. A threshold check on the merged report would catch the next one.
