### PR TITLE
[Server] Add `X-Medplum-Log-Tag` request header

### DIFF
--- a/packages/docs/docs/integration/log-streaming.md
+++ b/packages/docs/docs/integration/log-streaming.md
@@ -36,7 +36,7 @@ To forward logs from CloudWatch to external platforms, AWS Lambda functions are 
 
 ## Log Correlation
 
-Medplum includes both request IDs and trace IDs to aid in log correlation, enhancing debugging and monitoring capabilities.
+Medplum includes request IDs and trace IDs to aid in log correlation, enhancing debugging and monitoring capabilities, and accepts a caller-supplied log tag for correlating against your own records.
 
 ### Request IDs
 
@@ -90,3 +90,78 @@ curl https://api.medplum.com/fhir/R4/Patient/homer-simpson \
   </TabItem>
 </Tabs>
 </details>
+
+### Log Tags
+
+Trace IDs correlate a request across systems. When you instead need to attach your _own_ piece of
+metadata to a request, send the `X-Medplum-Log-Tag` header. Its value is copied verbatim onto
+the `logTag` field of every log line emitted through the request logger while serving that
+request, including the `Request served` access log line.
+
+The most common use is per-user traceability. When a server side application authenticates as a
+single machine-to-machine [`ClientApplication`](/docs/api/fhir/medplum/clientapplication), every
+request arrives under the same Medplum identity. Passing your own end user identifier in
+`X-Medplum-Log-Tag` lets you answer "which of my users caused this request?" from the logs.
+
+<details>
+<summary>
+  Example: Tagging a request with your own end user identifier
+</summary>
+
+<Tabs groupId="language">
+  <TabItem value="ts" label="Typescript">
+
+```ts
+await medplum.readResource('Patient', 'homer-simpson', {
+  headers: {
+    'X-Medplum-Log-Tag': 'my-end-user-1234',
+  },
+});
+```
+
+  </TabItem>
+
+  <TabItem value="curl" label="cURL">
+
+```bash
+curl https://api.medplum.com/fhir/R4/Patient/homer-simpson \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/fhir+json" \
+  -H "X-Medplum-Log-Tag: my-end-user-1234"
+```
+
+  </TabItem>
+</Tabs>
+</details>
+
+Note the following about this header:
+
+- The value is opaque to Medplum. It is never parsed, resolved to a Medplum resource, or used to
+  make an authorization decision. If you need the acting user to affect authorship and access
+  control, use [On-Behalf-Of](/docs/auth/on-behalf-of) instead, which resolves to a real
+  `ProjectMembership`.
+- The value must be 1 to 128 characters of printable ASCII. Encode values outside that range, for
+  example as base64. A request carrying a value that does not meet these constraints is rejected
+  with a `400 Bad Request`, rather than served with the value dropped. You set this header so the
+  value is in the logs later, so a silent drop would hide the mistake until someone went looking
+  for data that was never recorded. Correct the value or omit the header.
+- The value is not propagated. It appears on log lines for the synchronous request only; background
+  work triggered by the request, such as an async batch, a subscription delivery, or a bot
+  execution, does not carry it, and it is not forwarded on outbound requests the way `X-Trace-Id`
+  is.
+- The value is not recorded on [AuditEvent](/docs/api/fhir/resources/auditevent) resources, and so
+  does not appear on the log lines produced by
+  [`logAuditEvents`](/docs/self-hosting/server-config#logauditevents). Correlate an `AuditEvent`
+  with a `logTag` through the request ID and trace ID that both carry.
+- The header only has an effect on requests that produce log output. A request that emits no log
+  lines has nothing to annotate, so enable
+  [`logRequests`](/docs/self-hosting/server-config#logrequests) to get one access log line per
+  request.
+
+:::warning[]
+
+Log output is retained by your log management tooling and is not subject to FHIR access controls.
+Do not put PHI or other sensitive data in `X-Medplum-Log-Tag`. Use an opaque identifier that
+you can resolve against your own records.
+
+:::

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -347,6 +347,99 @@ describe('App', () => {
         .send();
       expect(res1).toHaveStatus(400);
     });
+
+    test('X-Medplum-Log-Tag on unauthenticated request', async () => {
+      const res = await request(app).get('/').set('X-Medplum-Log-Tag', 'my-end-user-1234');
+      expect(res).toHaveStatus(200);
+
+      const logLines = stdOutSpy.mock.calls.filter((call) => call[0].includes('Request served'));
+      expect(logLines).toHaveLength(1);
+      const logObj = JSON.parse(logLines[0][0]);
+      expect(logObj.logTag).toBe('my-end-user-1234');
+    });
+
+    test('X-Medplum-Log-Tag on authenticated request', async () => {
+      const accessToken = await initTestAuth();
+      (process.stdout.write as Mock).mockClear();
+
+      const res = await request(app)
+        .get('/fhir/R4/Patient')
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('X-Medplum-Log-Tag', 'my-end-user-1234');
+      expect(res).toHaveStatus(200);
+
+      const logLines = stdOutSpy.mock.calls.filter((call) => call[0].includes('Request served'));
+      expect(logLines).toHaveLength(1);
+      const logObj = JSON.parse(logLines[0][0]);
+      expect(logObj.logTag).toBe('my-end-user-1234');
+    });
+
+    test('X-Medplum-Log-Tag rejects an unusable value', async () => {
+      const res = await request(app).get('/').set('X-Medplum-Log-Tag', 'a'.repeat(129));
+      expect(res).toHaveStatus(400);
+      expect((res.body as OperationOutcome).issue[0].details?.text).toStrictEqual(
+        'Invalid X-Medplum-Log-Tag header: expected 1 to 128 characters of printable ASCII'
+      );
+
+      // The request is still logged, so an operator can see the rejection
+      const logLines = stdOutSpy.mock.calls.filter((call) => call[0].includes('Request served'));
+      expect(logLines).toHaveLength(1);
+      const logObj = JSON.parse(logLines[0][0]);
+      expect(logObj).toMatchObject({ status: 400 });
+      expect(logObj.logTag).toBeUndefined();
+    });
+
+    test('X-Medplum-Log-Tag is rejected before authentication', async () => {
+      // The header is a request shape error, so it does not depend on a valid token
+      const res = await request(app)
+        .get('/fhir/R4/Patient')
+        .set('Authorization', 'Bearer invalid')
+        .set('X-Medplum-Log-Tag', 'a'.repeat(129));
+      expect(res).toHaveStatus(400);
+      expect((res.body as OperationOutcome).issue[0].details?.text).toStrictEqual(
+        'Invalid X-Medplum-Log-Tag header: expected 1 to 128 characters of printable ASCII'
+      );
+    });
+
+    test('X-Medplum-Log-Tag does not reach AuditEvent log lines', async () => {
+      // AuditEvents are serialized FHIR resources written straight to stdout, not log lines built
+      // from the request logger's metadata, so they carry no logTag. Correlate them with the
+      // requestId and traceId in the tracing extension instead.
+      getConfig().logAuditEvents = true;
+      const accessToken = await initTestAuth();
+      (process.stdout.write as Mock).mockClear();
+
+      const res = await request(app)
+        .get('/fhir/R4/Patient')
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('X-Medplum-Log-Tag', 'my-end-user-1234');
+      expect(res).toHaveStatus(200);
+
+      const auditLines = stdOutSpy.mock.calls.filter((call) => call[0].includes('"resourceType":"AuditEvent"'));
+      expect(auditLines.length).toBeGreaterThan(0);
+      for (const line of auditLines) {
+        expect(JSON.parse(line[0]).logTag).toBeUndefined();
+      }
+    });
+
+    test('X-Medplum-Log-Tag on authentication error', async () => {
+      const { accessToken, membership, project } = await createTestProject({ withAccessToken: true, withClient: true });
+
+      // Delete ProjectMembership to cause a 410 Gone error in the authentication middleware
+      await (await getProjectSystemRepo(project)).deleteResource(membership.resourceType, membership.id);
+      (process.stdout.write as Mock).mockClear();
+
+      const res = await request(app)
+        .get('/fhir/R4/Patient')
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('X-Medplum-Log-Tag', 'my-end-user-1234');
+      expect(res).toHaveStatus(400);
+
+      const logLines = stdOutSpy.mock.calls.filter((call) => call[0].includes('Request served'));
+      expect(logLines).toHaveLength(1);
+      const logObj = JSON.parse(logLines[0][0]);
+      expect(logObj.logTag).toBe('my-end-user-1234');
+    });
   });
 
   test('Internal Server Error', async () => {

--- a/packages/server/src/context.ts
+++ b/packages/server/src/context.ts
@@ -24,6 +24,7 @@ import { authenticateTokenImpl } from './oauth/middleware';
 import { getRateLimitRedis } from './redis';
 import type { IRequestContext } from './request-context-store';
 import { requestContextStore } from './request-context-store';
+import { getLogTag } from './util/log-tag';
 import { generateTraceId, getTraceId } from './util/tracing';
 
 export class RequestContext implements IRequestContext {
@@ -55,6 +56,7 @@ export class RequestContext implements IRequestContext {
 export type AuthenticatedContextOptions = {
   logger?: Logger;
   async?: boolean;
+  logTag?: string; // Opaque caller-supplied string included in log output
 };
 
 export class AuthenticatedRequestContext extends RequestContext {
@@ -71,7 +73,7 @@ export class AuthenticatedRequestContext extends RequestContext {
     repo: Repository,
     options?: AuthenticatedContextOptions
   ) {
-    let loggerMetadata: Record<string, any> | undefined;
+    const loggerMetadata: Record<string, any> = {};
     const projectId = repo.currentProject()?.id;
     if (projectId) {
       let profile = authState.membership.profile.reference;
@@ -79,7 +81,11 @@ export class AuthenticatedRequestContext extends RequestContext {
       if (asUserProfile && asUserProfile !== profile) {
         profile += ` (as ${asUserProfile})`;
       }
-      loggerMetadata = { projectId, profile };
+      loggerMetadata.projectId = projectId;
+      loggerMetadata.profile = profile;
+    }
+    if (options?.logTag) {
+      loggerMetadata.logTag = options.logTag;
     }
     super(requestId, traceId, options?.logger, loggerMetadata);
 
@@ -152,16 +158,27 @@ export async function attachRequestContext(req: Request, res: Response, next: Ne
   res.set('X-Request-Id', requestId);
   res.set('X-Trace-Id', traceId);
 
+  let logTag: string | undefined;
+  try {
+    logTag = getLogTag(req);
+  } catch (err: any) {
+    // Ensure next() is called in a request context, so later middleware (e.g. logging) can run correctly
+    const ctx = new RequestContext(requestId, traceId);
+    requestContextStore.run(ctx, () => next(err));
+    return;
+  }
+  const loggerMetadata = logTag ? { logTag } : undefined;
+
   let ctx: RequestContext | undefined;
   try {
     const result = await authenticateTokenImpl(req);
     if (result) {
       const { authState, repo } = result;
-      ctx = new AuthenticatedRequestContext(requestId, traceId, authState, repo);
+      ctx = new AuthenticatedRequestContext(requestId, traceId, authState, repo, { logTag });
     }
   } catch (err: any) {
     // Ensure next() is called in a request context, so later middleware (e.g. logging) can run correctly
-    ctx ??= new RequestContext(requestId, traceId);
+    ctx ??= new RequestContext(requestId, traceId, undefined, loggerMetadata);
     requestContextStore.run(ctx, () => {
       getLogger().error('Authentication error', { err: err.toString(), stack: err.stack });
       const outcome = badRequest('Authentication error');
@@ -172,7 +189,7 @@ export async function attachRequestContext(req: Request, res: Response, next: Ne
     return;
   }
 
-  ctx ??= new RequestContext(requestId, traceId);
+  ctx ??= new RequestContext(requestId, traceId, undefined, loggerMetadata);
   requestContextStore.run(ctx, () => next());
 }
 

--- a/packages/server/src/util/log-tag.test.ts
+++ b/packages/server/src/util/log-tag.test.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { OperationOutcomeError } from '@medplum/core';
+import type { Request } from 'express';
+import { LOG_TAG_HEADER, getLogTag } from './log-tag';
+
+function mockRequest(value?: string): Request {
+  return { header: (name: string) => (name === LOG_TAG_HEADER ? value : undefined) } as unknown as Request;
+}
+
+describe('getLogTag', () => {
+  test('Missing header', () => {
+    expect(getLogTag(mockRequest())).toBeUndefined();
+  });
+
+  test('Passes through usable values', () => {
+    expect(getLogTag(mockRequest('user-1234'))).toBe('user-1234');
+    expect(getLogTag(mockRequest('tenant=acme; user=1234'))).toBe('tenant=acme; user=1234');
+    expect(getLogTag(mockRequest('{"u":"1234"}'))).toBe('{"u":"1234"}');
+    expect(getLogTag(mockRequest('a'))).toBe('a');
+    expect(getLogTag(mockRequest('a'.repeat(128)))).toBe('a'.repeat(128));
+  });
+
+  test('Rejects an empty value', () => {
+    expect(() => getLogTag(mockRequest(''))).toThrow(OperationOutcomeError);
+  });
+
+  test('Rejects a value over the length limit', () => {
+    expect(() => getLogTag(mockRequest('a'.repeat(129)))).toThrow(OperationOutcomeError);
+  });
+
+  test('Rejects values outside printable ASCII', () => {
+    expect(() => getLogTag(mockRequest('user\n1234'))).toThrow(OperationOutcomeError);
+    expect(() => getLogTag(mockRequest('user\t1234'))).toThrow(OperationOutcomeError);
+    expect(() => getLogTag(mockRequest('\x1b[31muser'))).toThrow(OperationOutcomeError);
+    expect(() => getLogTag(mockRequest('useré'))).toThrow(OperationOutcomeError);
+  });
+
+  test('Does not echo the rejected value', () => {
+    expect(() => getLogTag(mockRequest('user\n1234'))).toThrow(
+      `Invalid ${LOG_TAG_HEADER} header: expected 1 to 128 characters of printable ASCII`
+    );
+  });
+});

--- a/packages/server/src/util/log-tag.ts
+++ b/packages/server/src/util/log-tag.ts
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { OperationOutcomeError, badRequest } from '@medplum/core';
+import type { Request } from 'express';
+
+/**
+ * The request header that carries a caller-supplied string to be included in Medplum's logs.
+ *
+ * Written in canonical casing so that it reads back to the caller in error messages. Look it up
+ * with `req.header()`, which is case insensitive, rather than indexing `req.headers` directly.
+ */
+export const LOG_TAG_HEADER = 'X-Medplum-Log-Tag';
+
+/**
+ * Characters allowed in a log tag: printable ASCII.
+ *
+ * Control characters are excluded because this value is written to log output, where an embedded
+ * ANSI escape sequence can manipulate an operator's terminal. Non-ASCII is excluded because HTTP
+ * header values outside ASCII are not portably transmitted; callers with non-ASCII values should
+ * encode them.
+ *
+ * The 128 character limit is a log volume bound: this string is attached to every log line the
+ * request emits, so its cost is per-line multiplied by request rate.
+ */
+const SAFE_LOG_TAG_REGEX = /^[\x20-\x7E]{1,128}$/;
+
+/**
+ * Returns the caller-supplied log tag for an incoming request.
+ *
+ * The tag is opaque to Medplum: it is never parsed, resolved, or used to make a decision. Its only
+ * effect is to appear as the `logTag` field on log lines emitted while serving the request.
+ *
+ * A single scalar rather than a set of caller-supplied fields is deliberate. Log metadata is
+ * merged flat into each log line, so an object here would let a caller shadow server-recorded
+ * fields such as `profile`, `projectId`, or `requestId` in log output.
+ *
+ * An unusable value fails the request rather than being ignored or sanitized. A caller sets this
+ * header precisely so that the value is available in the logs later, so silently dropping it would
+ * turn a small mistake into missing data that is only discovered when someone goes looking for it.
+ * Sanitizing is worse still: a partially stripped identifier no longer matches the caller's own
+ * records but still looks like a valid tag.
+ *
+ * @param req - The incoming HTTP request.
+ * @returns The log tag, or undefined if the request does not carry one.
+ * @throws OperationOutcomeError if the header is present but not usable.
+ */
+export function getLogTag(req: Request): string | undefined {
+  const value = req.header(LOG_TAG_HEADER);
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!SAFE_LOG_TAG_REGEX.test(value)) {
+    // The rejected value is deliberately left out of the message: it is unvalidated caller input,
+    // and the response is echoed in logs and error trackers.
+    throw new OperationOutcomeError(
+      badRequest(`Invalid ${LOG_TAG_HEADER} header: expected 1 to 128 characters of printable ASCII`)
+    );
+  }
+
+  return value;
+}


### PR DESCRIPTION
Customers using a single M2M ClientApplication authenticate through one generic identity, so requests cannot be correlated back to their end users. X-Trace-Id is unsuitable for this: it is a correlation identifier that is propagated downstream and recorded on AuditEvent, so overloading it means a caller cannot have both a trace and a user tag on the same request.

We solve this by introducing a new `X-Medplum-Log-Tag` header. Requests to Medplum Server may include up to 128 characters of printable ASCII in the header's value. When present, this string will be attached to logs as the `logTag` field.

Invalid values for this header return HTTP 400 (Bad Request) rather than serving the request without annotations. This means that callers using this feature must validate the value before sending it, but ensures that during an incident you won't find that you've been silently dropping the logging information you need to resolve it.

Implementation Notes:
- The name is deliberately non-specific about what you tag with. Because Medplum treats the value as an opaque string, you can use it to put arbitrary data into the logs to associate with your request.

- While the initial use case for this tag involves annotating logs with identity information from the calling application, Medplum itself does not interpret it, use it to record any authorship, or enforce access control. Callers that need such behavior should use the `X-Medplum-On-Behalf-Of` header.

- The tag is a single scalar rather than a set of caller-supplied fields. Log metadata is merged flat into each log line, so an object here would let a caller shadow server-recorded fields such as `profile`, `projectId`, or `requestId` in log output.

- The value is limited to 1-128 characters of printable ASCII. Control characters are excluded because an embedded ANSI escape in a log line can manipulate an operator's terminal, and non-ASCII because header values outside ASCII are not portably transmitted. The 128 character cap bounds log volume, since the string is attached to every log line the request emits.

- The value is deliberately not propagated to background work and is not recorded on AuditEvent resources, which are serialized straight to stdout rather than built from logger metadata.

- Validation of this value runs before authentication, so a caller with a malformed header and an invalid token gets HTTP 400 rather than 401.

- Invalid values in this header are not echoed back to the caller, to avoid having them appear in logs or error trackers.

Fixes #10240

Assisted-by: Claude Opus 5