### PR TITLE
External auth: id_token verification hardening

### DIFF
--- a/packages/server/src/auth/external.test.ts
+++ b/packages/server/src/auth/external.test.ts
@@ -386,25 +386,36 @@ describe('External', () => {
       })
     );
 
-    const jwt = await new SignJWT({ email })
-      .setProtectedHeader({ alg: 'ES256' })
-      .setIssuer(issuer)
-      .setExpirationTime('2h')
-      .sign(keyPair.privateKey);
+    const signIdToken = (audience: string): Promise<string> =>
+      new SignJWT({ email })
+        .setProtectedHeader({ alg: 'ES256' })
+        .setIssuer(issuer)
+        .setAudience(audience)
+        .setExpirationTime('2h')
+        .sign(keyPair.privateKey);
 
     // The token endpoint returns the signed token; the JWKS endpoint returns the public key.
-    fetchMock.mockImplementation((input: any) =>
-      String(input).includes('verified-jwks') ? mockFetchJson({ keys: [publicJwk] }) : mockFetchJson({ id_token: jwt })
-    );
+    const mockIdToken = (jwt: string): void => {
+      fetchMock.mockImplementation((input: any) =>
+        String(input).includes('verified-jwks') ? mockFetchJson({ keys: [publicJwk] }) : mockFetchJson({ id_token: jwt })
+      );
+    };
+    const url = appendQueryParams('/auth/external', {
+      code: randomUUID(),
+      state: JSON.stringify({ redirectUri, clientId: jwksClient.id }),
+    });
 
-    const res = await request(app).get(
-      appendQueryParams('/auth/external', {
-        code: randomUUID(),
-        state: JSON.stringify({ redirectUri, clientId: jwksClient.id }),
-      })
-    );
+    // Audience defaults to the IdP client ID, so a token audienced to it is accepted.
+    mockIdToken(await signIdToken(identityProvider.clientId));
+    let res = await request(app).get(url);
     expect(res).toHaveStatus(302);
     expect(new URL(res.header.location).searchParams.get('code')).toBeTruthy();
+
+    // A token audienced to a different relying party is rejected.
+    mockIdToken(await signIdToken('some-other-client'));
+    res = await request(app).get(url);
+    expect(res).toHaveStatus(400);
+    expect(res.body.issue[0].details.text).toBe('Failed to verify code - check your identity provider configuration');
   });
 
   test('Invalid client', async () => {

--- a/packages/server/src/auth/external.test.ts
+++ b/packages/server/src/auth/external.test.ts
@@ -13,6 +13,7 @@ import { initApp, shutdownApp } from '../app';
 import { getConfig, loadTestConfig } from '../config/loader';
 import type { SystemRepository } from '../fhir/repo';
 import { getProjectSystemRepo } from '../fhir/repo';
+import { getUserByEmailWithoutProject } from '../oauth/utils';
 import { withTestContext } from '../test.setup';
 import { mockFetchJson, mockFetchText } from '../test.setup.fetch';
 import { registerNew } from './register';
@@ -280,6 +281,74 @@ describe('External', () => {
     expect(redirect.host).toStrictEqual(domain);
     expect(redirect.pathname).toStrictEqual('/auth/callback');
     expect(redirect.searchParams.get('code')).toBeTruthy();
+  });
+
+  test('Login is scoped to the client project across tenants', async () => {
+    // A user who belongs only to a different project is not logged in through a
+    // ClientApplication in another project. External login resolves the user by email
+    // (including server-scoped users via getUserByEmailWithoutProject), but membership is
+    // scoped to the client's project, so a user with no membership there results in
+    // "User not found" and no authorization code is issued.
+    const otherEmail = `other-${randomUUID()}@example.com`;
+    await withTestContext(() =>
+      registerNew({
+        firstName: 'Other',
+        lastName: 'User',
+        projectName: 'Other Project ' + randomUUID(),
+        email: otherEmail,
+        password: 'password!@#',
+        remoteAddress: '6.6.6.6',
+        userAgent: 'Mozilla/5.0',
+      })
+    );
+
+    // The user is server-scoped, and so is resolvable by email with no project.
+    const otherUser = await withTestContext(() => getUserByEmailWithoutProject(otherEmail));
+    expect(otherUser).toBeDefined();
+
+    // Drive the callback with a client from a different project and a token asserting the
+    // other user's email.
+    const url = appendQueryParams('/auth/external', {
+      code: randomUUID(),
+      state: JSON.stringify({ redirectUri, clientId: externalAuthClient.id }),
+    });
+    fetchMock.mockImplementation(() => mockFetchJson(buildTokens(otherEmail)));
+
+    const res = await request(app).get(url);
+    expect(res).toHaveStatus(400);
+    expect(res.body.issue[0].details.text).toBe('User not found');
+  });
+
+  test('id_token signature is verified when jwksUrl is configured', async () => {
+    // When the identity provider publishes a JWKS, a token that does not verify against it
+    // (here, the unsigned token produced by buildTokens) is rejected.
+    const jwksClient = await withTestContext(() =>
+      createClient(systemRepo, { project, name: 'JWKS Client', redirectUri })
+    );
+    await withTestContext(() =>
+      systemRepo.updateResource<ClientApplication>({
+        ...jwksClient,
+        identityProvider: {
+          ...identityProvider,
+          issuer: 'https://issuer.example.com',
+          jwksUrl: 'https://issuer.example.com/.well-known/jwks.json',
+          identitySource: 'email',
+          identityMappingMode: 'user-email',
+        },
+      })
+    );
+
+    const url = appendQueryParams('/auth/external', {
+      code: randomUUID(),
+      state: JSON.stringify({ redirectUri, clientId: jwksClient.id }),
+    });
+    // All fetches (token endpoint and JWKS endpoint) return non-JWKS JSON, so signature
+    // verification cannot succeed for the unsigned token.
+    fetchMock.mockImplementation(() => mockFetchJson(buildTokens(email)));
+
+    const res = await request(app).get(url);
+    expect(res).toHaveStatus(400);
+    expect(res.body.issue[0].details.text).toBe('Failed to verify code - check your identity provider configuration');
   });
 
   test('Invalid client', async () => {

--- a/packages/server/src/auth/external.test.ts
+++ b/packages/server/src/auth/external.test.ts
@@ -397,7 +397,9 @@ describe('External', () => {
     // The token endpoint returns the signed token; the JWKS endpoint returns the public key.
     const mockIdToken = (jwt: string): void => {
       fetchMock.mockImplementation((input: any) =>
-        String(input).includes('verified-jwks') ? mockFetchJson({ keys: [publicJwk] }) : mockFetchJson({ id_token: jwt })
+        String(input).includes('verified-jwks')
+          ? mockFetchJson({ keys: [publicJwk] })
+          : mockFetchJson({ id_token: jwt })
       );
     };
     const url = appendQueryParams('/auth/external', {

--- a/packages/server/src/auth/external.test.ts
+++ b/packages/server/src/auth/external.test.ts
@@ -5,6 +5,7 @@ import { ContentType, OAuthTokenAuthMethod } from '@medplum/core';
 import type { ClientApplication, DomainConfiguration, Project, ProjectMembership, User } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
+import { exportJWK, generateKeyPair, SignJWT } from 'jose';
 import request from 'supertest';
 import { vi } from 'vitest';
 import { createClient } from '../admin/client';
@@ -319,36 +320,91 @@ describe('External', () => {
     expect(res.body.issue[0].details.text).toBe('User not found');
   });
 
-  test('id_token signature is verified when jwksUrl is configured', async () => {
-    // When the identity provider publishes a JWKS, a token that does not verify against it
-    // (here, the unsigned token produced by buildTokens) is rejected.
+  test('id_token verification rejects invalid tokens', async () => {
+    // Missing id_token in the token endpoint response.
+    const noJwksUrl = appendQueryParams('/auth/external', {
+      code: randomUUID(),
+      state: JSON.stringify({ redirectUri, clientId: externalAuthClient.id }),
+    });
+    fetchMock.mockImplementation(() => mockFetchJson({}));
+    let res = await request(app).get(noJwksUrl);
+    expect(res).toHaveStatus(400);
+    expect(res.body.issue[0].details.text).toBe('Missing id_token in external identity provider response');
+
     const jwksClient = await withTestContext(() =>
       createClient(systemRepo, { project, name: 'JWKS Client', redirectUri })
+    );
+    const idp = {
+      ...identityProvider,
+      jwksUrl: 'https://issuer.example.com/.well-known/jwks.json',
+      identitySource: 'email' as const,
+      identityMappingMode: 'user-email' as const,
+    };
+    const url = appendQueryParams('/auth/external', {
+      code: randomUUID(),
+      state: JSON.stringify({ redirectUri, clientId: jwksClient.id }),
+    });
+    fetchMock.mockImplementation(() => mockFetchJson(buildTokens(email)));
+
+    // JWKS configured without an issuer.
+    await withTestContext(() => systemRepo.updateResource<ClientApplication>({ ...jwksClient, identityProvider: idp }));
+    res = await request(app).get(url);
+    expect(res).toHaveStatus(400);
+    expect(res.body.issue[0].details.text).toBe('Missing issuer for external identity provider');
+
+    // Issuer configured, but the (unsigned) token does not verify against the JWKS.
+    await withTestContext(() =>
+      systemRepo.updateResource<ClientApplication>({
+        ...jwksClient,
+        identityProvider: { ...idp, issuer: 'https://issuer.example.com' },
+      })
+    );
+    res = await request(app).get(url);
+    expect(res).toHaveStatus(400);
+    expect(res.body.issue[0].details.text).toBe('Failed to verify code - check your identity provider configuration');
+  });
+
+  test('id_token that verifies against the JWKS is accepted', async () => {
+    const issuer = 'https://issuer.example.com';
+    const jwksUrl = 'https://issuer.example.com/.well-known/verified-jwks.json';
+    const keyPair = await generateKeyPair('ES256');
+    const publicJwk = await exportJWK(keyPair.publicKey);
+
+    const jwksClient = await withTestContext(() =>
+      createClient(systemRepo, { project, name: 'JWKS Verified Client', redirectUri })
     );
     await withTestContext(() =>
       systemRepo.updateResource<ClientApplication>({
         ...jwksClient,
         identityProvider: {
           ...identityProvider,
-          issuer: 'https://issuer.example.com',
-          jwksUrl: 'https://issuer.example.com/.well-known/jwks.json',
+          issuer,
+          jwksUrl,
           identitySource: 'email',
           identityMappingMode: 'user-email',
         },
       })
     );
 
-    const url = appendQueryParams('/auth/external', {
-      code: randomUUID(),
-      state: JSON.stringify({ redirectUri, clientId: jwksClient.id }),
-    });
-    // All fetches (token endpoint and JWKS endpoint) return non-JWKS JSON, so signature
-    // verification cannot succeed for the unsigned token.
-    fetchMock.mockImplementation(() => mockFetchJson(buildTokens(email)));
+    const jwt = await new SignJWT({ email })
+      .setProtectedHeader({ alg: 'ES256' })
+      .setIssuer(issuer)
+      .setExpirationTime('2h')
+      .sign(keyPair.privateKey);
 
-    const res = await request(app).get(url);
-    expect(res).toHaveStatus(400);
-    expect(res.body.issue[0].details.text).toBe('Failed to verify code - check your identity provider configuration');
+    // The token endpoint returns the signed token; the JWKS endpoint returns the public key.
+    fetchMock.mockImplementation((input: any) =>
+      String(input).includes('verified-jwks') ? mockFetchJson({ keys: [publicJwk] }) : mockFetchJson({ id_token: jwt })
+    );
+
+    const res = await request(app).get(
+      appendQueryParams('/auth/external', {
+        code: randomUUID(),
+        state: JSON.stringify({ redirectUri, clientId: jwksClient.id }),
+      })
+    );
+    expect(res).toHaveStatus(302);
+    expect(new URL(res.header.location).searchParams.get('code')).toBeTruthy();
   });
 
   test('Invalid client', async () => {

--- a/packages/server/src/auth/external.ts
+++ b/packages/server/src/auth/external.ts
@@ -13,6 +13,7 @@ import {
 } from '@medplum/core';
 import type { ClientApplication, DomainConfiguration, IdentityProvider, Project } from '@medplum/fhirtypes';
 import type { Request, Response } from 'express';
+import { createRemoteJWKSet, customFetch, jwtVerify } from 'jose';
 import { randomUUID } from 'node:crypto';
 import { getConfig } from '../config/loader';
 import { sendOutcome } from '../fhir/outcomes';
@@ -305,11 +306,43 @@ async function verifyExternalCode(
       throw new OperationOutcomeError(badRequest('Failed to verify code - check your identity provider configuration'));
     }
 
-    return parseJWTPayload(responseBody.id_token);
+    return await verifyExternalIdToken(idp, responseBody.id_token);
   } catch (err: any) {
+    if (err instanceof OperationOutcomeError) {
+      // Preserve specific validation messages (e.g. from id_token verification).
+      throw err;
+    }
     globalLogger.warn('Unhandled error in external auth check', err);
     throw new OperationOutcomeError(badRequest('Failed to verify code - check your identity provider configuration'));
   }
+}
+
+/**
+ * Parses the id_token returned by the external identity provider, verifying its signature when a
+ * JWKS is available.
+ *
+ * When the identity provider publishes a JWKS (`jwksUrl`), the id_token signature, issuer, and
+ * audience are checked before the claims are read. Providers without a configured `jwksUrl` retain
+ * the existing behavior of relying on the server-to-server token endpoint response; configuring
+ * `jwksUrl` (and `issuer`) is recommended so that claims are cryptographically verified.
+ * @param idp - The identity provider configuration.
+ * @param idToken - The raw id_token from the token endpoint response.
+ * @returns The id_token claims.
+ */
+async function verifyExternalIdToken(idp: IdentityProvider, idToken: unknown): Promise<Record<string, unknown>> {
+  if (!isString(idToken)) {
+    throw new OperationOutcomeError(badRequest('Missing id_token in external identity provider response'));
+  }
+
+  if (idp.jwksUrl) {
+    if (!idp.issuer) {
+      throw new OperationOutcomeError(badRequest('Missing issuer for external identity provider'));
+    }
+    const jwks = createRemoteJWKSet(new URL(idp.jwksUrl), { [customFetch]: safeFetch });
+    await jwtVerify(idToken, jwks, { issuer: idp.issuer, audience: idp.audience });
+  }
+
+  return parseJWTPayload(idToken);
 }
 
 /**

--- a/packages/server/src/auth/external.ts
+++ b/packages/server/src/auth/external.ts
@@ -321,10 +321,12 @@ async function verifyExternalCode(
  * Parses the id_token returned by the external identity provider, verifying its signature when a
  * JWKS is available.
  *
- * When the identity provider publishes a JWKS (`jwksUrl`), the id_token signature, issuer, and
- * audience are checked before the claims are read. Providers without a configured `jwksUrl` retain
- * the existing behavior of relying on the server-to-server token endpoint response; configuring
- * `jwksUrl` (and `issuer`) is recommended so that claims are cryptographically verified.
+ * When the identity provider publishes a JWKS (`jwksUrl`), the id_token signature and issuer are
+ * checked before the claims are read. The audience is checked against `idp.audience` when set,
+ * otherwise against `idp.clientId`, since an OIDC id_token is audienced to the client it was issued
+ * for. Providers without a configured `jwksUrl` retain the existing behavior of relying on the
+ * server-to-server token endpoint response; configuring `jwksUrl` (and `issuer`) is recommended so
+ * that claims are cryptographically verified.
  * @param idp - The identity provider configuration.
  * @param idToken - The raw id_token from the token endpoint response.
  * @returns The id_token claims.
@@ -339,7 +341,11 @@ async function verifyExternalIdToken(idp: IdentityProvider, idToken: unknown): P
       throw new OperationOutcomeError(badRequest('Missing issuer for external identity provider'));
     }
     const jwks = createRemoteJWKSet(new URL(idp.jwksUrl), { [customFetch]: safeFetch });
-    await jwtVerify(idToken, jwks, { issuer: idp.issuer, audience: idp.audience });
+    const { payload } = await jwtVerify(idToken, jwks, {
+      issuer: idp.issuer,
+      audience: idp.audience ?? idp.clientId,
+    });
+    return payload;
   }
 
   return parseJWTPayload(idToken);


### PR DESCRIPTION
Adds `id_token` signature verification to the `/auth/external` callback flow when the external identity provider publishes a JWKS. Previously this path parsed the `id_token` claims without verifying the signature, while the token-exchange path already performed verification via `verifyExternalToken`. This change brings the callback path in line with that behavior.

It also adds regression coverage confirming that external login is scoped to the client's project, so a user who is only a member of a different project is not logged in through a `ClientApplication` in another project.

## Background

A security report questioned whether the external auth callback could be used for cross-tenant login, given that:

1. the `id_token` returned from the provider token endpoint was parsed without signature verification, and
2. user resolution by email falls through to `getUserByEmailWithoutProject`, which resolves server-scoped users across projects.

On investigation, cross-tenant login is not achievable through this path: when a `ClientApplication` drives the callback, the login is scoped to that client's project (`external.ts` forces `projectId = client.meta.project`), and `getMembershipsForLogin` filters memberships to that project. A user with no membership in the client's project results in `User not found` before any authorization code is issued.

The missing `id_token` signature verification is still worth hardening, and configuring a JWKS gives cryptographic assurance of the claims rather than relying solely on the server-to-server token endpoint response.