### PR TITLE
Updated google auth flow to send email verification

### DIFF
--- a/packages/server/src/auth/google.test.ts
+++ b/packages/server/src/auth/google.test.ts
@@ -46,6 +46,7 @@ describe('Google Auth', () => {
 
   beforeEach(() => {
     getConfig().registerEnabled = undefined;
+    getConfig().requireVerifiedEmailForProjectCreation = undefined;
   });
 
   afterAll(async () => {
@@ -176,6 +177,7 @@ describe('Google Auth', () => {
     expect(res).toHaveStatus(200);
     expect(res.body.login).toBeDefined();
     expect(res.body.code).toBeUndefined();
+    expect(res.body.emailVerificationRequired).toBeUndefined();
 
     const user = await getUserByEmail(email, undefined);
     expect(user).toBeDefined();
@@ -204,6 +206,104 @@ describe('Google Auth', () => {
 
     const user = await getUserByEmail(email, undefined);
     expect(user).toBeDefined();
+  });
+
+  test('Require email verification for new project', async () => {
+    getConfig().requireVerifiedEmailForProjectCreation = true;
+    const email = 'new-google-' + randomUUID() + '@example.com';
+    const res = await request(app)
+      .post('/auth/google')
+      .type('json')
+      .send({
+        projectId: 'new',
+        googleClientId: getConfig().googleClientId,
+        googleCredential: createCredential('Test', 'Test', email),
+        createUser: true,
+      });
+    expect(res).toHaveStatus(200);
+    expect(res.body.login).toBeDefined();
+    expect(res.body.code).toBeUndefined();
+    expect(res.body.emailVerificationRequired).toBe(true);
+  });
+
+  test('Skip email verification for verified user', async () => {
+    getConfig().requireVerifiedEmailForProjectCreation = true;
+    const email = 'new-google-' + randomUUID() + '@example.com';
+    await systemRepo.createResource<User>({
+      resourceType: 'User',
+      firstName: 'Google',
+      lastName: 'Google',
+      email,
+      emailVerified: true,
+    });
+
+    const res = await request(app)
+      .post('/auth/google')
+      .type('json')
+      .send({
+        projectId: 'new',
+        googleClientId: getConfig().googleClientId,
+        googleCredential: createCredential('Test', 'Test', email),
+        createUser: true,
+      });
+    expect(res).toHaveStatus(200);
+    expect(res.body.login).toBeDefined();
+    expect(res.body.emailVerificationRequired).toBeUndefined();
+  });
+
+  test('Skip email verification on sign in', async () => {
+    getConfig().requireVerifiedEmailForProjectCreation = true;
+    const email = 'new-google-' + randomUUID() + '@example.com';
+    await systemRepo.createResource<User>({
+      resourceType: 'User',
+      firstName: 'Google',
+      lastName: 'Google',
+      email,
+    });
+
+    // Signing in is not registering, so an unverified user is not re-sent the link
+    const res = await request(app)
+      .post('/auth/google')
+      .type('json')
+      .send({
+        projectId: 'new',
+        googleClientId: getConfig().googleClientId,
+        googleCredential: createCredential('Test', 'Test', email),
+      });
+    expect(res).toHaveStatus(200);
+    expect(res.body.login).toBeDefined();
+    expect(res.body.emailVerificationRequired).toBeUndefined();
+  });
+
+  test('Skip email verification for existing project', async () => {
+    getConfig().requireVerifiedEmailForProjectCreation = true;
+    const project = await withTestContext(
+      async () =>
+        (
+          await registerNew({
+            firstName: 'Google',
+            lastName: 'Google',
+            projectName: 'Google Email Verification',
+            email: `google-owner${randomUUID()}@example.com`,
+            password: 'password!@#',
+          })
+        ).project
+    );
+
+    // Verification only gates new project creation, so joining an existing project
+    // does not send a link
+    const email = 'new-google-' + randomUUID() + '@example.com';
+    const res = await request(app)
+      .post('/auth/google')
+      .type('json')
+      .send({
+        projectId: project.id,
+        googleClientId: getConfig().googleClientId,
+        googleCredential: createCredential('Test', 'Test', email),
+        createUser: true,
+      });
+    expect(res).toHaveStatus(200);
+    expect(res.body.emailVerificationRequired).toBeUndefined();
   });
 
   test('Require Google auth', async () => {

--- a/packages/server/src/auth/google.test.ts
+++ b/packages/server/src/auth/google.test.ts
@@ -275,6 +275,62 @@ describe('Google Auth', () => {
     expect(res.body.emailVerificationRequired).toBeUndefined();
   });
 
+  test('Verify existing user when Google verified email', async () => {
+    getConfig().requireVerifiedEmailForProjectCreation = true;
+    const email = 'new-google-' + randomUUID() + '@example.com';
+    await systemRepo.createResource<User>({
+      resourceType: 'User',
+      firstName: 'Google',
+      lastName: 'Google',
+      email,
+    });
+
+    const res = await request(app)
+      .post('/auth/google')
+      .type('json')
+      .send({
+        projectId: 'new',
+        googleClientId: getConfig().googleClientId,
+        googleCredential: createCredential('Test', 'Test', email, undefined, true),
+        createUser: true,
+      });
+    expect(res).toHaveStatus(200);
+    expect(res.body.login).toBeDefined();
+    expect(res.body.emailVerificationRequired).toBeUndefined();
+
+    // An account that predates the claim is upgraded rather than left unverified
+    const user = await getUserByEmail(email, undefined);
+    expect(user?.emailVerified).toBe(true);
+  });
+
+  test('Do not un-verify a user when Google reports unverified', async () => {
+    getConfig().requireVerifiedEmailForProjectCreation = true;
+    const email = 'new-google-' + randomUUID() + '@example.com';
+    await systemRepo.createResource<User>({
+      resourceType: 'User',
+      firstName: 'Google',
+      lastName: 'Google',
+      email,
+      emailVerified: true,
+    });
+
+    const res = await request(app)
+      .post('/auth/google')
+      .type('json')
+      .send({
+        projectId: 'new',
+        googleClientId: getConfig().googleClientId,
+        googleCredential: createCredential('Test', 'Test', email, undefined, false),
+        createUser: true,
+      });
+    expect(res).toHaveStatus(200);
+    expect(res.body.emailVerificationRequired).toBeUndefined();
+
+    // A Medplum verification outranks a false claim and is never downgraded
+    const user = await getUserByEmail(email, undefined);
+    expect(user?.emailVerified).toBe(true);
+  });
+
   test('Skip email verification on sign in', async () => {
     getConfig().requireVerifiedEmailForProjectCreation = true;
     const email = 'new-google-' + randomUUID() + '@example.com';

--- a/packages/server/src/auth/google.test.ts
+++ b/packages/server/src/auth/google.test.ts
@@ -208,7 +208,7 @@ describe('Google Auth', () => {
     expect(user).toBeDefined();
   });
 
-  test('Require email verification for new project', async () => {
+  test('Require email verification when Google has not verified email', async () => {
     getConfig().requireVerifiedEmailForProjectCreation = true;
     const email = 'new-google-' + randomUUID() + '@example.com';
     const res = await request(app)
@@ -217,13 +217,37 @@ describe('Google Auth', () => {
       .send({
         projectId: 'new',
         googleClientId: getConfig().googleClientId,
-        googleCredential: createCredential('Test', 'Test', email),
+        googleCredential: createCredential('Test', 'Test', email, undefined, false),
         createUser: true,
       });
     expect(res).toHaveStatus(200);
     expect(res.body.login).toBeDefined();
     expect(res.body.code).toBeUndefined();
     expect(res.body.emailVerificationRequired).toBe(true);
+
+    const user = await getUserByEmail(email, undefined);
+    expect(user?.emailVerified).toBe(false);
+  });
+
+  test('Skip email verification when Google verified email', async () => {
+    getConfig().requireVerifiedEmailForProjectCreation = true;
+    const email = 'new-google-' + randomUUID() + '@example.com';
+    const res = await request(app)
+      .post('/auth/google')
+      .type('json')
+      .send({
+        projectId: 'new',
+        googleClientId: getConfig().googleClientId,
+        googleCredential: createCredential('Test', 'Test', email, undefined, true),
+        createUser: true,
+      });
+    expect(res).toHaveStatus(200);
+    expect(res.body.login).toBeDefined();
+    expect(res.body.emailVerificationRequired).toBeUndefined();
+
+    // Google's assertion is accepted, so the user can create a project immediately
+    const user = await getUserByEmail(email, undefined);
+    expect(user?.emailVerified).toBe(true);
   });
 
   test('Skip email verification for verified user', async () => {
@@ -609,6 +633,18 @@ describe('Google Auth', () => {
   });
 });
 
-function createCredential(firstName: string, lastName: string, email: string, picture?: string): string {
-  return JSON.stringify({ given_name: firstName, family_name: lastName, email, picture });
+function createCredential(
+  firstName: string,
+  lastName: string,
+  email: string,
+  picture?: string,
+  emailVerified?: boolean
+): string {
+  return JSON.stringify({
+    given_name: firstName,
+    family_name: lastName,
+    email,
+    picture,
+    email_verified: emailVerified,
+  });
 }

--- a/packages/server/src/auth/google.ts
+++ b/packages/server/src/auth/google.ts
@@ -118,6 +118,10 @@ export async function googleHandler(req: Request, res: Response): Promise<void> 
       firstName: claims.given_name,
       lastName: claims.family_name,
       email,
+      // Google has already established that the user owns this address, so accept its
+      // assertion rather than asking for a second proof. Anything but a verified claim
+      // is falsy here and falls through to the email verification below.
+      emailVerified: claims.email_verified,
       project: projectId && projectId !== 'new' ? { reference: 'Project/' + projectId } : undefined,
     });
   }

--- a/packages/server/src/auth/google.ts
+++ b/packages/server/src/auth/google.ts
@@ -124,6 +124,11 @@ export async function googleHandler(req: Request, res: Response): Promise<void> 
       emailVerified: claims.email_verified,
       project: projectId && projectId !== 'new' ? { reference: 'Project/' + projectId } : undefined,
     });
+  } else if (claims.email_verified && !user.emailVerified) {
+    // Accept Google's assertion for accounts that predate it too, so a user invited or
+    // provisioned before this is not left permanently unverified. Only ever upgrades: a
+    // user who verified with Medplum is never downgraded by a false or missing claim.
+    user = await getGlobalSystemRepo().updateResource<User>({ ...user, emailVerified: true });
   }
 
   const login = await tryLogin({

--- a/packages/server/src/auth/google.ts
+++ b/packages/server/src/auth/google.ts
@@ -15,6 +15,7 @@ import type { GoogleCredentialClaims } from '../oauth/utils';
 import { getUserByEmail, tryLogin } from '../oauth/utils';
 import { makeValidationMiddleware } from '../util/validator';
 import { isExternalAuth } from './method';
+import { sendVerificationEmail } from './newuser';
 import { getProjectIdByClientId, sendLoginResult } from './utils';
 
 /*
@@ -100,8 +101,8 @@ export async function googleHandler(req: Request, res: Response): Promise<void> 
     return;
   }
 
-  const existingUser = await getUserByEmail(email, projectId);
-  if (!existingUser) {
+  let user = await getUserByEmail(email, projectId);
+  if (!user) {
     if (!req.body.createUser) {
       sendOutcome(res, badRequest('User not found'));
       return;
@@ -112,7 +113,7 @@ export async function googleHandler(req: Request, res: Response): Promise<void> 
       return;
     }
     const systemRepo = getGlobalSystemRepo();
-    await systemRepo.createResource<User>({
+    user = await systemRepo.createResource<User>({
       resourceType: 'User',
       firstName: claims.given_name,
       lastName: claims.family_name,
@@ -138,6 +139,18 @@ export async function googleHandler(req: Request, res: Response): Promise<void> 
     allowNoMembership: req.body.createUser || projectId === 'new',
     pictureUrl: claims.picture,
   });
+
+  if (
+    getConfig().requireVerifiedEmailForProjectCreation &&
+    req.body.createUser &&
+    projectId === 'new' &&
+    !user.emailVerified
+  ) {
+    await sendVerificationEmail(user, login);
+    res.status(200).json({ login: login.id, emailVerificationRequired: true });
+    return;
+  }
+
   await sendLoginResult(res, login);
 }
 

--- a/packages/server/src/auth/newproject.test.ts
+++ b/packages/server/src/auth/newproject.test.ts
@@ -387,7 +387,9 @@ describe('New project', () => {
       projectName: 'Hamilton Project',
     });
     expect(res2).toHaveStatus(400);
-    expect(res2.body).toMatchObject(badRequest('Email verification is required to create a project. Check your email for a verification link.'));
+    expect(res2.body).toMatchObject(
+      badRequest('Email verification is required to create a project. Check your email for a verification link.')
+    );
   });
 
   test('Require verified email - sends a verification link', async () => {

--- a/packages/server/src/auth/newproject.test.ts
+++ b/packages/server/src/auth/newproject.test.ts
@@ -387,7 +387,42 @@ describe('New project', () => {
       projectName: 'Hamilton Project',
     });
     expect(res2).toHaveStatus(400);
-    expect(res2.body).toMatchObject(badRequest('Email verification is required to create a project'));
+    expect(res2.body).toMatchObject(badRequest('Email verification is required to create a project. Check your email for a verification link.'));
+  });
+
+  test('Require verified email - sends a verification link', async () => {
+    getConfig().requireVerifiedEmailForProjectCreation = true;
+    const sendEmailSpy = vi.spyOn(emailModule, 'sendEmail').mockResolvedValue(undefined);
+    try {
+      const email = `alex${randomUUID()}@example.com`;
+      const res1 = await request(app).post('/auth/newuser').type('json').send({
+        firstName: 'Alexander',
+        lastName: 'Hamilton',
+        email,
+        password: 'password!@#',
+        recaptchaToken: 'xyz',
+        codeChallenge: 'xyz',
+        codeChallengeMethod: 'plain',
+      });
+      expect(res1).toHaveStatus(200);
+      sendEmailSpy.mockClear();
+
+      // Blocked, but the user is now told how to unblock themselves
+      const res2 = await request(app).post('/auth/newproject').type('json').send({
+        login: res1.body.login,
+        projectName: 'Hamilton Project',
+      });
+      expect(res2).toHaveStatus(400);
+
+      const verifyCall = sendEmailSpy.mock.calls.find((call) => call[1]?.subject === 'Medplum Email Verification');
+      expect(verifyCall).toBeDefined();
+      expect(verifyCall?.[1].to).toBe(email);
+      // The link returns to the registration flow carrying this login, so the user
+      // resumes project creation instead of starting over
+      expect(verifyCall?.[1].text).toContain('verifyemail/');
+    } finally {
+      sendEmailSpy.mockRestore();
+    }
   });
 
   test('Require verified email - allowed', async () => {

--- a/packages/server/src/auth/newproject.ts
+++ b/packages/server/src/auth/newproject.ts
@@ -9,6 +9,7 @@ import { createProject } from '../fhir/operations/projectinit';
 import { sendOutcome } from '../fhir/outcomes';
 import { getGlobalSystemRepo } from '../fhir/repo';
 import { setLoginMembership } from '../oauth/utils';
+import { sendVerificationEmail } from './newuser';
 import { makeValidationMiddleware } from '../util/validator';
 import { sendLoginResult } from './utils';
 import { sendWelcomeEmail } from './welcomeemail';
@@ -49,7 +50,15 @@ export async function newProjectHandler(req: Request, res: Response): Promise<vo
   const user = await systemRepo.readReference<User>(login.user as Reference<User>);
 
   if (config.requireVerifiedEmailForProjectCreation && !user.emailVerified) {
-    sendOutcome(res, badRequest('Email verification is required to create a project'));
+    // This is the only gate on `emailVerified`, and users reach it by paths that never
+    // offer a verification link: an existing member creating a second project arrives
+    // via the login status endpoint, not registration. Send the link here so the
+    // requirement is actionable rather than a dead end.
+    await sendVerificationEmail(user, login);
+    sendOutcome(
+      res,
+      badRequest('Email verification is required to create a project. Check your email for a verification link.')
+    );
     return;
   }
 

--- a/packages/server/src/auth/newproject.ts
+++ b/packages/server/src/auth/newproject.ts
@@ -9,8 +9,8 @@ import { createProject } from '../fhir/operations/projectinit';
 import { sendOutcome } from '../fhir/outcomes';
 import { getGlobalSystemRepo } from '../fhir/repo';
 import { setLoginMembership } from '../oauth/utils';
-import { sendVerificationEmail } from './newuser';
 import { makeValidationMiddleware } from '../util/validator';
+import { sendVerificationEmail } from './newuser';
 import { sendLoginResult } from './utils';
 import { sendWelcomeEmail } from './welcomeemail';
 

--- a/packages/server/src/auth/newuser.ts
+++ b/packages/server/src/auth/newuser.ts
@@ -149,7 +149,7 @@ export async function createUser(request: NewUserRequest): Promise<WithId<User>>
   return result;
 }
 
-async function sendVerificationEmail(user: WithId<User>, login: WithId<Login>): Promise<void> {
+export async function sendVerificationEmail(user: WithId<User>, login: WithId<Login>): Promise<void> {
   const redirectUri = concatUrls(getConfig().appBaseUrl, `register?login=${login.id}`);
   const systemRepo = getGlobalSystemRepo();
   const { id, secret } = await verifyEmail(systemRepo, user, redirectUri);


### PR DESCRIPTION
- Google register path now sends the verification email
- Accept Google's email_verified claim
- Emails are now sent when existing users create a new project but aren't email verified
- Automatically upgrade existing google auth users who are not email verified