### PR TITLE
feat(server): add FHIRcast subscriber name tracking

### DIFF
--- a/packages/core/src/client-fhircast.test.ts
+++ b/packages/core/src/client-fhircast.test.ts
@@ -47,6 +47,30 @@ describe('FHIRcast', () => {
       expect(subRequest.endpoint?.startsWith('ws')).toBeTruthy();
     });
 
+    test('Valid subscription request with subscriber name', async () => {
+      const fetch = mockFetch(200, { 'hub.channel.endpoint': 'wss://api.medplum.com/ws/fhircast/def456' });
+      const client = new MedplumClient({ fetch });
+
+      const topic = 'abc123';
+      const events = ['Patient-open'] as FhircastEventName[];
+      const expectedSubRequest = {
+        mode: 'subscribe',
+        channelType: 'websocket',
+        topic,
+        events,
+        subscriberName: 'Acme Viewer',
+      } satisfies PendingSubscriptionRequest;
+
+      const subRequest = await client.fhircastSubscribe(topic, events, 'Acme Viewer');
+      expect(fetch).toHaveBeenCalledWith(
+        'https://api.medplum.com/fhircast/STU3',
+        expect.objectContaining<RequestInit>({
+          body: serializeFhircastSubscriptionRequest(expectedSubRequest),
+        })
+      );
+      expect(subRequest).toStrictEqual(expect.objectContaining<PendingSubscriptionRequest>(expectedSubRequest));
+    });
+
     test('Invalid subscription request', async () => {
       const fetch = mockFetch(500, { error: 'how did we make it here?' });
       const client = new MedplumClient({ fetch });

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -4484,9 +4484,15 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * @category FHIRcast
    * @param topic - The topic to publish to. Usually a UUID.
    * @param events - An array of event names to listen for.
+   * @param subscriberName - An optional description of this subscriber. The Hub names a subscriber
+   * that leaves this unset after the identity it subscribed with.
    * @returns A `Promise` that resolves once the request completes, or rejects if it fails.
    */
-  async fhircastSubscribe(topic: string, events: FhircastEventName[]): Promise<SubscriptionRequest> {
+  async fhircastSubscribe(
+    topic: string,
+    events: FhircastEventName[],
+    subscriberName?: string
+  ): Promise<SubscriptionRequest> {
     if (!(typeof topic === 'string' && topic !== '')) {
       throw new OperationOutcomeError(validationError('Invalid topic provided. Topic must be a valid string.'));
     }
@@ -4503,6 +4509,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
       mode: 'subscribe',
       topic,
       events,
+      subscriberName,
     } as PendingSubscriptionRequest;
 
     const body = await this.post<{ 'hub.channel.endpoint': string }>(

--- a/packages/core/src/fhircast/index.test.ts
+++ b/packages/core/src/fhircast/index.test.ts
@@ -156,6 +156,17 @@ describe('validateFhircastSubscriptionRequest', () => {
     ).toBe(false);
 
     expect(
+      validateFhircastSubscriptionRequest({
+        mode: 'subscribe',
+        topic: 'abc123',
+        channelType: 'websocket',
+        events: ['Patient-open'],
+        // @ts-expect-error subscriberName needs to be a string
+        subscriberName: 12,
+      })
+    ).toBe(false);
+
+    expect(
       // @ts-expect-error subscriptionRequest must be an object
       validateFhircastSubscriptionRequest(undefined)
     ).toBe(false);
@@ -211,6 +222,36 @@ describe('serializeFhircastSubscriptionRequest', () => {
         topic: 'abc123',
         events: ['Patient-open'],
         endpoint: 'wss://abc.com/hub',
+      })
+    ).toStrictEqual(
+      'hub.channel.type=websocket&hub.mode=unsubscribe&hub.topic=abc123&hub.channel.endpoint=wss%3A%2F%2Fabc.com%2Fhub'
+    );
+  });
+
+  test('Valid subscription request with subscriber name', () => {
+    expect(
+      serializeFhircastSubscriptionRequest({
+        mode: 'subscribe',
+        channelType: 'websocket',
+        topic: 'abc123',
+        events: ['Patient-open'],
+        subscriberName: 'Acme Viewer',
+      })
+    ).toStrictEqual(
+      'hub.channel.type=websocket&hub.mode=subscribe&hub.topic=abc123&hub.events=Patient-open&subscriber.name=Acme+Viewer'
+    );
+  });
+
+  // The Hub named the subscription when it was created, so an unsubscribe has no reason to repeat it
+  test('Valid unsubscribe request omits the subscriber name', () => {
+    expect(
+      serializeFhircastSubscriptionRequest({
+        mode: 'unsubscribe',
+        channelType: 'websocket',
+        topic: 'abc123',
+        events: ['Patient-open'],
+        endpoint: 'wss://abc.com/hub',
+        subscriberName: 'Acme Viewer',
       })
     ).toStrictEqual(
       'hub.channel.type=websocket&hub.mode=unsubscribe&hub.topic=abc123&hub.channel.endpoint=wss%3A%2F%2Fabc.com%2Fhub'

--- a/packages/core/src/fhircast/index.ts
+++ b/packages/core/src/fhircast/index.ts
@@ -153,6 +153,12 @@ export type SubscriptionRequest = {
   events: FhircastEventName[];
   topic: string;
   endpoint: string;
+  /**
+   * An optional description of this subscriber, sent as `subscriber.name`. The Hub names a
+   * subscriber that leaves this unset after the identity it subscribed with.
+   * Source: https://build.fhir.org/ig/HL7/fhircast-docs/2-4-Subscribing.html
+   */
+  subscriberName?: string;
 };
 
 export type FhircastPatientContext = { key: 'patient'; resource: Patient };
@@ -293,7 +299,7 @@ export function serializeFhircastSubscriptionRequest(
     );
   }
 
-  const { channelType, mode, topic, events } = subscriptionRequest;
+  const { channelType, mode, topic, events, subscriberName } = subscriptionRequest;
 
   const formattedSubRequest = {
     'hub.channel.type': channelType,
@@ -302,8 +308,13 @@ export function serializeFhircastSubscriptionRequest(
   } as Record<string, string>;
 
   if (mode === 'subscribe') {
-    // An unsubscribe cancels an endpoint, and the Hub already holds the events it was issued for
+    // An unsubscribe cancels an endpoint, and the Hub already holds the events and name it was
+    // issued for
     formattedSubRequest['hub.events'] = events.join(',');
+    if (subscriberName) {
+      // The one subscribe parameter the spec does not prefix with `hub.`
+      formattedSubRequest['subscriber.name'] = subscriberName;
+    }
   }
 
   if (isCompletedSubscriptionRequest(subscriptionRequest)) {
@@ -326,8 +337,11 @@ export function validateFhircastSubscriptionRequest(
   if (typeof subscriptionRequest !== 'object') {
     return false;
   }
-  const { channelType, mode, topic, events } = subscriptionRequest;
+  const { channelType, mode, topic, events, subscriberName } = subscriptionRequest;
   if (!(channelType && mode && topic && events)) {
+    return false;
+  }
+  if (subscriberName !== undefined && typeof subscriberName !== 'string') {
     return false;
   }
   if (typeof topic !== 'string') {

--- a/packages/docs/docs/fhircast/index.md
+++ b/packages/docs/docs/fhircast/index.md
@@ -23,6 +23,16 @@ FHIRcast is a **lightweight, topic-based publish/subscribe protocol** that enabl
 4. **Notification**: Subscribers to that topic receive the event, which includes the new context (e.g., the Patient FHIR resource, which contains information like the patient's ID, name, date of birth, etc.).
 5. **Synchronization**: Upon receiving the event, the subscriber application can then update its own display or internal state to reflect the new context.
 
+## Naming a Subscriber
+
+A subscribe request may carry an optional [`subscriber.name`](https://build.fhir.org/ig/HL7/fhircast-docs/2-4-Subscribing.html) describing the subscribing application. It is the one subscribe parameter the spec does not prefix with `hub.`, and it is what identifies a subscriber in a `syncerror` when an event is refused or cannot be delivered.
+
+```ts
+await medplum.fhircastSubscribe(topic, ['Patient-open'], 'Acme Viewer');
+```
+
+A subscriber that does not name itself is named by the hub after the identity it subscribed with: the `ClientApplication` the access token was issued to, or else the name on the subscriber's own profile resource. Several applications commonly share a topic, so this is what tells them apart. On the STU2 hub the resulting name is returned as `hub.subscriber` in the subscription confirmation; STU3 dropped that field from the confirmation.
+
 ## Use Cases
 
 - **EHR to SMART App Integration**: An EHR system publishes Patient-open events, and a SMART on FHIR application automatically loads the newly selected patient's data.

--- a/packages/server/src/fhircast/routes.test.ts
+++ b/packages/server/src/fhircast/routes.test.ts
@@ -25,7 +25,7 @@ import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
 import { getCacheRedis } from '../redis';
-import { createTestProject, withTestContext } from '../test.setup';
+import { addTestUser, createTestProject, withTestContext } from '../test.setup';
 import type { EventCategory } from './routes';
 import { getEventCategory } from './routes';
 import {
@@ -267,12 +267,82 @@ describe('FHIRcast routes', () => {
       topic,
       events: ['Patient-open'],
       version: 'STU3',
+      subscriberName: 'Test Client Application',
     });
     await expect(getEndpointSubscription(extractEndpoint(endpoint2) as string)).resolves.toStrictEqual({
       projectId: project.id,
       topic,
       events: ['ImagingStudy-open', 'ImagingStudy-close'],
       version: 'STU3',
+      subscriberName: 'Test Client Application',
+    });
+  });
+
+  describe('subscriber.name', () => {
+    // Returns the name the Hub recorded for a subscription made as the given identity
+    const subscribeAs = async (auth: string, body?: Record<string, string>): Promise<string | undefined> => {
+      const res = await request(server)
+        .post(STU3_BASE_ROUTE)
+        .set('Content-Type', ContentType.FORM_URL_ENCODED)
+        .set('Authorization', auth)
+        .send(
+          new URLSearchParams({
+            'hub.channel.type': 'websocket',
+            'hub.mode': 'subscribe',
+            'hub.topic': randomUUID(),
+            'hub.events': 'Patient-open',
+            ...body,
+          }).toString()
+        );
+      expect(res).toHaveStatus(202);
+      const endpoint = extractEndpoint(res.body['hub.channel.endpoint']) as string;
+      return (await getEndpointSubscription(endpoint))?.subscriberName;
+    };
+
+    test('A subscriber that names itself is remembered by that name', async () => {
+      await expect(subscribeAs('Bearer ' + accessToken, { 'subscriber.name': 'Acme Viewer' })).resolves.toStrictEqual(
+        'Acme Viewer'
+      );
+    });
+
+    // These tests authenticate as a `ClientApplication` named 'Test Client Application'
+    test('A subscriber that does not name itself takes the name of the client it subscribed with', async () => {
+      await expect(subscribeAs('Bearer ' + accessToken)).resolves.toStrictEqual('Test Client Application');
+    });
+
+    test('A name that is only whitespace names no subscriber', async () => {
+      await expect(subscribeAs('Bearer ' + accessToken, { 'subscriber.name': '   ' })).resolves.toStrictEqual(
+        'Test Client Application'
+      );
+    });
+
+    // Basic auth mints a login naming no client, so the name comes off the membership's profile
+    test('A subscriber using basic auth takes the name of its client', async () => {
+      const { client } = await withTestContext(() => createTestProject({ withClient: true }));
+      const basicAuth = 'Basic ' + Buffer.from(client.id + ':' + client.secret).toString('base64');
+      await expect(subscribeAs(basicAuth)).resolves.toStrictEqual('Test Client Application');
+    });
+
+    // A user signing in directly went through no client, so the Hub falls back to their profile
+    test('A subscriber authenticated as a user takes the name on their profile', async () => {
+      const { accessToken: userAccessToken } = await addTestUser(project);
+      await expect(subscribeAs('Bearer ' + userAccessToken)).resolves.toStrictEqual('Bob Jones');
+    });
+
+    test.each([['a'.repeat(257)], [{ name: 'Acme Viewer' }]])('A name of %j is rejected', async (subscriberName) => {
+      const res = await request(server)
+        .post(STU3_BASE_ROUTE)
+        .set('Content-Type', ContentType.JSON)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .send({
+          'hub.channel.type': 'websocket',
+          'hub.mode': 'subscribe',
+          'hub.topic': randomUUID(),
+          'hub.events': 'Patient-open',
+          'subscriber.name': subscriberName,
+        });
+      expect(res).toHaveStatus(400);
+      expect(res.body.issue[0].details.text).toStrictEqual('Invalid subscriber.name');
     });
   });
 

--- a/packages/server/src/fhircast/routes.ts
+++ b/packages/server/src/fhircast/routes.ts
@@ -27,6 +27,7 @@ import type { Request, Response } from 'express';
 import { Router } from 'express';
 import { body, oneOf, validationResult } from 'express-validator';
 import { getConfig } from '../config/loader';
+import type { AuthenticatedRequestContext } from '../context';
 import { getAuthenticatedContext } from '../context';
 import { invalidRequest, sendOutcome } from '../fhir/outcomes';
 import { getLogger } from '../logger';
@@ -215,6 +216,23 @@ function getFhircastVersion(req: Request): FhircastVersion {
   return req.baseUrl.includes(FhircastVersion.STU2) ? FhircastVersion.STU2 : FhircastVersion.STU3;
 }
 
+/** The Hub stores a subscriber's name and hands it back on the wire, so it is bounded. */
+const MAX_SUBSCRIBER_NAME_LENGTH = 256;
+
+/**
+ * Names a subscriber that did not name itself, after the identity it subscribed with.
+ *
+ * The `ClientApplication` a token was issued to comes first, since it names the application rather
+ * than the person in front of it. A login that went through no client falls back to the
+ * membership's profile -- which under HTTP Basic auth is the client itself. Both displays are
+ * `getDisplayString` of what they reference, so naming a subscriber costs no reads.
+ * @param ctx - The authenticated context of the subscribe request.
+ * @returns A description of the subscriber, or `undefined` if its identity has no name.
+ */
+function getDefaultSubscriberName(ctx: AuthenticatedRequestContext): string | undefined {
+  return ctx.login.client?.display ?? ctx.membership.profile.display;
+}
+
 async function handleSubscriptionRequest(req: Request, res: Response): Promise<void> {
   const ctx = getAuthenticatedContext();
 
@@ -250,6 +268,18 @@ async function handleSubscriptionRequest(req: Request, res: Response): Promise<v
     return;
   }
 
+  // `subscriber.name` is the one subscribe parameter the spec does not prefix with `hub.`
+  // Source: https://build.fhir.org/ig/HL7/fhircast-docs/2-4-Subscribing.html
+  const requestedName = singularize(req.body['subscriber.name']);
+  if (
+    requestedName !== undefined &&
+    !(typeof requestedName === 'string' && requestedName.length <= MAX_SUBSCRIBER_NAME_LENGTH)
+  ) {
+    sendOutcome(res, badRequest('Invalid subscriber.name'));
+    return;
+  }
+  const subscriberName = requestedName?.trim() || getDefaultSubscriberName(ctx);
+
   // Every subscribe request gets its own endpoint, so that the Hub can tell apart subscribers
   // sharing a topic and remember the events each one asked for.
   const endpoint = generateId();
@@ -259,11 +289,13 @@ async function handleSubscriptionRequest(req: Request, res: Response): Promise<v
       topic,
       events,
       version: getFhircastVersion(req),
+      subscriberName,
     });
   } catch (err) {
     sendOutcome(res, serverError(new Error('Failed to create subscription for topic')));
     getLogger().error(`[FHIRcast]: Received error while creating subscription for topic`, {
       topic,
+      subscriberName,
       error: normalizeErrorString(err),
     });
     return;

--- a/packages/server/src/fhircast/utils.test.ts
+++ b/packages/server/src/fhircast/utils.test.ts
@@ -171,6 +171,7 @@ describe('FHIRcast Utils', () => {
         topic: generateId(),
         events: ['Patient-open'],
         version: 'STU3',
+        subscriberName: 'Acme Viewer',
       };
 
       await expect(getEndpointSubscription(endpoint)).resolves.toBeUndefined();
@@ -192,10 +193,27 @@ describe('FHIRcast Utils', () => {
       [JSON.stringify({ projectId: generateId() })],
       [JSON.stringify({ projectId: generateId(), topic: generateId(), events: [42], version: 'STU3' })],
       [JSON.stringify({ projectId: generateId(), topic: generateId(), events: [], version: 'STU4' })],
+      [
+        JSON.stringify({
+          projectId: generateId(),
+          topic: generateId(),
+          events: [],
+          version: 'STU3',
+          subscriberName: 42,
+        }),
+      ],
     ])('A cached subscription of %j reads as no subscription', async (cached) => {
       const endpoint = generateId();
       await getCacheRedis().set(getEndpointSubscriptionKey(endpoint), cached);
       await expect(getEndpointSubscription(endpoint)).resolves.toBeUndefined();
+    });
+
+    // A subscription stored before the Hub recorded subscriber names is still a subscription
+    test('A cached subscription that names no subscriber still reads back', async () => {
+      const endpoint = generateId();
+      const subscription = { projectId: generateId(), topic: generateId(), events: ['Patient-open'], version: 'STU3' };
+      await getCacheRedis().set(getEndpointSubscriptionKey(endpoint), JSON.stringify(subscription));
+      await expect(getEndpointSubscription(endpoint)).resolves.toStrictEqual(subscription);
     });
   });
 

--- a/packages/server/src/fhircast/utils.ts
+++ b/packages/server/src/fhircast/utils.ts
@@ -39,6 +39,11 @@ export type FhircastSubscription = {
   topic: string;
   events: string[];
   version: FhircastVersion;
+  /**
+   * A description of the subscriber, from `subscriber.name` or else the identity it subscribed
+   * with. Optional because a subscription stored before the Hub recorded names has none.
+   */
+  subscriberName?: string;
 };
 
 export function getEndpointSubscriptionKey(endpoint: string): string {
@@ -85,7 +90,8 @@ function isFhircastSubscription(subscription: unknown): subscription is Fhircast
     typeof candidate.topic === 'string' &&
     Array.isArray(candidate.events) &&
     candidate.events.every((event) => typeof event === 'string') &&
-    Object.values(FhircastVersion).includes(candidate.version)
+    Object.values(FhircastVersion).includes(candidate.version) &&
+    (candidate.subscriberName === undefined || typeof candidate.subscriberName === 'string')
   );
 }
 

--- a/packages/server/src/ws/fhircast.test.ts
+++ b/packages/server/src/ws/fhircast.test.ts
@@ -237,8 +237,36 @@ describe('FHIRcast WebSocket', () => {
             'hub.lease_seconds': 3600,
             'hub.mode': 'subscribe',
             'hub.secret': '',
-            'hub.subscriber': '',
+            'hub.subscriber': 'Test Client Application',
             'hub.topic': topic,
+          })
+          .close()
+          .expectClosed();
+      }));
+
+    // STU3 has no field to carry it, so the name a subscriber gave only comes back on STU2
+    test('STU2 connection verification names the subscriber', () =>
+      withTestContext(async () => {
+        const topic = randomUUID();
+
+        const res = await request(server)
+          .post('/fhircast/STU2')
+          .set('Content-Type', ContentType.FORM_URL_ENCODED)
+          .set('Authorization', 'Bearer ' + accessToken)
+          .send(
+            serializeFhircastSubscriptionRequest({
+              mode: 'subscribe',
+              channelType: 'websocket',
+              topic,
+              events: ['Patient-open'],
+              subscriberName: 'Acme Viewer',
+            })
+          );
+
+        await request(server)
+          .ws(new URL(res.body['hub.channel.endpoint']).pathname)
+          .expectJson((obj: Record<string, unknown>) => {
+            expect(obj['hub.subscriber']).toStrictEqual('Acme Viewer');
           })
           .close()
           .expectClosed();

--- a/packages/server/src/ws/fhircast.ts
+++ b/packages/server/src/ws/fhircast.ts
@@ -161,7 +161,7 @@ export async function handleFhircastConnection(socket: WebSocket, request: Incom
   // except for additional SUBSCRIBE, PSUBSCRIBE, UNSUBSCRIBE and PUNSUBSCRIBE commands.
   const redisSubscriber = getPubSubRedisSubscriber();
 
-  const { projectId, topic, events, version } = subscription;
+  const { projectId, topic, events, version, subscriberName } = subscription;
   const projectAndTopic = `${projectId}:${topic}`;
 
   // Bind all listeners (and topic bookkeeping) before awaiting the subscribe, so that
@@ -240,12 +240,12 @@ export async function handleFhircastConnection(socket: WebSocket, request: Incom
   };
   if (version !== FhircastVersion.STU3) {
     // STU3 dropped these, but STU2 clients still expect them
-    // TODO: Fill in these properties
+    // TODO: Fill in the remaining properties
     Object.assign(confirmation, {
       'hub.callback': '',
       'hub.channel': '',
       'hub.secret': '',
-      'hub.subscriber': '',
+      'hub.subscriber': subscriberName ?? '',
     });
   }
   socket.send(JSON.stringify(confirmation), { binary: false });


### PR DESCRIPTION
The FHIRcast spec defines an optional [`subscriber.name`](https://build.fhir.org/ig/HL7/fhircast-docs/2-4-Subscribing.html) on a subscription request, describing the subscribing application. It is the one subscribe parameter the spec does not prefix with `hub.`, and it is what names a subscriber in a `syncerror` when an event is refused or cannot be delivered.

The Hub ignored it: `handleSubscriptionRequest` read only `hub.channel.type`, `hub.mode`, `hub.topic` and `hub.events`, so a client sending `subscriber.name` had it silently dropped. Meanwhile the STU2 subscription confirmation carried a hardcoded empty `'hub.subscriber': ''` with a `TODO`. This fills both ends.

## Server

- `fhircast/utils.ts` — `FhircastSubscription` gains an optional `subscriberName`. The type guard accepts it as optional, so subscriptions already in Redis when this deploys keep validating rather than being discarded as malformed and denying live sockets.
- `fhircast/routes.ts` — `handleSubscriptionRequest` reads `subscriber.name` through `singularize` (a form body repeating the key would otherwise yield an array), bounds it at 256 characters since the Hub stores it and hands it back on the wire, and falls back to the identity the caller subscribed with.
- `ws/fhircast.ts` — the STU2 confirmation now carries the recorded name in `hub.subscriber`. STU3 dropped that field from the confirmation, so it is unchanged.

## Naming a subscriber that did not name itself

`getDefaultSubscriberName` resolves to the `ClientApplication` a token was issued to, else the membership's profile. The client comes first because it names the application driving the subscription rather than the person in front of it.

Three auth shapes land in three places, and all are covered by tests:

| Auth | Result |
| --- | --- |
| Bearer token issued to a client | `login.client.display` — the `ClientApplication` name |
| HTTP Basic auth | Mints a `Login` with no `client` at all, so the name comes off the membership profile — which under Basic auth **is** the `ClientApplication` |
| User signing in directly | The name on their own profile resource |

Both displays are `getDisplayString` of the resource they reference, computed when the reference was built, so naming a subscriber costs no extra reads.

## Core

`SubscriptionRequest` gains an optional `subscriberName`, serialized as `subscriber.name` on subscribe only — an unsubscribe cancels an endpoint the Hub already named. `MedplumClient.fhircastSubscribe` takes it as a trailing third argument, so existing two-argument callers are unaffected.

```ts
await medplum.fhircastSubscribe(topic, ['Patient-open'], 'Acme Viewer');
```

## Out of scope

Hub-generated `SyncError` events. Medplum has no path today where the Hub refuses or fails to deliver an event, so there is nothing yet to name a subscriber in — this puts the name in place for when there is.

## Testing

111 server tests (`src/fhircast`, `src/ws/fhircast.test.ts`) and 48 core tests pass; eslint, prettier and `tsc --noEmit` are clean.

Closes #10038
