### PR TITLE
test(server): fix flaky multiple-ProjectMemberships subscription test

### DIFF
--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -2745,30 +2745,32 @@ describe('Subscription Worker', () => {
           resource: [{ resourceType: 'Patient', criteria: `Patient?_compartment=${allowedOrgId}` }],
         });
 
-        // Create the "no access" membership FIRST so that `findProjectMembership` returns
-        // it ahead of the "has access" membership -- this is what makes the
-        // `authorMembershipId` plumbing necessary in the first place.
-        const noAccessMembership = await superAdminRepo.createResource<ProjectMembership>({
+        // Two memberships for the same profile, created without policies: `findProjectMembership`
+        // returns them in no particular order, so which policy goes where is decided after the fact.
+        const membershipTemplate: ProjectMembership = {
           resourceType: 'ProjectMembership',
           user: createReference(client),
           profile: createReference(practitioner),
           project: createReference(wsProject),
+        };
+        const membershipA = await superAdminRepo.createResource<ProjectMembership>(membershipTemplate);
+        const membershipB = await superAdminRepo.createResource<ProjectMembership>(membershipTemplate);
+
+        // Whichever membership the unordered lookup returns first gets the denying policy, so a
+        // worker that fell back to `findProjectMembership` would deny the allowed subscription.
+        const firstFound = await workerUtils.findProjectMembership(wsProject.id, createReference(practitioner));
+        expect([membershipA.id, membershipB.id]).toContain(firstFound?.id);
+        const [noAccessMembership, hasAccessMembership] =
+          firstFound?.id === membershipA.id ? [membershipA, membershipB] : [membershipB, membershipA];
+
+        await superAdminRepo.updateResource<ProjectMembership>({
+          ...noAccessMembership,
           accessPolicy: createReference(noAccessPolicy),
         });
-
-        const hasAccessMembership = await superAdminRepo.createResource<ProjectMembership>({
-          resourceType: 'ProjectMembership',
-          user: createReference(client),
-          profile: createReference(practitioner),
-          project: createReference(wsProject),
+        await superAdminRepo.updateResource<ProjectMembership>({
+          ...hasAccessMembership,
           accessPolicy: createReference(hasAccessPolicy),
         });
-
-        // Sanity check: the unordered membership lookup returns the denying membership
-        // first.  If this ever changes, the rest of the test stops exercising what it
-        // intends to exercise.
-        const firstFound = await workerUtils.findProjectMembership(wsProject.id, createReference(practitioner));
-        expect(firstFound?.id).toStrictEqual(noAccessMembership.id);
 
         // Two WebSocket subscriptions, one bound with each membership.
         const noAccessSub = await wsRepo.createResource<Subscription>({


### PR DESCRIPTION
Fixes #10514

`WebSocket Subscriptions > Uses correct AccessPolicy when author has multiple ProjectMemberships` contained a sanity check asserting that `findProjectMembership` returns the membership that was created first:

```ts
const firstFound = await workerUtils.findProjectMembership(wsProject.id, createReference(practitioner));
expect(firstFound?.id).toStrictEqual(noAccessMembership.id);
```

The lookup is an unordered `searchOne`, so that ordering is not guaranteed and the assertion can flip.

The test still needs the *first-found* membership to be the denying one — that is what makes a worker ignoring `authorMembershipId` fail to notify `hasAccessSub`. So instead of depending on insertion order, both memberships are now created without a policy, the lookup decides which is which, and the policies are assigned afterwards.

Tested: the test passes and the full `WebSocket` describe block passes (20 tests); eslint and prettier are clean.