### PR TITLE
fix: report deleted resources in export and omit empty deleted key (#10479)

### DIFF
--- a/packages/server/src/fhir/bulkdata.test.ts
+++ b/packages/server/src/fhir/bulkdata.test.ts
@@ -52,6 +52,27 @@ describe('Binary', () => {
     });
   });
 
+  test('Omits deleted key when there is nothing to report', async () => {
+    const exportResource = await repo.createResource<BulkDataExport>({
+      resourceType: 'BulkDataExport',
+      status: 'completed',
+      request: 'foo',
+      requestTime: new Date().toISOString(),
+      output: [{ url: 'http://example.com/output', type: 'Patient' }],
+      // No `error` or `deleted` entries -- both should be omitted or empty as appropriate.
+    });
+
+    const initRes = await request(app)
+      .get('/fhir/R4/bulkdata/export/' + exportResource.id)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .set('X-Medplum', 'extended');
+    expect(initRes).toHaveStatus(200);
+    expect(initRes.body.output).toEqual(exportResource.output);
+    expect(initRes.body.error).toEqual([]);
+    expect(initRes.body).not.toHaveProperty('deleted');
+  });
+
   test('Cancellation', async () => {
     const exportResource = await repo.createResource<BulkDataExport>({
       resourceType: 'BulkDataExport',

--- a/packages/server/src/fhir/bulkdata.ts
+++ b/packages/server/src/fhir/bulkdata.ts
@@ -44,13 +44,18 @@ bulkDataRouter.get('/export/:id', async (req: Request, res: Response) => {
     return;
   }
 
+  // Per the Bulk Data Access IG, `deleted` MAY be omitted when there is nothing to report
+  // (e.g. no resources were deleted). Only include the key when it is non-empty so clients
+  // can distinguish "nothing deleted" from "this field was never populated".
+  const deleted = extractOutputParameters(bulkDataExport, 'deleted');
+
   const json = await rewriteAttachments(RewriteMode.PRESIGNED_URL, ctx.repo, {
     transactionTime: bulkDataExport.transactionTime,
     request: bulkDataExport.request,
     requiresAccessToken: false, // Rewritten attachments use presigned S3 URLs and do not require the access token
     output: extractOutputParameters(bulkDataExport, 'output'),
     error: extractOutputParameters(bulkDataExport, 'error'),
-    deleted: extractOutputParameters(bulkDataExport, 'deleted'),
+    ...(deleted.length > 0 ? { deleted } : undefined),
   });
   res.status(200).type(ContentType.JSON).json(json);
 });

--- a/packages/server/src/fhir/operations/export.test.ts
+++ b/packages/server/src/fhir/operations/export.test.ts
@@ -165,6 +165,82 @@ describe('Export', () => {
       expect(exportWriteResourceSpy).toHaveBeenCalled();
     }));
 
+  test('exportResourceType reports deleted resources when since is provided', async () =>
+    withTestContext(async () => {
+      const accessToken = await initTestAuth({ membership: { admin: true } });
+
+      const createRes = await request(app)
+        .post('/fhir/R4/Observation')
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .send({ resourceType: 'Observation', status: 'final', code: { text: 'to be deleted' } });
+      expect(createRes).toHaveStatus(201);
+      const observationId = createRes.body.id;
+
+      // `_since` must be strictly before the delete, and the delete's `_lastUpdated` must be
+      // strictly >= `_since` for the deletion search filter to pick it up.
+      const since = new Date().toISOString();
+
+      const deleteRes = await request(app)
+        .delete(`/fhir/R4/Observation/${observationId}`)
+        .set('Authorization', 'Bearer ' + accessToken);
+      expect(deleteRes).toHaveStatus(200);
+
+      const initRes = await request(app)
+        .get(`/fhir/R4/$export?_since=${encodeURIComponent(since)}&_type=Observation`)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('Accept', ContentType.FHIR_JSON)
+        .set('Prefer', 'respond-async');
+      expect(initRes).toHaveStatus(202);
+      expect(initRes.headers['content-location']).toBeDefined();
+
+      const contentLocation = new URL(initRes.headers['content-location']);
+      await waitForAsyncJob(initRes.headers['content-location'], app, accessToken);
+
+      const statusRes = await request(app)
+        .get(contentLocation.pathname)
+        .set('Authorization', 'Bearer ' + accessToken);
+      expect(statusRes).toHaveStatus(200);
+
+      // The deleted resource must not also appear in `output`.
+      const output = (statusRes.body.output ?? []) as BulkDataExportOutput[];
+      expect(output.some((o) => o.type === 'Observation')).toBe(false);
+
+      const deleted = statusRes.body.deleted as BulkDataExportOutput[] | undefined;
+      expect(deleted).toBeDefined();
+      expect(deleted?.length).toBe(1);
+      expect(deleted?.[0].type).toBe('Observation');
+
+      const deletedLocation = new URL(deleted?.[0].url as string);
+      const deletedContent = (getBinaryStorage() as FileSystemStorage).readFileByUrlForTests(deletedLocation);
+      const bundles = deletedContent
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line));
+      expect(bundles).toHaveLength(1);
+      expect(bundles[0].resourceType).toBe('Bundle');
+      expect(bundles[0].type).toBe('transaction');
+      expect(bundles[0].entry[0].request).toEqual({
+        method: 'DELETE',
+        url: `Observation/${observationId}`,
+      });
+    }));
+
+  test('exportResourceType does not query for deletions when since is not provided', async () =>
+    withTestContext(async () => {
+      const exporter = new BulkExporter(systemRepo);
+      const writeDeletedResourceSpy = vi.spyOn(exporter, 'writeDeletedResource');
+      await exporter.start('http://example.com');
+
+      const { project } = await createTestProject();
+      await exportResourceType(exporter, 'Observation', 100, undefined);
+      const bulkDataExport = await exporter.close(project);
+
+      expect(writeDeletedResourceSpy).not.toHaveBeenCalled();
+      const deletedParams = bulkDataExport.output?.parameter?.filter((p) => p.name === 'deleted');
+      expect(deletedParams?.length ?? 0).toBe(0);
+    }));
+
   test('closeWriter removes only specified resource type from tracking', async () =>
     withTestContext(async () => {
       const exporter = new BulkExporter(systemRepo);

--- a/packages/server/src/fhir/operations/export.ts
+++ b/packages/server/src/fhir/operations/export.ts
@@ -107,6 +107,26 @@ export async function exportResourceType<T extends Resource>(
 
   // Close writer and free memory for this resource type immediately
   await exporter.closeWriter(resourceType);
+
+  // Per the Bulk Data Access IG, when `_since` is supplied, also report resources of this
+  // type that were deleted on or after that timestamp, as transaction Bundles under `deleted`.
+  // Deleted resources are never also present in `output` above, since a deleted resource
+  // cannot match the `_lastUpdated` search performed there (its content is a tombstone).
+  if (since) {
+    const deletedSearchRequest: SearchRequest<T> = {
+      resourceType,
+      count,
+      filters: [
+        { code: '_lastUpdated', operator: Operator.GREATER_THAN_OR_EQUALS, value: since },
+        { code: '_deleted', operator: Operator.EQUALS, value: 'true' },
+      ],
+      sortRules: [{ code: '_lastUpdated', descending: false }],
+    };
+    await repo.processAllResources(deletedSearchRequest, async (resource) => {
+      await exporter.writeDeletedResource(resourceType, resource.id);
+    });
+    await exporter.closeDeletedWriter(resourceType);
+  }
 }
 
 function getResourceTypesByExportLevel(exportLevel: string): ResourceType[] {

--- a/packages/server/src/fhir/operations/utils/bulkexporter.ts
+++ b/packages/server/src/fhir/operations/utils/bulkexporter.ts
@@ -43,6 +43,7 @@ export class BulkExporter {
   readonly repo: Repository;
   private resource: WithId<AsyncJob> | undefined;
   readonly writers: Record<string, BulkFileWriter> = {};
+  readonly deletedWriters: Record<string, BulkFileWriter> = {};
   readonly resourceSets = new Map<string, Set<string>>();
 
   constructor(repo: Repository) {
@@ -91,6 +92,24 @@ export class BulkExporter {
     return writer;
   }
 
+  async getDeletedWriter(resourceType: string): Promise<BulkFileWriter> {
+    let writer = this.deletedWriters[resourceType];
+    if (!writer) {
+      const accountCompartment = this.repo.effectiveAccessPolicy()?.compartment;
+      const binary = await this.repo.getSystemRepo().createResource<Binary>({
+        resourceType: 'Binary',
+        contentType: NDJSON_CONTENT_TYPE,
+        meta: {
+          project: this.repo.currentProject()?.id,
+          accounts: accountCompartment ? [accountCompartment] : undefined,
+        },
+      });
+      writer = new BulkFileWriter(binary);
+      this.deletedWriters[resourceType] = writer;
+    }
+    return writer;
+  }
+
   async closeWriter(resourceType: string): Promise<void> {
     const writer = this.writers[resourceType];
     if (writer) {
@@ -100,6 +119,14 @@ export class BulkExporter {
 
     // Clear tracking for this resource type to free memory
     this.resourceSets.delete(resourceType);
+  }
+
+  async closeDeletedWriter(resourceType: string): Promise<void> {
+    const writer = this.deletedWriters[resourceType];
+    if (writer) {
+      await writer.close();
+      // Keep reference for formatOutput(), but free the stream resources
+    }
   }
 
   async writeBundle(bundle: Bundle<WithId<Resource>>): Promise<void> {
@@ -129,12 +156,33 @@ export class BulkExporter {
     }
   }
 
+  /**
+   * Records a resource that was deleted after the export's `_since` timestamp.
+   * Per the Bulk Data Access IG, deleted resources are reported as FHIR transaction
+   * Bundles (one DELETE entry per Bundle) in a separate NDJSON file from `output`,
+   * and must not also appear in `output`.
+   * @param resourceType - The resource type that was deleted.
+   * @param id - The id of the deleted resource.
+   */
+  async writeDeletedResource(resourceType: string, id: string): Promise<void> {
+    const deleteBundle: Bundle = {
+      resourceType: 'Bundle',
+      type: 'transaction',
+      entry: [{ request: { method: 'DELETE', url: `${resourceType}/${id}` } }],
+    };
+    const writer = await this.getDeletedWriter(resourceType);
+    await writer.write(deleteBundle);
+  }
+
   async close(project: Project): Promise<AsyncJob> {
     if (!this.resource) {
       throw new Error('Export must be started before calling close()');
     }
 
     for (const writer of Object.values(this.writers)) {
+      await writer.close();
+    }
+    for (const writer of Object.values(this.deletedWriters)) {
       await writer.close();
     }
 
@@ -164,13 +212,22 @@ export class BulkExporter {
   formatOutput(): Parameters {
     return {
       resourceType: 'Parameters',
-      parameter: Object.entries(this.writers).map(([resourceType, writer]) => ({
-        name: 'output',
-        part: [
-          { name: 'type', valueCode: resourceType },
-          { name: 'url', valueUri: getReferenceString(writer.binary) },
-        ],
-      })),
+      parameter: [
+        ...Object.entries(this.writers).map(([resourceType, writer]) => ({
+          name: 'output',
+          part: [
+            { name: 'type', valueCode: resourceType },
+            { name: 'url', valueUri: getReferenceString(writer.binary) },
+          ],
+        })),
+        ...Object.entries(this.deletedWriters).map(([resourceType, writer]) => ({
+          name: 'deleted',
+          part: [
+            { name: 'type', valueCode: resourceType },
+            { name: 'url', valueUri: getReferenceString(writer.binary) },
+          ],
+        })),
+      ],
     };
   }
 }


### PR DESCRIPTION
Fixes part of #10479

## What this does
The `$export` bulk-data manifest was always emitting `deleted: []`, even when
deletions were never checked for. This PR fixes both halves of the issue:

1. **Deletion detection** — when `_since` is supplied, `export.ts` now also
   searches for resources of each exported type that were deleted on or after
   that timestamp (`_deleted=true` + `_lastUpdated>=since`), and writes them as
   FHIR transaction Bundles via a new `deleted` output channel in
   `BulkExporter`, kept separate from `output` per the spec.
2. **Response omission** — `bulkdata.ts` now only includes the `deleted` key
   in the response when it's actually non-empty, instead of always emitting
   `[]`.

## Testing
- Added `exportResourceType reports deleted resources when since is provided`
  in `export.test.ts` — creates a resource, deletes it, exports with `_since`,
  and verifies `deleted` is populated with a correct transaction Bundle, and
  that the resource does *not* also appear in `output`.
- Added `exportResourceType does not query for deletions when since is not
  provided` — confirms no behavior change when `_since` is absent.
- Added `Omits deleted key when there is nothing to report` in
  `bulkdata.test.ts`.
- Ran the full `export`, `groupexport`, `ccdaexport`, and `claimexport` suites
  locally — all 22 tests pass, no regressions.

## Note on scope / tradeoffs
This adds one extra search query per exported resource type whenever `_since`
is supplied (to check for deletions), even if there turn out to be none.
Wanted to flag that tradeoff explicitly in case there's a preferred approach
here — happy to adjust if maintainers want this batched differently or made
opt-in.