### PR TITLE
fix: correct broken home page links to provider and messages pages (#10508)

### DIFF
--- a/examples/foomedical/src/pages/HomePage.tsx
+++ b/examples/foomedical/src/pages/HomePage.tsx
@@ -53,7 +53,7 @@ const carouselItems = [
     title: 'Select a Doctor',
     description:
       'Lorem ipsum at porta donec ultricies ut, arcu morbi amet arcu ornare, curabitur pharetra magna tempus',
-    url: '/account/provider/choose-a-primary-care-povider',
+    url: '/account/provider',
     label: 'Choose a Primary Care Provider',
   },
   {
@@ -134,7 +134,7 @@ export function HomePage(): JSX.Element {
         <Group justify="center">
           <IconGift />
           <p>Put calls to action here</p>
-          <Button variant="white" onClick={() => navigate('/messages')?.catch(console.error)}>
+          <Button variant="white" onClick={() => navigate('/Communication')?.catch(console.error)}>
             Send Message
           </Button>
         </Group>


### PR DESCRIPTION
Fixes #10508

## What this does
Two links on the Foo Medical home page pointed at routes that don't exist,
so clicking them rendered a blank page below the header (no error shown to
the user):

- "Choose a Primary Care Provider" linked to
  `/account/provider/choose-a-primary-care-povider` (typo, and not a real
  route). Changed to `/account/provider`, matching the working "Choose
  Provider" button further down the same page.
- "Send Message" called `navigate('/messages')`, but the messages page is
  actually mounted at `Communication` per `Router.tsx`. Changed to
  `/Communication`, matching the header nav's "Messages" link.

## Testing
Verified manually against a local server + local Foo Medical instance:
registered a test patient, confirmed both links previously led to a blank
page, and confirmed both now correctly navigate to their working
destinations (Provider page and Messages page respectively).